### PR TITLE
Support factor-bundle plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "test": "npm run lint && mocha",
+    "mocha": "mocha",
     "cover": "istanbul test --print both ./node_modules/mocha/bin/_mocha",
     "lint": "eslint . && jscs ."
   },
@@ -18,6 +19,7 @@
     "browserify": "^12.0.1",
     "eslint": "^1.7.3",
     "eslint-config-arenanet": "^1.0.1",
+    "factor-bundle": "^2.5.0",
     "istanbul": "^0.4.0",
     "jscs": "^2.5.0",
     "jscs-preset-arenanet": "^1.0.0",
@@ -27,6 +29,10 @@
     "dependency-graph": "^0.4.1",
     "hasha": "^2.0.2",
     "lodash.assign": "^3.2.0",
+    "lodash.difference": "^3.2.2",
+    "lodash.filter": "^3.1.1",
+    "lodash.flatten": "^3.0.2",
+    "lodash.foreach": "^3.0.3",
     "lodash.get": "^3.7.0",
     "lodash.invert": "^3.0.1",
     "lodash.mapvalues": "^3.0.1",

--- a/src/browserify.js
+++ b/src/browserify.js
@@ -4,10 +4,16 @@ var fs   = require("fs"),
     path = require("path"),
 
     through = require("through2"),
-    assign  = require("lodash.assign"),
-    map     = require("lodash.mapvalues"),
     
