### PR TITLE
Actual tests for multiple composes statements

### DIFF
--- a/src/plugins/composition.js
+++ b/src/plugins/composition.js
@@ -45,7 +45,7 @@ module.exports = postcss.plugin(plugin, function() {
         css.walkDecls("composes", function(decl) {
             var selectors;
             
-            if(decl.prev()) {
+            if(decl.prev() && decl.prev().prop !== "composes") {
                 throw decl.error("composes must be the first declaration in the rule", { word : "composes" });
             }
             
@@ -122,17 +122,19 @@ module.exports = postcss.plugin(plugin, function() {
             // Update out by walking dep graph and updating classes
             graph.overallOrder().forEach(function(selector) {
                 graph.dependenciesOf(selector).reverse().forEach(function(dep) {
-                    out[selector] = _.unique(refs[dep].concat(out[selector]));
+                    out[selector] = refs[dep].concat(out[selector]);
                 });
             });
         } catch(e) {
             throw css.error(e.toString());
         }
-        
+
         result.messages.push({
             type         : "modularcss",
             plugin       : plugin,
-            compositions : out
+            compositions : _.map(out, function(val) {
+                return _.unique(val);
+            })
         });
     };
 });

--- a/test/plugin-composition.js
+++ b/test/plugin-composition.js
@@ -123,6 +123,16 @@ describe("postcss-modular-css", function() {
                 booga : [ "booga" ]
             }) ]);
         });
+
+        it("should allow multiple composes declarations", function() {
+            var out = composition.process(".wooga { } .booga { } .tooga { composes: wooga; composes: booga; }");
+
+            assert.deepEqual(out.messages, [ msg({
+                wooga : [ "wooga" ],
+                booga : [ "booga" ],
+                tooga : [ "wooga", "booga" ]
+            }) ]);
+        });
         
         it("should support composing against global identifiers", function() {
             var out;
@@ -153,6 +163,20 @@ describe("postcss-modular-css", function() {
             }) ]);
 
             out = composition.process(".tooga { } .wooga { composes: global(booga) tooga; color: red; }");
+            
+            assert.deepEqual(out.messages, [ msg({
+                tooga : [ "tooga" ],
+                wooga : [ "booga", "tooga", "wooga" ]
+            }) ]);
+
+            out = composition.process(".tooga { } .wooga { composes: global(booga); composes: tooga; }");
+            
+            assert.deepEqual(out.messages, [ msg({
+                tooga : [ "tooga" ],
+                wooga : [ "booga", "tooga" ]
+            }) ]);
+
+            out = composition.process(".tooga { } .wooga { composes: global(booga); composes: tooga; color: red; }");
             
             assert.deepEqual(out.messages, [ msg({
                 tooga : [ "tooga" ],


### PR DESCRIPTION
- decl.prev() seems a bit wonky, may need to rethink that check. Seems
to work for now though.
- Added some tests to make sure that it works with global(...)
- Minor optimization, only call unique once per selector we're
outputting instead of every single time they're composed.