### PR TITLE
Use unique-slug instead of hasha

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "dependency-graph": "^0.4.1",
-    "hasha": "^2.0.2",
     "lodash.assign": "^3.2.0",
     "lodash.difference": "^3.2.2",
     "lodash.filter": "^3.1.1",
@@ -44,6 +43,7 @@
     "resolve-from": "^1.0.1",
     "sink-transform": "^1.0.0",
     "through2": "^2.0.0",
+    "unique-slug": "^2.0.0",
     "update-notifier": "^0.5.0"
   },
   "eslintConfig": {

--- a/src/plugins/scoping.js
+++ b/src/plugins/scoping.js
@@ -3,7 +3,7 @@
 var postcss      = require("postcss"),
     createParser = require("postcss-selector-parser"),
     
-    hasha = require("hasha"),
+    unique = require("unique-slug"),
 
     identifiers = require("../_identifiers"),
     
@@ -20,7 +20,9 @@ module.exports = postcss.plugin(plugin, function(opts) {
             parser, current;
             
         if(!prefix && !namer) {
-            prefix = "mc" + hasha(css.toString(), { algorithm : "md5" });
+            namer = function(file, selector) {
+                return "mc" + unique(file) + "_" + selector;
+            };
         }
         
         if(typeof namer !== "function") {

--- a/test/plugin-composition.js
+++ b/test/plugin-composition.js
@@ -264,12 +264,12 @@ describe("postcss-modular-css", function() {
                 type    : "modularcss",
                 plugin  : "postcss-modular-css-scoping",
                 classes : {
-                    googa : "08e91a5b_googa",
-                    wooga : "08e91a5b_wooga"
+                    googa : "mc08e91a5b_googa",
+                    wooga : "mc08e91a5b_wooga"
                 }
             }, msg({
-                googa : [ "08e91a5b_wooga" ],
-                wooga : [ "08e91a5b_wooga" ]
+                googa : [ "mc08e91a5b_wooga" ],
+                wooga : [ "mc08e91a5b_wooga" ]
             }) ]);
         });
         

--- a/test/plugin-composition.js
+++ b/test/plugin-composition.js
@@ -5,7 +5,9 @@ var assert = require("assert"),
     postcss = require("postcss"),
     
     scoping     = require("../src/plugins/scoping"),
-    composition = require("../src/plugins/composition");
+    composition = require("../src/plugins/composition"),
+    
+    from = { from : "test/specimens/simple.css" };
 
 function msg(compositions) {
     return {
@@ -256,18 +258,18 @@ describe("postcss-modular-css", function() {
         });
         
         it("should find scoped identifiers from the scoping plugin's message", function() {
-            var out = postcss([ scoping, composition ]).process(".wooga { color: red; } .googa { composes: wooga; }");
+            var out = postcss([ scoping, composition ]).process(".wooga { color: red; } .googa { composes: wooga; }", from);
             
             assert.deepEqual(out.messages, [ {
                 type    : "modularcss",
                 plugin  : "postcss-modular-css-scoping",
                 classes : {
-                    googa : "mc7277eb6cdd9ca80332ddd1cd83af7935_googa",
-                    wooga : "mc7277eb6cdd9ca80332ddd1cd83af7935_wooga"
+                    googa : "08e91a5b_googa",
+                    wooga : "08e91a5b_wooga"
                 }
             }, msg({
-                googa : [ "mc7277eb6cdd9ca80332ddd1cd83af7935_wooga" ],
-                wooga : [ "mc7277eb6cdd9ca80332ddd1cd83af7935_wooga" ]
+                googa : [ "08e91a5b_wooga" ],
+                wooga : [ "08e91a5b_wooga" ]
             }) ]);
         });
         

--- a/test/plugin-keyframes.js
+++ b/test/plugin-keyframes.js
@@ -11,25 +11,27 @@ describe("postcss-modular-css", function() {
     describe("plugin-keyframes", function() {
         it("should update scoped animations from the scoping plugin's message", function() {
             var out = postcss([ scoping, keyframes ]).process(
-                    "@keyframes kooga { } .wooga { animation: kooga; }"
+                    "@keyframes kooga { } .wooga { animation: kooga; }",
+                    { from : "test/specimens/simple.css" }
                 );
             
             assert.equal(
                 out.css,
-                "@keyframes mcb4af99404319798e981c4177a3a110fc_kooga { } " +
-                ".mcb4af99404319798e981c4177a3a110fc_wooga { animation: mcb4af99404319798e981c4177a3a110fc_kooga; }"
+                "@keyframes 08e91a5b_kooga { } " +
+                ".08e91a5b_wooga { animation: 08e91a5b_kooga; }"
             );
         });
 
         it("should update scoped prefixed animations from the scoping plugin's message", function() {
             var out = postcss([ scoping, keyframes ]).process(
-                    "@-webkit-keyframes kooga { } .wooga { animation: kooga; }"
+                    "@-webkit-keyframes kooga { } .wooga { animation: kooga; }",
+                    { from : "test/specimens/simple.css" }
                 );
             
             assert.equal(
                 out.css,
-                "@-webkit-keyframes mcda556213f48c595171cbc3ab40b8b727_kooga { } " +
-                ".mcda556213f48c595171cbc3ab40b8b727_wooga { animation: mcda556213f48c595171cbc3ab40b8b727_kooga; }"
+                "@-webkit-keyframes 08e91a5b_kooga { } " +
+                ".08e91a5b_wooga { animation: 08e91a5b_kooga; }"
             );
         });
     });

--- a/test/plugin-keyframes.js
+++ b/test/plugin-keyframes.js
@@ -17,8 +17,8 @@ describe("postcss-modular-css", function() {
             
             assert.equal(
                 out.css,
-                "@keyframes 08e91a5b_kooga { } " +
-                ".08e91a5b_wooga { animation: 08e91a5b_kooga; }"
+                "@keyframes mc08e91a5b_kooga { } " +
+                ".mc08e91a5b_wooga { animation: mc08e91a5b_kooga; }"
             );
         });
 
@@ -30,8 +30,8 @@ describe("postcss-modular-css", function() {
             
             assert.equal(
                 out.css,
-                "@-webkit-keyframes 08e91a5b_kooga { } " +
-                ".08e91a5b_wooga { animation: 08e91a5b_kooga; }"
+                "@-webkit-keyframes mc08e91a5b_kooga { } " +
+                ".mc08e91a5b_wooga { animation: mc08e91a5b_kooga; }"
             );
         });
     });

--- a/test/plugin-scoping.js
+++ b/test/plugin-scoping.js
@@ -11,14 +11,14 @@ describe("postcss-modular-css", function() {
         it("should generate a prefix for class names", function() {
             assert.equal(
                 css(".wooga { color: red; }"),
-                ".08e91a5b_wooga { color: red; }"
+                ".mc08e91a5b_wooga { color: red; }"
             );
         });
         
         it("should generate a prefix for ids", function() {
             assert.equal(
                 css("#wooga { color: red; }"),
-                "#08e91a5b_wooga { color: red; }"
+                "#mc08e91a5b_wooga { color: red; }"
             );
         });
         
@@ -32,51 +32,51 @@ describe("postcss-modular-css", function() {
         it("should transform class/id selectors", function() {
             assert.equal(
                 css(".wooga p { color: red; }"),
-                ".08e91a5b_wooga p { color: red; }"
+                ".mc08e91a5b_wooga p { color: red; }"
             );
 
             assert.equal(
                 css("#wooga p { color: red; }"),
-                "#08e91a5b_wooga p { color: red; }"
+                "#mc08e91a5b_wooga p { color: red; }"
             );
             
             assert.equal(
                 css("#wooga .booga { color: red; }"),
-                "#08e91a5b_wooga .08e91a5b_booga { color: red; }"
+                "#mc08e91a5b_wooga .mc08e91a5b_booga { color: red; }"
             );
 
             assert.equal(
                 css("#wooga { color: red; } #wooga:hover { color: blue; }"),
-                "#08e91a5b_wooga { color: red; } #08e91a5b_wooga:hover { color: blue; }"
+                "#mc08e91a5b_wooga { color: red; } #mc08e91a5b_wooga:hover { color: blue; }"
             );
 
             assert.equal(
                 css(".wooga { color: red; } .wooga:hover { color: black; }"),
-                ".08e91a5b_wooga { color: red; } .08e91a5b_wooga:hover { color: black; }"
+                ".mc08e91a5b_wooga { color: red; } .mc08e91a5b_wooga:hover { color: black; }"
             );
         });
         
         it("should transform selectors within media queries", function() {
             assert.equal(
                 css("@media (max-width: 100px) { .booga { color: red; } }"),
-                "@media (max-width: 100px) { .08e91a5b_booga { color: red; } }"
+                "@media (max-width: 100px) { .mc08e91a5b_booga { color: red; } }"
             );
         });
 
         it("should transform the names of @keyframes rules", function() {
             assert.equal(
                 css("@keyframes fooga { }"),
-                "@keyframes 08e91a5b_fooga { }"
+                "@keyframes mc08e91a5b_fooga { }"
             );
 
             assert.equal(
                 css("@-webkit-keyframes fooga { }"),
-                "@-webkit-keyframes 08e91a5b_fooga { }"
+                "@-webkit-keyframes mc08e91a5b_fooga { }"
             );
 
             assert.equal(
                 css("@-moz-keyframes fooga { }"),
-                "@-moz-keyframes 08e91a5b_fooga { }"
+                "@-moz-keyframes mc08e91a5b_fooga { }"
             );
         });
         
@@ -108,9 +108,9 @@ describe("postcss-modular-css", function() {
                 type    : "modularcss",
                 plugin  : "postcss-modular-css-scoping",
                 classes : {
-                    booga : "08e91a5b_booga",
-                    fooga : "08e91a5b_fooga",
-                    wooga : "08e91a5b_wooga"
+                    booga : "mc08e91a5b_booga",
+                    fooga : "mc08e91a5b_fooga",
+                    wooga : "mc08e91a5b_wooga"
                 }
             } ]);
         });
@@ -158,7 +158,7 @@ describe("postcss-modular-css", function() {
             it("should support mixed local & global selectors", function() {
                 assert.equal(
                     css(":global(#wooga), .wooga { color: red; }"),
-                    "#wooga, .08e91a5b_wooga { color: red; }"
+                    "#wooga, .mc08e91a5b_wooga { color: red; }"
                 );
             });
 

--- a/test/plugin-scoping.js
+++ b/test/plugin-scoping.js
@@ -1,8 +1,9 @@
 var assert = require("assert"),
+    assign = require("lodash.assign"),
     plugin = require("../src/plugins/scoping");
 
 function css(src, options) {
-    return plugin.process(src, options).css;
+    return plugin.process(src, assign({ from : "test/specimens/simple.css" }, options || {})).css;
 }
 
 describe("postcss-modular-css", function() {
@@ -10,14 +11,14 @@ describe("postcss-modular-css", function() {
         it("should generate a prefix for class names", function() {
             assert.equal(
                 css(".wooga { color: red; }"),
-                ".mc83fe1a59eebdf17220df583a8e9048da_wooga { color: red; }"
+                ".08e91a5b_wooga { color: red; }"
             );
         });
         
         it("should generate a prefix for ids", function() {
             assert.equal(
                 css("#wooga { color: red; }"),
-                "#mc5dde9181034d498d7163570eea1e3987_wooga { color: red; }"
+                "#08e91a5b_wooga { color: red; }"
             );
         });
         
@@ -31,51 +32,51 @@ describe("postcss-modular-css", function() {
         it("should transform class/id selectors", function() {
             assert.equal(
                 css(".wooga p { color: red; }"),
-                ".mc7b944dc32d3d3f9ee2567de2101b5988_wooga p { color: red; }"
+                ".08e91a5b_wooga p { color: red; }"
             );
 
             assert.equal(
                 css("#wooga p { color: red; }"),
-                "#mcb350f25893cfee96ec24f2e48e73349e_wooga p { color: red; }"
+                "#08e91a5b_wooga p { color: red; }"
             );
             
             assert.equal(
                 css("#wooga .booga { color: red; }"),
-                "#mcbf6193cc71ecb94fb202e8fea1df388a_wooga .mcbf6193cc71ecb94fb202e8fea1df388a_booga { color: red; }"
+                "#08e91a5b_wooga .08e91a5b_booga { color: red; }"
             );
 
             assert.equal(
                 css("#wooga { color: red; } #wooga:hover { color: blue; }"),
-                "#mc134c0871e7c8220eca018a7499dc4bc4_wooga { color: red; } #mc134c0871e7c8220eca018a7499dc4bc4_wooga:hover { color: blue; }"
+                "#08e91a5b_wooga { color: red; } #08e91a5b_wooga:hover { color: blue; }"
             );
 
             assert.equal(
                 css(".wooga { color: red; } .wooga:hover { color: black; }"),
-                ".mcb788f7606cd25b7137bda6ab728d76a7_wooga { color: red; } .mcb788f7606cd25b7137bda6ab728d76a7_wooga:hover { color: black; }"
+                ".08e91a5b_wooga { color: red; } .08e91a5b_wooga:hover { color: black; }"
             );
         });
         
         it("should transform selectors within media queries", function() {
             assert.equal(
                 css("@media (max-width: 100px) { .booga { color: red; } }"),
-                "@media (max-width: 100px) { .mc1c058ba8c40ce27eb8eef0ed1d5ef09a_booga { color: red; } }"
+                "@media (max-width: 100px) { .08e91a5b_booga { color: red; } }"
             );
         });
 
         it("should transform the names of @keyframes rules", function() {
             assert.equal(
                 css("@keyframes fooga { }"),
-                "@keyframes mc1e94ad5ed57bec6e30ca29b42f68dcc6_fooga { }"
+                "@keyframes 08e91a5b_fooga { }"
             );
 
             assert.equal(
                 css("@-webkit-keyframes fooga { }"),
-                "@-webkit-keyframes mc4f812711fa10a3203c5aecebdeb3e540_fooga { }"
+                "@-webkit-keyframes 08e91a5b_fooga { }"
             );
 
             assert.equal(
                 css("@-moz-keyframes fooga { }"),
-                "@-moz-keyframes mcb061bc99d952e01429c8456dd506aca9_fooga { }"
+                "@-moz-keyframes 08e91a5b_fooga { }"
             );
         });
         
@@ -99,16 +100,17 @@ describe("postcss-modular-css", function() {
         
         it("should expose original names in a message", function() {
             var result = plugin.process(
-                ".wooga { color: red; } #booga { color: black; } @keyframes fooga { 0% { color: red; } 100% { color: black; } }"
+                ".wooga { color: red; } #booga { color: black; } @keyframes fooga { 0% { color: red; } 100% { color: black; } }",
+                { from : "test/specimens/simple.css" }
             );
             
             assert.deepEqual(result.messages, [ {
                 type    : "modularcss",
                 plugin  : "postcss-modular-css-scoping",
                 classes : {
-                    booga : "mce71f0a57b16849313577efa7f45d31e2_booga",
-                    fooga : "mce71f0a57b16849313577efa7f45d31e2_fooga",
-                    wooga : "mce71f0a57b16849313577efa7f45d31e2_wooga"
+                    booga : "08e91a5b_booga",
+                    fooga : "08e91a5b_fooga",
+                    wooga : "08e91a5b_wooga"
                 }
             } ]);
         });
@@ -156,7 +158,7 @@ describe("postcss-modular-css", function() {
             it("should support mixed local & global selectors", function() {
                 assert.equal(
                     css(":global(#wooga), .wooga { color: red; }"),
-                    "#wooga, .mc0161606ae727b8d0466e905957eca53c_wooga { color: red; }"
+                    "#wooga, .08e91a5b_wooga { color: red; }"
                 );
             });
 
@@ -172,7 +174,8 @@ describe("postcss-modular-css", function() {
                         ":global(.wooga) { color: red; } " +
                         ":global(#fooga) { color: red; } " +
                         ":global(.googa .tooga) { color: red; } " +
-                        "@keyframes :global(yooga) { 0% { color: red; } 100% { color: black; } }"
+                        "@keyframes :global(yooga) { 0% { color: red; } 100% { color: black; } }",
+                        { from : "test/specimens/simple.css" }
                     );
                 
                 assert.deepEqual(result.messages, [ {

--- a/test/processor.js
+++ b/test/processor.js
@@ -29,17 +29,17 @@ describe("postcss-modular-css", function() {
                         file   = result.files["test/specimens/simple.css"];
                     
                     assert.deepEqual(result.exports, {
-                        wooga : [ "08e91a5b_wooga" ]
+                        wooga : [ "mc08e91a5b_wooga" ]
                     });
 
                     assert.equal(typeof file, "object");
 
                     assert.deepEqual(file.compositions, {
-                        wooga : [ "08e91a5b_wooga" ]
+                        wooga : [ "mc08e91a5b_wooga" ]
                     });
 
                     assert.equal(file.text, ".wooga { }");
-                    assert.equal(file.parsed.root.toResult().css, ".08e91a5b_wooga { }");
+                    assert.equal(file.parsed.root.toResult().css, ".mc08e91a5b_wooga { }");
                 });
             });
 
@@ -49,17 +49,17 @@ describe("postcss-modular-css", function() {
                         file   = result.files["test/specimens/simple.css"];
                     
                     assert.deepEqual(result.exports, {
-                        wooga : [ "08e91a5b_wooga" ]
+                        wooga : [ "mc08e91a5b_wooga" ]
                     });
 
                     assert.equal(typeof file, "object");
 
                     assert.deepEqual(file.compositions, {
-                        wooga : [ "08e91a5b_wooga" ]
+                        wooga : [ "mc08e91a5b_wooga" ]
                     });
 
                     assert.equal(file.text, ".wooga { color: red; }\n");
-                    assert.equal(file.parsed.root.toResult().css, ".08e91a5b_wooga { color: red; }\n");
+                    assert.equal(file.parsed.root.toResult().css, ".mc08e91a5b_wooga { color: red; }\n");
                 });
             });
             
@@ -133,25 +133,25 @@ describe("postcss-modular-css", function() {
                         file   = result.files["test/specimens/simple.css"];
                     
                     assert.deepEqual(result.exports, {
-                        fooga : [ "08e91a5b_fooga" ],
-                        kooga : [ "08e91a5b_kooga" ],
-                        wooga : [ "08e91a5b_wooga" ]
+                        fooga : [ "mc08e91a5b_fooga" ],
+                        kooga : [ "mc08e91a5b_kooga" ],
+                        wooga : [ "mc08e91a5b_wooga" ]
                     });
 
                     assert.equal(typeof file, "object");
 
                     assert.deepEqual(file.compositions, {
-                        fooga : [ "08e91a5b_fooga" ],
-                        kooga : [ "08e91a5b_kooga" ],
-                        wooga : [ "08e91a5b_wooga" ]
+                        fooga : [ "mc08e91a5b_fooga" ],
+                        kooga : [ "mc08e91a5b_kooga" ],
+                        wooga : [ "mc08e91a5b_wooga" ]
                     });
 
                     assert.equal(file.text, "@keyframes kooga { } #fooga { } .wooga { }");
                     assert.equal(
                         file.parsed.root.toResult().css,
-                        "@keyframes 08e91a5b_kooga { } " +
-                        "#08e91a5b_fooga { } " +
-                        ".08e91a5b_wooga { }"
+                        "@keyframes mc08e91a5b_kooga { } " +
+                        "#mc08e91a5b_fooga { } " +
+                        ".mc08e91a5b_wooga { }"
                     );
                 });
 
@@ -160,8 +160,8 @@ describe("postcss-modular-css", function() {
                     file;
                 
                 assert.deepEqual(result.exports, {
-                    booga : [ "1fad4cc3_wooga" ],
-                    wooga : [ "1fad4cc3_wooga" ]
+                    booga : [ "mc1fad4cc3_wooga" ],
+                    wooga : [ "mc1fad4cc3_wooga" ]
                 });
 
                 file = result.files["test/specimens/node_modules.css"];
@@ -170,17 +170,17 @@ describe("postcss-modular-css", function() {
                 assert.equal(file.parsed.root.toResult().css, "\n");
 
                 assert.deepEqual(file.compositions, {
-                    booga : [ "1fad4cc3_wooga" ],
-                    wooga : [ "1fad4cc3_wooga" ]
+                    booga : [ "mc1fad4cc3_wooga" ],
+                    wooga : [ "mc1fad4cc3_wooga" ]
                 });
 
                 file = result.files["test/specimens/node_modules/styles/styles.css"];
 
                 assert.equal(file.text, fs.readFileSync("./test/specimens/node_modules/styles/styles.css", "utf8"));
-                assert.equal(file.parsed.root.toResult().css, ".1fad4cc3_wooga { color: white; }\n");
+                assert.equal(file.parsed.root.toResult().css, ".mc1fad4cc3_wooga { color: white; }\n");
 
                 assert.deepEqual(file.compositions, {
-                    wooga : [ "1fad4cc3_wooga" ]
+                    wooga : [ "mc1fad4cc3_wooga" ]
                 });
             });
 
@@ -189,9 +189,9 @@ describe("postcss-modular-css", function() {
                     file;
                 
                 assert.deepEqual(result.exports, {
-                    wooga : [ "04cb4cb2_booga" ],
-                    booga : [ "61f0515a_booga" ],
-                    tooga : [ "61f0515a_tooga" ]
+                    wooga : [ "mc04cb4cb2_booga" ],
+                    booga : [ "mc61f0515a_booga" ],
+                    tooga : [ "mc61f0515a_tooga" ]
                 });
 
                 file = result.files["test/specimens/start.css"];
@@ -199,8 +199,8 @@ describe("postcss-modular-css", function() {
                 assert.equal(file.text, fs.readFileSync("./test/specimens/start.css", "utf8"));
                 assert.equal(
                     file.parsed.root.toResult().css,
-                    ".61f0515a_booga { color: red; background: blue; }\n" +
-                    ".61f0515a_tooga { border: 1px solid white; }\n"
+                    ".mc61f0515a_booga { color: red; background: blue; }\n" +
+                    ".mc61f0515a_tooga { border: 1px solid white; }\n"
                 );
 
                 assert.deepEqual(file.values, {
@@ -210,15 +210,15 @@ describe("postcss-modular-css", function() {
                 });
 
                 assert.deepEqual(file.compositions, {
-                    wooga : [ "04cb4cb2_booga" ],
-                    booga : [ "61f0515a_booga" ],
-                    tooga : [ "61f0515a_tooga" ]
+                    wooga : [ "mc04cb4cb2_booga" ],
+                    booga : [ "mc61f0515a_booga" ],
+                    tooga : [ "mc61f0515a_tooga" ]
                 });
 
                 file = result.files["test/specimens/local.css"];
 
                 assert.equal(file.text, fs.readFileSync("./test/specimens/local.css", "utf8"));
-                assert.equal(file.parsed.root.toResult().css, ".04cb4cb2_booga { background: green; }\n");
+                assert.equal(file.parsed.root.toResult().css, ".mc04cb4cb2_booga { background: green; }\n");
 
                 assert.deepEqual(file.values, {
                     folder : "white",
@@ -227,21 +227,21 @@ describe("postcss-modular-css", function() {
                 });
 
                 assert.deepEqual(file.compositions, {
-                    booga : [ "04cb4cb2_booga" ],
-                    looga : [ "04cb4cb2_booga" ]
+                    booga : [ "mc04cb4cb2_booga" ],
+                    looga : [ "mc04cb4cb2_booga" ]
                 });
 
                 file = result.files["test/specimens/folder/folder.css"];
 
                 assert.equal(file.text, fs.readFileSync("./test/specimens/folder/folder.css", "utf8"));
-                assert.equal(file.parsed.root.toResult().css, ".04bb002b_folder { margin: 2px; }\n");
+                assert.equal(file.parsed.root.toResult().css, ".mc04bb002b_folder { margin: 2px; }\n");
 
                 assert.deepEqual(file.values, {
                     folder : "white"
                 });
                 
                 assert.deepEqual(file.compositions, {
-                    folder : [ "04bb002b_folder" ]
+                    folder : [ "mc04bb002b_folder" ]
                 });
             });
 

--- a/test/processor.js
+++ b/test/processor.js
@@ -160,8 +160,8 @@ describe("postcss-modular-css", function() {
                     file;
                 
                 assert.deepEqual(result.exports, {
-                    booga : [ "mc669ffa9d9ce988eb34ed75f927156773_wooga" ],
-                    wooga : [ "mc669ffa9d9ce988eb34ed75f927156773_wooga" ]
+                    booga : [ "1fad4cc3_wooga" ],
+                    wooga : [ "1fad4cc3_wooga" ]
                 });
 
                 file = result.files["test/specimens/node_modules.css"];
@@ -170,17 +170,17 @@ describe("postcss-modular-css", function() {
                 assert.equal(file.parsed.root.toResult().css, "\n");
 
                 assert.deepEqual(file.compositions, {
-                    booga : [ "mc669ffa9d9ce988eb34ed75f927156773_wooga" ],
-                    wooga : [ "mc669ffa9d9ce988eb34ed75f927156773_wooga" ]
+                    booga : [ "1fad4cc3_wooga" ],
+                    wooga : [ "1fad4cc3_wooga" ]
                 });
 
                 file = result.files["test/specimens/node_modules/styles/styles.css"];
 
                 assert.equal(file.text, fs.readFileSync("./test/specimens/node_modules/styles/styles.css", "utf8"));
-                assert.equal(file.parsed.root.toResult().css, ".mc669ffa9d9ce988eb34ed75f927156773_wooga { color: white; }\n");
+                assert.equal(file.parsed.root.toResult().css, ".1fad4cc3_wooga { color: white; }\n");
 
                 assert.deepEqual(file.compositions, {
-                    wooga : [ "mc669ffa9d9ce988eb34ed75f927156773_wooga" ]
+                    wooga : [ "1fad4cc3_wooga" ]
                 });
             });
 
@@ -189,9 +189,9 @@ describe("postcss-modular-css", function() {
                     file;
                 
                 assert.deepEqual(result.exports, {
-                    wooga : [ "mcf5507abd3eea0987714c5d92c3230347_booga" ],
-                    booga : [ "mcaeacf0c6fbb2445f549ddc0fcfc1747b_booga" ],
-                    tooga : [ "mcaeacf0c6fbb2445f549ddc0fcfc1747b_tooga" ]
+                    wooga : [ "04cb4cb2_booga" ],
+                    booga : [ "61f0515a_booga" ],
+                    tooga : [ "61f0515a_tooga" ]
                 });
 
                 file = result.files["test/specimens/start.css"];
@@ -199,8 +199,8 @@ describe("postcss-modular-css", function() {
                 assert.equal(file.text, fs.readFileSync("./test/specimens/start.css", "utf8"));
                 assert.equal(
                     file.parsed.root.toResult().css,
-                    ".mcaeacf0c6fbb2445f549ddc0fcfc1747b_booga { color: red; background: blue; }\n" +
-                    ".mcaeacf0c6fbb2445f549ddc0fcfc1747b_tooga { border: 1px solid white; }\n"
+                    ".61f0515a_booga { color: red; background: blue; }\n" +
+                    ".61f0515a_tooga { border: 1px solid white; }\n"
                 );
 
                 assert.deepEqual(file.values, {
@@ -210,15 +210,15 @@ describe("postcss-modular-css", function() {
                 });
 
                 assert.deepEqual(file.compositions, {
-                    wooga : [ "mcf5507abd3eea0987714c5d92c3230347_booga" ],
-                    booga : [ "mcaeacf0c6fbb2445f549ddc0fcfc1747b_booga" ],
-                    tooga : [ "mcaeacf0c6fbb2445f549ddc0fcfc1747b_tooga" ]
+                    wooga : [ "04cb4cb2_booga" ],
+                    booga : [ "61f0515a_booga" ],
+                    tooga : [ "61f0515a_tooga" ]
                 });
 
                 file = result.files["test/specimens/local.css"];
 
                 assert.equal(file.text, fs.readFileSync("./test/specimens/local.css", "utf8"));
-                assert.equal(file.parsed.root.toResult().css, ".mcf5507abd3eea0987714c5d92c3230347_booga { background: green; }\n");
+                assert.equal(file.parsed.root.toResult().css, ".04cb4cb2_booga { background: green; }\n");
 
                 assert.deepEqual(file.values, {
                     folder : "white",
@@ -227,21 +227,21 @@ describe("postcss-modular-css", function() {
                 });
 
                 assert.deepEqual(file.compositions, {
-                    booga : [ "mcf5507abd3eea0987714c5d92c3230347_booga" ],
-                    looga : [ "mcf5507abd3eea0987714c5d92c3230347_booga" ]
+                    booga : [ "04cb4cb2_booga" ],
+                    looga : [ "04cb4cb2_booga" ]
                 });
 
                 file = result.files["test/specimens/folder/folder.css"];
 
                 assert.equal(file.text, fs.readFileSync("./test/specimens/folder/folder.css", "utf8"));
-                assert.equal(file.parsed.root.toResult().css, ".mcdafdfcc7dc876084d352519086f9e6e9_folder { margin: 2px; }\n");
+                assert.equal(file.parsed.root.toResult().css, ".04bb002b_folder { margin: 2px; }\n");
 
                 assert.deepEqual(file.values, {
                     folder : "white"
                 });
                 
                 assert.deepEqual(file.compositions, {
-                    folder : [ "mcdafdfcc7dc876084d352519086f9e6e9_folder" ]
+                    folder : [ "04bb002b_folder" ]
                 });
             });
 

--- a/test/processor.js
+++ b/test/processor.js
@@ -29,17 +29,17 @@ describe("postcss-modular-css", function() {
                         file   = result.files["test/specimens/simple.css"];
                     
                     assert.deepEqual(result.exports, {
-                        wooga : [ "mc361c6a593917072a0083c6531865077d_wooga" ]
+                        wooga : [ "08e91a5b_wooga" ]
                     });
 
                     assert.equal(typeof file, "object");
 
                     assert.deepEqual(file.compositions, {
-                        wooga : [ "mc361c6a593917072a0083c6531865077d_wooga" ]
+                        wooga : [ "08e91a5b_wooga" ]
                     });
 
                     assert.equal(file.text, ".wooga { }");
-                    assert.equal(file.parsed.root.toResult().css, ".mc361c6a593917072a0083c6531865077d_wooga { }");
+                    assert.equal(file.parsed.root.toResult().css, ".08e91a5b_wooga { }");
                 });
             });
 
@@ -49,17 +49,17 @@ describe("postcss-modular-css", function() {
                         file   = result.files["test/specimens/simple.css"];
                     
                     assert.deepEqual(result.exports, {
-                        wooga : [ "mc1bc1718879cff9694b0f5cc8ad7b7537_wooga" ]
+                        wooga : [ "08e91a5b_wooga" ]
                     });
 
                     assert.equal(typeof file, "object");
 
                     assert.deepEqual(file.compositions, {
-                        wooga : [ "mc1bc1718879cff9694b0f5cc8ad7b7537_wooga" ]
+                        wooga : [ "08e91a5b_wooga" ]
                     });
 
                     assert.equal(file.text, ".wooga { color: red; }\n");
-                    assert.equal(file.parsed.root.toResult().css, ".mc1bc1718879cff9694b0f5cc8ad7b7537_wooga { color: red; }\n");
+                    assert.equal(file.parsed.root.toResult().css, ".08e91a5b_wooga { color: red; }\n");
                 });
             });
             
@@ -133,25 +133,25 @@ describe("postcss-modular-css", function() {
                         file   = result.files["test/specimens/simple.css"];
                     
                     assert.deepEqual(result.exports, {
-                        fooga : [ "mc433a1e5568b4a09c50491d8f1ff70725_fooga" ],
-                        kooga : [ "mc433a1e5568b4a09c50491d8f1ff70725_kooga" ],
-                        wooga : [ "mc433a1e5568b4a09c50491d8f1ff70725_wooga" ]
+                        fooga : [ "08e91a5b_fooga" ],
+                        kooga : [ "08e91a5b_kooga" ],
+                        wooga : [ "08e91a5b_wooga" ]
                     });
 
                     assert.equal(typeof file, "object");
 
                     assert.deepEqual(file.compositions, {
-                        fooga : [ "mc433a1e5568b4a09c50491d8f1ff70725_fooga" ],
-                        kooga : [ "mc433a1e5568b4a09c50491d8f1ff70725_kooga" ],
-                        wooga : [ "mc433a1e5568b4a09c50491d8f1ff70725_wooga" ]
+                        fooga : [ "08e91a5b_fooga" ],
+                        kooga : [ "08e91a5b_kooga" ],
+                        wooga : [ "08e91a5b_wooga" ]
                     });
 
                     assert.equal(file.text, "@keyframes kooga { } #fooga { } .wooga { }");
                     assert.equal(
                         file.parsed.root.toResult().css,
-                        "@keyframes mc433a1e5568b4a09c50491d8f1ff70725_kooga { } " +
-                        "#mc433a1e5568b4a09c50491d8f1ff70725_fooga { } " +
-                        ".mc433a1e5568b4a09c50491d8f1ff70725_wooga { }"
+                        "@keyframes 08e91a5b_kooga { } " +
+                        "#08e91a5b_fooga { } " +
+                        ".08e91a5b_wooga { }"
                     );
                 });
 

--- a/test/results/browserify-avoid-duplicates-local.js
+++ b/test/results/browserify-avoid-duplicates-local.js
@@ -1,1 +1,1 @@
-module.exports = {"booga":["04cb4cb2_booga"],"looga":["04cb4cb2_booga"]};
+module.exports = {"booga":["mc04cb4cb2_booga"],"looga":["mc04cb4cb2_booga"]};

--- a/test/results/browserify-avoid-duplicates-local.js
+++ b/test/results/browserify-avoid-duplicates-local.js
@@ -1,1 +1,1 @@
-module.exports = {"booga":["mcf5507abd3eea0987714c5d92c3230347_booga"],"looga":["mcf5507abd3eea0987714c5d92c3230347_booga"]};
+module.exports = {"booga":["04cb4cb2_booga"],"looga":["04cb4cb2_booga"]};

--- a/test/results/browserify-avoid-duplicates-start.js
+++ b/test/results/browserify-avoid-duplicates-start.js
@@ -1,1 +1,1 @@
-module.exports = {"wooga":["04cb4cb2_booga"],"booga":["61f0515a_booga"],"tooga":["61f0515a_tooga"]};
+module.exports = {"wooga":["mc04cb4cb2_booga"],"booga":["mc61f0515a_booga"],"tooga":["mc61f0515a_tooga"]};

--- a/test/results/browserify-avoid-duplicates-start.js
+++ b/test/results/browserify-avoid-duplicates-start.js
@@ -1,1 +1,1 @@
-module.exports = {"wooga":["mcf5507abd3eea0987714c5d92c3230347_booga"],"booga":["mcaeacf0c6fbb2445f549ddc0fcfc1747b_booga"],"tooga":["mcaeacf0c6fbb2445f549ddc0fcfc1747b_tooga"]};
+module.exports = {"wooga":["04cb4cb2_booga"],"booga":["61f0515a_booga"],"tooga":["61f0515a_tooga"]};

--- a/test/results/browserify-avoid-duplicates.css
+++ b/test/results/browserify-avoid-duplicates.css
@@ -1,16 +1,16 @@
 /* test/specimens/folder/folder.css */
-.mcdafdfcc7dc876084d352519086f9e6e9_folder {
+.04bb002b_folder {
     margin: 2px
 }
 /* test/specimens/local.css */
-.mcf5507abd3eea0987714c5d92c3230347_booga {
+.04cb4cb2_booga {
     background: green
 }
 /* test/specimens/start.css */
-.mcaeacf0c6fbb2445f549ddc0fcfc1747b_booga {
+.61f0515a_booga {
     color: red;
     background: blue
 }
-.mcaeacf0c6fbb2445f549ddc0fcfc1747b_tooga {
+.61f0515a_tooga {
     border: 1px solid white
 }

--- a/test/results/browserify-avoid-duplicates.css
+++ b/test/results/browserify-avoid-duplicates.css
@@ -1,16 +1,16 @@
 /* test/specimens/folder/folder.css */
-.04bb002b_folder {
+.mc04bb002b_folder {
     margin: 2px
 }
 /* test/specimens/local.css */
-.04cb4cb2_booga {
+.mc04cb4cb2_booga {
     background: green
 }
 /* test/specimens/start.css */
-.61f0515a_booga {
+.mc61f0515a_booga {
     color: red;
     background: blue
 }
-.61f0515a_tooga {
+.mc61f0515a_tooga {
     border: 1px solid white
 }

--- a/test/results/browserify-export-all-identifiers.json
+++ b/test/results/browserify-export-all-identifiers.json
@@ -1,1 +1,1 @@
-{"test/specimens/simple.css":{"wooga":["mc1bc1718879cff9694b0f5cc8ad7b7537_wooga"]}}
+{"test/specimens/simple.css":{"wooga":["08e91a5b_wooga"]}}

--- a/test/results/browserify-export-all-identifiers.json
+++ b/test/results/browserify-export-all-identifiers.json
@@ -1,1 +1,1 @@
-{"test/specimens/simple.css":{"wooga":["08e91a5b_wooga"]}}
+{"test/specimens/simple.css":{"wooga":["mc08e91a5b_wooga"]}}

--- a/test/results/browserify-export-identifiers.js
+++ b/test/results/browserify-export-identifiers.js
@@ -1,1 +1,1 @@
-module.exports = {"wooga":["08e91a5b_wooga"]};
+module.exports = {"wooga":["mc08e91a5b_wooga"]};

--- a/test/results/browserify-export-identifiers.js
+++ b/test/results/browserify-export-identifiers.js
@@ -1,1 +1,1 @@
-module.exports = {"wooga":["mc1bc1718879cff9694b0f5cc8ad7b7537_wooga"]};
+module.exports = {"wooga":["08e91a5b_wooga"]};

--- a/test/results/browserify-fb-basic-a.css
+++ b/test/results/browserify-fb-basic-a.css
@@ -1,8 +1,8 @@
 /* test/specimens/start.css */
-.mcaeacf0c6fbb2445f549ddc0fcfc1747b_booga {
+.61f0515a_booga {
     color: red;
     background: blue
 }
-.mcaeacf0c6fbb2445f549ddc0fcfc1747b_tooga {
+.61f0515a_tooga {
     border: 1px solid white
 }

--- a/test/results/browserify-fb-basic-a.css
+++ b/test/results/browserify-fb-basic-a.css
@@ -1,8 +1,8 @@
 /* test/specimens/start.css */
-.61f0515a_booga {
+.mc61f0515a_booga {
     color: red;
     background: blue
 }
-.61f0515a_tooga {
+.mc61f0515a_tooga {
     border: 1px solid white
 }

--- a/test/results/browserify-fb-basic.css
+++ b/test/results/browserify-fb-basic.css
@@ -1,8 +1,8 @@
 /* test/specimens/folder/folder.css */
-.04bb002b_folder {
+.mc04bb002b_folder {
     margin: 2px
 }
 /* test/specimens/local.css */
-.04cb4cb2_booga {
+.mc04cb4cb2_booga {
     background: green
 }

--- a/test/results/browserify-fb-basic.css
+++ b/test/results/browserify-fb-basic.css
@@ -1,8 +1,8 @@
 /* test/specimens/folder/folder.css */
-.mcdafdfcc7dc876084d352519086f9e6e9_folder {
+.04bb002b_folder {
     margin: 2px
 }
 /* test/specimens/local.css */
-.mcf5507abd3eea0987714c5d92c3230347_booga {
+.04cb4cb2_booga {
     background: green
 }

--- a/test/results/browserify-fb-noempty-a.css
+++ b/test/results/browserify-fb-noempty-a.css
@@ -1,16 +1,16 @@
 /* test/specimens/folder/folder.css */
-.mcdafdfcc7dc876084d352519086f9e6e9_folder {
+.04bb002b_folder {
     margin: 2px
 }
 /* test/specimens/local.css */
-.mcf5507abd3eea0987714c5d92c3230347_booga {
+.04cb4cb2_booga {
     background: green
 }
 /* test/specimens/start.css */
-.mcaeacf0c6fbb2445f549ddc0fcfc1747b_booga {
+.61f0515a_booga {
     color: red;
     background: blue
 }
-.mcaeacf0c6fbb2445f549ddc0fcfc1747b_tooga {
+.61f0515a_tooga {
     border: 1px solid white
 }

--- a/test/results/browserify-fb-noempty-a.css
+++ b/test/results/browserify-fb-noempty-a.css
@@ -1,16 +1,16 @@
 /* test/specimens/folder/folder.css */
-.04bb002b_folder {
+.mc04bb002b_folder {
     margin: 2px
 }
 /* test/specimens/local.css */
-.04cb4cb2_booga {
+.mc04cb4cb2_booga {
     background: green
 }
 /* test/specimens/start.css */
-.61f0515a_booga {
+.mc61f0515a_booga {
     color: red;
     background: blue
 }
-.61f0515a_tooga {
+.mc61f0515a_tooga {
     border: 1px solid white
 }

--- a/test/results/browserify-fb-relative-a.css
+++ b/test/results/browserify-fb-relative-a.css
@@ -1,9 +1,9 @@
 /* test/specimens/start.css */
-.mcaeacf0c6fbb2445f549ddc0fcfc1747b_booga {
+.mc61f0515a_booga {
     color: red;
     background: blue
 }
-.mcaeacf0c6fbb2445f549ddc0fcfc1747b_tooga {
+.mc61f0515a_tooga {
     border: 1px solid white
 }
 /* test/specimens/relative.css */

--- a/test/results/browserify-fb-relative-a.css
+++ b/test/results/browserify-fb-relative-a.css
@@ -7,7 +7,7 @@
     border: 1px solid white
 }
 /* test/specimens/relative.css */
-.mcb561b6ffa8d1684699785a5ab2357f1a_wooga {
+.592b2d8f_wooga {
     color: red;
     background: url("../specimens/folder/to.png")
 }

--- a/test/results/browserify-fb-relative-a.css
+++ b/test/results/browserify-fb-relative-a.css
@@ -7,7 +7,7 @@
     border: 1px solid white
 }
 /* test/specimens/relative.css */
-.592b2d8f_wooga {
+.mc592b2d8f_wooga {
     color: red;
     background: url("../specimens/folder/to.png")
 }

--- a/test/results/browserify-include-css-deps.css
+++ b/test/results/browserify-include-css-deps.css
@@ -1,16 +1,16 @@
 /* test/specimens/folder/folder.css */
-.mcdafdfcc7dc876084d352519086f9e6e9_folder {
+.04bb002b_folder {
     margin: 2px
 }
 /* test/specimens/local.css */
-.mcf5507abd3eea0987714c5d92c3230347_booga {
+.04cb4cb2_booga {
     background: green
 }
 /* test/specimens/start.css */
-.mcaeacf0c6fbb2445f549ddc0fcfc1747b_booga {
+.61f0515a_booga {
     color: red;
     background: blue
 }
-.mcaeacf0c6fbb2445f549ddc0fcfc1747b_tooga {
+.61f0515a_tooga {
     border: 1px solid white
 }

--- a/test/results/browserify-include-css-deps.css
+++ b/test/results/browserify-include-css-deps.css
@@ -1,16 +1,16 @@
 /* test/specimens/folder/folder.css */
-.04bb002b_folder {
+.mc04bb002b_folder {
     margin: 2px
 }
 /* test/specimens/local.css */
-.04cb4cb2_booga {
+.mc04cb4cb2_booga {
     background: green
 }
 /* test/specimens/start.css */
-.61f0515a_booga {
+.mc61f0515a_booga {
     color: red;
     background: blue
 }
-.61f0515a_tooga {
+.mc61f0515a_tooga {
     border: 1px solid white
 }

--- a/test/results/browserify-include-css-deps.js
+++ b/test/results/browserify-include-css-deps.js
@@ -1,1 +1,1 @@
-module.exports = {"wooga":["04cb4cb2_booga"],"booga":["61f0515a_booga"],"tooga":["61f0515a_tooga"]};
+module.exports = {"wooga":["mc04cb4cb2_booga"],"booga":["mc61f0515a_booga"],"tooga":["mc61f0515a_tooga"]};

--- a/test/results/browserify-include-css-deps.js
+++ b/test/results/browserify-include-css-deps.js
@@ -1,1 +1,1 @@
-module.exports = {"wooga":["mcf5507abd3eea0987714c5d92c3230347_booga"],"booga":["mcaeacf0c6fbb2445f549ddc0fcfc1747b_booga"],"tooga":["mcaeacf0c6fbb2445f549ddc0fcfc1747b_tooga"]};
+module.exports = {"wooga":["04cb4cb2_booga"],"booga":["61f0515a_booga"],"tooga":["61f0515a_tooga"]};

--- a/test/results/browserify-relative.css
+++ b/test/results/browserify-relative.css
@@ -1,5 +1,5 @@
 /* test/specimens/relative.css */
-.592b2d8f_wooga {
+.mc592b2d8f_wooga {
     color: red;
     background: url("../specimens/folder/to.png")
 }

--- a/test/results/browserify-relative.css
+++ b/test/results/browserify-relative.css
@@ -1,5 +1,5 @@
 /* test/specimens/relative.css */
-.mcb561b6ffa8d1684699785a5ab2357f1a_wooga {
+.592b2d8f_wooga {
     color: red;
     background: url("../specimens/folder/to.png")
 }

--- a/test/results/processor-avoid-duplicates.css
+++ b/test/results/processor-avoid-duplicates.css
@@ -1,16 +1,16 @@
 /* test/specimens/folder/folder.css */
-.mcdafdfcc7dc876084d352519086f9e6e9_folder {
+.04bb002b_folder {
     margin: 2px
 }
 /* test/specimens/local.css */
-.mcf5507abd3eea0987714c5d92c3230347_booga {
+.04cb4cb2_booga {
     background: green
 }
 /* test/specimens/start.css */
-.mcaeacf0c6fbb2445f549ddc0fcfc1747b_booga {
+.61f0515a_booga {
     color: red;
     background: blue
 }
-.mcaeacf0c6fbb2445f549ddc0fcfc1747b_tooga {
+.61f0515a_tooga {
     border: 1px solid white
 }

--- a/test/results/processor-avoid-duplicates.css
+++ b/test/results/processor-avoid-duplicates.css
@@ -1,16 +1,16 @@
 /* test/specimens/folder/folder.css */
-.04bb002b_folder {
+.mc04bb002b_folder {
     margin: 2px
 }
 /* test/specimens/local.css */
-.04cb4cb2_booga {
+.mc04cb4cb2_booga {
     background: green
 }
 /* test/specimens/start.css */
-.61f0515a_booga {
+.mc61f0515a_booga {
     color: red;
     background: blue
 }
-.61f0515a_tooga {
+.mc61f0515a_tooga {
     border: 1px solid white
 }

--- a/test/results/processor-output-all.css
+++ b/test/results/processor-output-all.css
@@ -1,21 +1,21 @@
 /* test/specimens/folder/folder.css */
-.04bb002b_folder {
+.mc04bb002b_folder {
     margin: 2px
 }
 /* test/specimens/local.css */
-.04cb4cb2_booga {
+.mc04cb4cb2_booga {
     background: green
 }
 /* test/specimens/start.css */
-.61f0515a_booga {
+.mc61f0515a_booga {
     color: red;
     background: blue
 }
-.61f0515a_tooga {
+.mc61f0515a_tooga {
     border: 1px solid white
 }
 /* test/specimens/node_modules/styles/styles.css */
-.1fad4cc3_wooga {
+.mc1fad4cc3_wooga {
     color: white
 }
 /* test/specimens/node_modules.css */

--- a/test/results/processor-output-all.css
+++ b/test/results/processor-output-all.css
@@ -1,21 +1,21 @@
 /* test/specimens/folder/folder.css */
-.mcdafdfcc7dc876084d352519086f9e6e9_folder {
+.04bb002b_folder {
     margin: 2px
 }
 /* test/specimens/local.css */
-.mcf5507abd3eea0987714c5d92c3230347_booga {
+.04cb4cb2_booga {
     background: green
 }
 /* test/specimens/start.css */
-.mcaeacf0c6fbb2445f549ddc0fcfc1747b_booga {
+.61f0515a_booga {
     color: red;
     background: blue
 }
-.mcaeacf0c6fbb2445f549ddc0fcfc1747b_tooga {
+.61f0515a_tooga {
     border: 1px solid white
 }
 /* test/specimens/node_modules/styles/styles.css */
-.mc669ffa9d9ce988eb34ed75f927156773_wooga {
+.1fad4cc3_wooga {
     color: white
 }
 /* test/specimens/node_modules.css */

--- a/test/results/processor-relative.css
+++ b/test/results/processor-relative.css
@@ -1,5 +1,5 @@
 /* test/specimens/relative.css */
-.592b2d8f_wooga {
+.mc592b2d8f_wooga {
     color: red;
     background: url("../specimens/folder/to.png")
 }

--- a/test/results/processor-relative.css
+++ b/test/results/processor-relative.css
@@ -1,5 +1,5 @@
 /* test/specimens/relative.css */
-.mcb561b6ffa8d1684699785a5ab2357f1a_wooga {
+.592b2d8f_wooga {
     color: red;
     background: url("../specimens/folder/to.png")
 }


### PR DESCRIPTION
Hasha was spitting out md5 of the contents, this uses murmur and hashes the file path. Should be faster and the output's half the size!

Fixes #22