-    Processor = require("./processor");
+    assign  = require("lodash.assign"),
+    diff    = require("lodash.difference"),
+    each    = require("lodash.foreach"),
+    flatten = require("lodash.flatten"),
+    map     = require("lodash.mapvalues"),
+    unique  = require("lodash.uniq"),
+    
+    Processor = require("./processor"),
+    relative  = require("./relative");
 
 module.exports = function(browserify, opts) {
     var options = assign({
@@ -16,7 +22,9 @@ module.exports = function(browserify, opts) {
             json : false
         }, opts),
         
-        processor = new Processor();
+        processor = new Processor(),
+        bundles   = {},
+        common    = [];
 
     if(!options.ext || options.ext.charAt(0) !== ".") {
         return browserify.emit("error", "Missing or invalid \"ext\" option: " + options.ext);
@@ -29,35 +37,105 @@ module.exports = function(browserify, opts) {
             return through();
         }
         
+        common.push(relative(file));
         buffer = "";
         
         return through(
-            function(chunk, enc, callback) {
+            function(chunk, enc, done) {
                 buffer += chunk.toString("utf8");
-                callback();
+                
+                done();
             },
             
-            function(callback) {
+            function(done) {
                 var result = processor.string(file, buffer);
                 
                 this.push("module.exports = " + JSON.stringify(result.exports) + ";");
                 
-                callback();
+                done();
             }
         );
     }, { global : true });
 
-    browserify.on("bundle", function(bundle) {
-        bundle.on("end", function() {
-            if(options.css) {
-                fs.writeFileSync(options.css, processor.css);
+    browserify.on("factor.pipeline", function(file, pipeline) {
+        var identifier = relative(file);
+        
+        bundles[identifier] = [];
+
+        // Keep track of the files in each bundle so we can determine commonalities
+        // later and output CSS bundles
+        pipeline.unshift(through.obj(function(obj, enc, done) {
+            if(path.extname(obj.file) === options.ext) {
+                bundles[identifier].push(relative(obj.file));
             }
 
+            this.push(obj);
+
+            done();
+        }));
+    });
+    
+    browserify.on("bundle", function(bundler) {
+        bundler.on("end", function() {
+            var usage    = {},
+                bundling = Object.keys(bundles).length > 0;
+            
             if(options.json) {
                 fs.writeFileSync(options.json, JSON.stringify(map(processor.files, function(file) {
                     return file.compositions;
                 })));
             }
+            
+            if(!options.css) {
+                return;
+            }
+            
+            if(bundling) {
+                // Calculate usages of each CSS file across all bundles
+                processor.dependencies().forEach(function(file) {
+                    usage[file] = 0;
+                });
+                
+                each(bundles, function(contents) {
+                    contents.forEach(function(file) {
+                        usage[file]++;
+                        
+                        processor.dependencies(file).forEach(function(dep) {
+                            usage[dep]++;
+                        });
+                    });
+                });
+                
+                // only include files used more than once
+                common = unique(flatten(
+                    common.map(function(file) {
+                        return usage[file] > 1 ? processor.dependencies(file).concat(file) : [];
+                    })
+                ));
+                
+                // Write out each bundle's CSS files (if they have any)
+                each(bundles, function(contents, bundle) {
+                    var css = [];
+                    
+                    contents.forEach(function(file) {
+                        css = css.concat(processor.dependencies(file), file);
+                    });
+                    
+                    css = diff(css, common);
+                    
+                    if(!css.length) {
+                        return;
+                    }
+                    
+                    fs.writeFileSync(
+                        path.join(path.dirname(options.css), path.basename(bundle).replace(path.extname(bundle), options.ext)),
+                        processor.css(css)
+                    );
+                });
+            }
+            
+            // Write out common/all css depending on bundling status
+            fs.writeFileSync(options.css, processor.css(bundling ? common : false));
         });
     });
 };

--- a/src/imports.js
+++ b/src/imports.js
@@ -4,6 +4,8 @@ var path = require("path"),
     
     resolve = require("resolve-from"),
     
+    relative = require("./relative"),
+    
     format = /(.+) from ["']([^'"]+?)["']$/i;
 
 exports.format = format;
@@ -28,6 +30,6 @@ exports.parse = function(file, text) {
             return value.trim();
         }),
         
-        source : path.relative(process.cwd(), resolve(path.dirname(file), source)).replace(/\\/g, "/")
+        source : relative(resolve(path.dirname(file), source))
     };
 };

--- a/src/relative.js
+++ b/src/relative.js
@@ -1,0 +1,10 @@
+"use strict";
+
+var path = require("path"),
+
+    regex = /\\/g,
+    cwd   = process.cwd();
+
+module.exports = function(file) {
+    return path.relative(cwd, file).replace(regex, "/");
+};

--- a/test/browserify.js
+++ b/test/browserify.js
@@ -90,10 +90,49 @@ describe("postcss-modular-css", function() {
                 setImmediate(function() {
                     assert.equal(
                         fs.readFileSync("./test/output/browserify-avoid-duplicates.css", "utf8"),
-                        fs.readFileSync("./test/output/browserify-avoid-duplicates.css", "utf8")
+                        fs.readFileSync("./test/results/browserify-avoid-duplicates.css", "utf8")
                     );
                     
                     done();
+                });
+            });
+        });
+
+        describe("factor-bundle support", function() {
+            it("should support factor-bundle", function(done) {
+                var build = browserify([
+                        "./test/specimens/factor-bundle-a.js",
+                        "./test/specimens/factor-bundle-b.js"
+                    ]);
+                
+                build.plugin(plugin, {
+                    css : "./test/output/browserify-factor-bundle.css"
+                });
+
+                build.plugin("factor-bundle", {
+                    outputs : [
+                        "./test/output/factor-bundle-a.js",
+                        "./test/output/factor-bundle-b.js"
+                    ]
+                });
+                
+                build.bundle(function(err) {
+                    assert.ifError(err);
+                    
+                    // Wrapped because browserify event lifecycle is... odd
+                    setImmediate(function() {
+                        assert.equal(
+                            fs.readFileSync("./test/output/browserify-factor-bundle.css", "utf8"),
+                            fs.readFileSync("./test/results/browserify-factor-bundle.css", "utf8")
+                        );
+                        
+                        assert.equal(
+                            fs.readFileSync("./test/output/factor-bundle-a.css", "utf8"),
+                            fs.readFileSync("./test/results/browserify-factor-bundle-a.css", "utf8")
+                        );
+                        
+                        done();
+                    });
                 });
             });
         });

--- a/test/processor.js
+++ b/test/processor.js
@@ -15,31 +15,60 @@ describe("postcss-modular-css", function() {
             assert.equal(typeof Processor, "function");
         });
         
-        it("should process a string", function() {
-            var result = this.processor.string("./test/specimens/simple.css", ".wooga { color: red; }");
-            
-            assert.deepEqual(result, {
-                files : {
-                    "test/specimens/simple.css" : {
-                        text   : ".wooga { color: red; }",
-                        parsed : ".83fe1a59eebdf17220df583a8e9048da_wooga { color: red; }",
-                        
-                        compositions : {
-                            wooga : [ "83fe1a59eebdf17220df583a8e9048da_wooga" ]
+        it("should auto-instantiate if called without new", function() {
+            /* eslint new-cap:0 */
+            assert(Processor() instanceof Processor);
+        });
+        
+        describe(".string", function() {
+            it("should process a string", function() {
+                var result = this.processor.string("./test/specimens/simple.css", ".wooga { color: red; }");
+                
+                assert.deepEqual(result, {
+                    files : {
+                        "test/specimens/simple.css" : {
+                            text   : ".wooga { color: red; }",
+                            parsed : ".83fe1a59eebdf17220df583a8e9048da_wooga { color: red; }",
+                            
+                            compositions : {
+                                wooga : [ "83fe1a59eebdf17220df583a8e9048da_wooga" ]
+                            }
                         }
+                    },
+                    exports : {
+                        wooga : [ "83fe1a59eebdf17220df583a8e9048da_wooga" ]
                     }
-                },
-                exports : {
-                    wooga : [ "83fe1a59eebdf17220df583a8e9048da_wooga" ]
-                }
+                });
             });
         });
 
-        it("should process a file", function() {
-            var result = this.processor.file("./test/specimens/simple.css");
-            
-            assert.deepEqual(result, {
-                files : {
+        describe(".file", function() {
+            it("should process a file", function() {
+                var result = this.processor.file("./test/specimens/simple.css");
+                
+                assert.deepEqual(result, {
+                    files : {
+                        "test/specimens/simple.css" : {
+                            text   : fs.readFileSync("./test/specimens/simple.css", "utf8"),
+                            parsed : ".1bc1718879cff9694b0f5cc8ad7b7537_wooga { color: red; }\n",
+                            
+                            compositions : {
+                                wooga : [ "1bc1718879cff9694b0f5cc8ad7b7537_wooga" ]
+                            }
+                        }
+                    },
+                    exports : {
+                        wooga : [ "1bc1718879cff9694b0f5cc8ad7b7537_wooga" ]
+                    }
+                });
+            });
+        });
+        
+        describe(".files", function() {
+            it("should return the parsed files object", function() {
+                this.processor.file("./test/specimens/simple.css");
+                
+                assert.deepEqual(this.processor.files, {
                     "test/specimens/simple.css" : {
                         text   : fs.readFileSync("./test/specimens/simple.css", "utf8"),
                         parsed : ".1bc1718879cff9694b0f5cc8ad7b7537_wooga { color: red; }\n",
@@ -48,10 +77,28 @@ describe("postcss-modular-css", function() {
                             wooga : [ "1bc1718879cff9694b0f5cc8ad7b7537_wooga" ]
                         }
                     }
-                },
-                exports : {
-                    wooga : [ "1bc1718879cff9694b0f5cc8ad7b7537_wooga" ]
-                }
+                });
+            });
+        });
+        
+        describe("dependencies", function() {
+            it("should return the dependencies of the specified file", function() {
+                this.processor.file("./test/specimens/start.css");
+                
+                assert.deepEqual(this.processor.dependencies("test/specimens/start.css"), [
+                    "test/specimens/folder/folder.css",
+                    "test/specimens/local.css"
+                ]);
+            });
+            
+            it("should return the overall order of dependencies if no file is specified", function() {
+                this.processor.file("./test/specimens/start.css");
+                
+                assert.deepEqual(this.processor.dependencies(), [
+                    "test/specimens/folder/folder.css",
+                    "test/specimens/local.css",
+                    "test/specimens/start.css"
+                ]);
             });
         });
         
@@ -147,7 +194,7 @@ describe("postcss-modular-css", function() {
             this.processor.file("./test/specimens/node_modules.css");
             
             assert.equal(
-                this.processor.css,
+                this.processor.css(),
                 fs.readFileSync("./test/results/processor-output-all.css", "utf8")
             );
         });
@@ -157,7 +204,7 @@ describe("postcss-modular-css", function() {
             this.processor.file("./test/specimens/local.css");
             
             assert.equal(
-                this.processor.css,
+                this.processor.css(),
                 fs.readFileSync("./test/results/processor-avoid-duplicates.css", "utf8")
             );
         });

--- a/test/results/browserify-avoid-duplicates.css
+++ b/test/results/browserify-avoid-duplicates.css
@@ -1,0 +1,9 @@
+/* test/specimens/folder/folder.css */
+.dafdfcc7dc876084d352519086f9e6e9_folder { margin: 2px; }
+
+/* test/specimens/local.css */
+.f5507abd3eea0987714c5d92c3230347_booga { background: green; }
+
+/* test/specimens/start.css */
+.aeacf0c6fbb2445f549ddc0fcfc1747b_booga { color: red; background: blue; }
+.aeacf0c6fbb2445f549ddc0fcfc1747b_tooga { border: 1px solid white; }

--- a/test/results/browserify-factor-bundle-a.css
+++ b/test/results/browserify-factor-bundle-a.css
@@ -1,0 +1,3 @@
+/* test/specimens/start.css */
+.aeacf0c6fbb2445f549ddc0fcfc1747b_booga { color: red; background: blue; }
+.aeacf0c6fbb2445f549ddc0fcfc1747b_tooga { border: 1px solid white; }

--- a/test/results/browserify-factor-bundle.css
+++ b/test/results/browserify-factor-bundle.css
@@ -1,0 +1,5 @@
+/* test/specimens/folder/folder.css */
+.dafdfcc7dc876084d352519086f9e6e9_folder { margin: 2px; }
+
+/* test/specimens/local.css */
+.f5507abd3eea0987714c5d92c3230347_booga { background: green; }

--- a/test/specimens/factor-bundle-a.css
+++ b/test/specimens/factor-bundle-a.css
@@ -1,0 +1,3 @@
+/* C:\Users\Patrick\Documents\Code\modular-css\test\specimens\start.css */
+.aeacf0c6fbb2445f549ddc0fcfc1747b_booga { color: red; background: blue; }
+.aeacf0c6fbb2445f549ddc0fcfc1747b_tooga { border: 1px solid white; }

--- a/test/specimens/factor-bundle-a.js
+++ b/test/specimens/factor-bundle-a.js
@@ -1,0 +1,6 @@
+"use strict";
+
+var common = require("./factor-bundle-common"),
+    css    = require("./start.css");
+
+console.log(common.common);

--- a/test/specimens/factor-bundle-b.js
+++ b/test/specimens/factor-bundle-b.js
@@ -1,0 +1,6 @@
+"use strict";
+
+var common = require("./factor-bundle-common")
+    css    = require("./local.css");;
+
+console.log(common);

--- a/test/specimens/factor-bundle-common.js
+++ b/test/specimens/factor-bundle-common.js
@@ -1,0 +1,6 @@
+"use strict";
+
+var css = require("./folder/folder.css");
+
+exports.common = true;
+exports.folder = css;

--- a/test/specimens/local.js
+++ b/test/specimens/local.js
@@ -1,0 +1,3 @@
+"use strict";
+
+var local = require("./local.css");


### PR DESCRIPTION
Now able to map `factor-bundle` bundles to CSS dependencies, dedupe, and extract common dependencies amongst the bundles (and common files).

**NOTE**: `modular-css` must be added as a plugin **BEFORE** `factor-bundle` for it to work. Browserify limitation, sadly.

Example:
```js
var build = browserify([
        "./test/specimens/factor-bundle-a.js",
        "./test/specimens/factor-bundle-b.js"
    ]);

build.plugin("modular-css", {
    css : "./test/output/browserify-factor-bundle.css"
});

build.plugin("factor-bundle", {
    outputs : [
        "./test/output/factor-bundle-a.js",
        "./test/output/factor-bundle-b.js"
    ]
});

build.bundle(function(err, out) {
    ...
});
```