### PR TITLE
Custom naming

### DIFF
--- a/src/browserify.js
+++ b/src/browserify.js
@@ -17,9 +17,11 @@ var fs   = require("fs"),
 
 module.exports = function(browserify, opts) {
     var options = assign({
-            ext  : ".css",
-            css  : false,
-            json : false
+            ext    : ".css",
+            css    : false,
+            json   : false,
+            prefix : false,
+            namer  : false
         }, opts),
         
         processor = new Processor(),

--- a/src/browserify.js
+++ b/src/browserify.js
@@ -24,7 +24,7 @@ module.exports = function(browserify, opts) {
             namer  : false
         }, opts),
         
-        processor = new Processor(),
+        processor = new Processor(options),
         bundles   = {},
         common    = [];
 

--- a/src/plugins/scoping.js
+++ b/src/plugins/scoping.js
@@ -12,8 +12,8 @@ module.exports = postcss.plugin(plugin, function(opts) {
     
     return function(css, result) {
         var lookup  = {},
-            namer   = options.namer,
-            prefix  = options.prefix,
+            namer   = options.namer  || result.opts.namer,
+            prefix  = options.prefix || result.opts.prefix,
             
             parser, current;
             
@@ -22,15 +22,13 @@ module.exports = postcss.plugin(plugin, function(opts) {
         }
         
         if(typeof namer !== "function") {
-            namer = function(selector) {
+            namer = function(file, selector) {
                 return prefix + "_" + selector;
             };
         }
 
         parser = createParser(function(selectors) {
-            // Walk top-level selectors
             selectors.each(function(child) {
-                // Walk the parts of each
                 child.each(function(selector) {
                     var children, name;
                     
@@ -54,7 +52,7 @@ module.exports = postcss.plugin(plugin, function(opts) {
                     }
                     
                     if(selector.type === "class" || selector.type === "id") {
-                        name = namer(selector.value);
+                        name = namer(result.opts.from, selector.value);
                         
                         lookup[selector.value] = name;
                         

--- a/src/processor.js
+++ b/src/processor.js
@@ -4,7 +4,8 @@ var fs   = require("fs"),
 
     postcss = require("postcss"),
     Graph   = require("dependency-graph").DepGraph,
-    
+    assign  = require("lodash.assign"),
+
     parser = postcss([
         require("./plugins/values.js"),
         require("./plugins/scoping.js"),
@@ -14,11 +15,12 @@ var fs   = require("fs"),
     imports  = require("./imports"),
     relative = require("./relative");
 
-function Processor() {
+function Processor(opts) {
     if(!(this instanceof Processor)) {
-        return new Processor();
+        return new Processor(opts);
     }
 
+    this._opts  = opts;
     this._files = {};
     this._all   = new Graph();
 }
@@ -39,10 +41,10 @@ Processor.prototype = {
 
         this._local.overallOrder().forEach(function(file) {
             var details = self._files[file],
-                parsed  = parser.process(details.text, {
+                parsed  = parser.process(details.text, assign({}, self._opts, {
                     from  : file,
                     files : self._files
-                });
+                }));
             
             details.parsed = parsed.css;
             

--- a/test/browserify.js
+++ b/test/browserify.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var fs     = require("fs"),
+    path   = require("path"),
     assert = require("assert"),
     
     browserify = require("browserify"),
@@ -31,6 +32,54 @@ describe("postcss-modular-css", function() {
                 assert(out.toString().indexOf(fs.readFileSync("./test/results/browserify-export-identifiers.js", "utf8")) > -1);
 
                 done();
+            });
+        });
+
+        it("should use the specified prefix", function(done) {
+            var build = browserify("./test/specimens/simple.js");
+            
+            build.plugin(plugin, {
+                css    : "./test/output/browserify-prefix.css",
+                prefix : "prefix"
+            });
+            
+            build.bundle(function(err) {
+                assert.ifError(err);
+                
+                // Wrapped because browserify event lifecycle is... odd
+                setImmediate(function() {
+                    assert.equal(
+                        fs.readFileSync("./test/output/browserify-prefix.css", "utf8"),
+                        fs.readFileSync("./test/results/browserify-prefix.css", "utf8")
+                    );
+                    
+                    done();
+                });
+            });
+        });
+
+        it("should use the specified namer function", function(done) {
+            var build = browserify("./test/specimens/simple.js");
+            
+            build.plugin(plugin, {
+                css   : "./test/output/browserify-namer-fn.css",
+                namer : function(file, selector) {
+                    return path.basename(file, path.extname(file)) + "-" + selector;
+                }
+            });
+            
+            build.bundle(function(err) {
+                assert.ifError(err);
+                
+                // Wrapped because browserify event lifecycle is... odd
+                setImmediate(function() {
+                    assert.equal(
+                        fs.readFileSync("./test/output/browserify-namer-fn.css", "utf8"),
+                        fs.readFileSync("./test/results/browserify-namer-fn.css", "utf8")
+                    );
+                    
+                    done();
+                });
             });
         });
 

--- a/test/plugin-scoping.js
+++ b/test/plugin-scoping.js
@@ -72,7 +72,7 @@ describe("postcss-modular-css", function() {
         it("should call a naming function for class names", function() {
             assert.equal(
                 css(".wooga { color: red; }", {
-                    namer : function(selector) {
+                    namer : function(file, selector) {
                         return "googa_" + selector;
                     }
                 }),

--- a/test/processor.js
+++ b/test/processor.js
@@ -19,7 +19,53 @@ describe("postcss-modular-css", function() {
             /* eslint new-cap:0 */
             assert(Processor() instanceof Processor);
         });
-        
+
+        it("should pass prefix through to the plugins", function() {
+            var processor = new Processor({ prefix : "googa" }),
+                result    = processor.string("./test/specimens/simple.css", ".wooga { color: red; }");
+
+            assert.deepEqual(result, {
+                    files : {
+                        "test/specimens/simple.css" : {
+                            text   : ".wooga { color: red; }",
+                            parsed : ".googa_wooga { color: red; }",
+                            
+                            compositions : {
+                                wooga : [ "googa_wooga" ]
+                            }
+                        }
+                    },
+                    exports : {
+                        wooga : [ "googa_wooga" ]
+                    }
+                });
+        });
+
+        it("should pass a namer function through to the plugins", function() {
+            var processor = new Processor({
+                    namer : function(filename, selector) {
+                        return filename + selector;
+                    }
+                }),
+                result = processor.string("./test/specimens/simple.css", ".wooga { color: red; }");
+
+            assert.deepEqual(result, {
+                    files : {
+                        "test/specimens/simple.css" : {
+                            text   : ".wooga { color: red; }",
+                            parsed : ".test/specimens/simple.csswooga { color: red; }",
+                            
+                            compositions : {
+                                wooga : [ "test/specimens/simple.csswooga" ]
+                            }
+                        }
+                    },
+                    exports : {
+                        wooga : [ "test/specimens/simple.csswooga" ]
+                    }
+                });
+        });
+
         describe(".string", function() {
             it("should process a string", function() {
                 var result = this.processor.string("./test/specimens/simple.css", ".wooga { color: red; }");

--- a/test/results/browserify-namer-fn.css
+++ b/test/results/browserify-namer-fn.css
@@ -1,0 +1,2 @@
+/* test/specimens/simple.css */
+.simple-wooga { color: red; }

--- a/test/results/browserify-prefix.css
+++ b/test/results/browserify-prefix.css
@@ -1,0 +1,2 @@
+/* test/specimens/simple.css */
+.prefix_wooga { color: red; }


### PR DESCRIPTION
Ensure that `prefix` strings and `namer` functions can make it all the way from browserify through the processor and into the scoping plugin.