### PR TITLE
Fix missing files when using factor-bundle

### DIFF
--- a/test/browserify.js
+++ b/test/browserify.js
@@ -205,6 +205,29 @@ describe("postcss-modular-css", function() {
                     done();
                 });
             });
+
+            it("should properly handle files w/o dependencies", function(done) {
+                var build = browserify([
+                        "./test/specimens/browserify-fb-deps-a.js",
+                        "./test/specimens/browserify-fb-deps-b.js"
+                    ]);
+                
+                build.plugin(plugin, {
+                    css : "./test/output/browserify-fb-deps.css"
+                });
+
+                build.plugin("factor-bundle", {
+                    outputs : [
+                        "./test/output/browserify-fb-deps-a.js",
+                        "./test/output/browserify-fb-deps-b.js"
+                    ]
+                });
+                
+                bundle(build, function() {
+                    compare("browserify-fb-deps.css");
+                    compare("browserify-fb-deps-a.css");
+                    
+                    done();
                 });
             });
 

--- a/test/browserify.js
+++ b/test/browserify.js
@@ -9,10 +9,25 @@ var fs     = require("fs"),
     plugin  = require("../src/browserify");
 
 function compare(name1, name2) {
+    var path1 = path.join("./test/output", name1),
+        path2 = path.join("./test/results", name2 || name1);
+
     assert.equal(
-        fs.readFileSync(path.join("./test/output", name1), "utf8") + "\n",
-        fs.readFileSync(path.join("./test/results", (name2 || name1)), "utf8")
+        fs.readFileSync(path1, "utf8") + "\n",
+        fs.readFileSync(path2, "utf8"),
+        "Expected " + path1 + " to be the same as " + path2
     );
+}
+
+function bundle(build, done) {
+    build.bundle(function(err, out) {
+        assert.ifError(err);
+
+        // Wrapped because browserify event lifecycle is... odd
+        setImmediate(function() {
+            done(out);
+        });
+    });
 }
 
 describe("postcss-modular-css", function() {
@@ -183,16 +198,13 @@ describe("postcss-modular-css", function() {
                     ]
                 });
                 
-                build.bundle(function(err) {
-                    assert.ifError(err);
+                bundle(build, function() {
+                    compare("browserify-fb-basic.css");
+                    compare("browserify-fb-basic-a.css");
                     
-                    // Wrapped because browserify event lifecycle is... odd
-                    setImmediate(function() {
-                        compare("browserify-fb-basic.css");
-                        compare("browserify-fb-basic-a.css");
-                        
-                        done();
-                    });
+                    done();
+                });
+            });
                 });
             });
 
@@ -213,15 +225,10 @@ describe("postcss-modular-css", function() {
                     ]
                 });
                 
-                build.bundle(function(err) {
-                    assert.ifError(err);
+                bundle(build, function() {
+                    compare("browserify-fb-relative-a.css");
                     
-                    // Wrapped because browserify event lifecycle is... odd
-                    setImmediate(function() {
-                        compare("browserify-fb-relative-a.css");
-                        
-                        done();
-                    });
+                    done();
                 });
             });
 
@@ -242,23 +249,18 @@ describe("postcss-modular-css", function() {
                     ]
                 });
                 
-                build.bundle(function(err) {
-                    assert.ifError(err);
-                    
-                    // Wrapped because browserify event lifecycle is... odd
-                    setImmediate(function() {
-                        assert.throws(function() {
-                            fs.statSync("./test/output/browserify-fb-noempty-b.css");
-                        });
-                        
-                        assert.throws(function() {
-                            fs.statSync("./test/output/browserify-fb-noempty-common.css");
-                        });
-                        
-                        compare("browserify-fb-noempty-a.css");
-                        
-                        done();
+                bundle(build, function() {
+                    assert.throws(function() {
+                        fs.statSync("./test/output/browserify-fb-noempty-b.css");
                     });
+                    
+                    assert.throws(function() {
+                        fs.statSync("./test/output/browserify-fb-noempty-common.css");
+                    });
+                    
+                    compare("browserify-fb-noempty-a.css");
+                    
+                    done();
                 });
             });
 
@@ -280,16 +282,11 @@ describe("postcss-modular-css", function() {
                     ]
                 });
                 
-                build.bundle(function(err) {
-                    assert.ifError(err);
+                bundle(build, function() {
+                    compare("browserify-fb-empty.css");
+                    compare("browserify-fb-empty-b.css");
                     
-                    // Wrapped because browserify event lifecycle is... odd
-                    setImmediate(function() {
-                        compare("browserify-fb-empty.css");
-                        compare("browserify-fb-empty-b.css");
-                        
-                        done();
-                    });
+                    done();
                 });
             });
         });

--- a/test/results/browserify-fb-deps-a.css
+++ b/test/results/browserify-fb-deps-a.css
@@ -1,0 +1,4 @@
+/* test/specimens/simple.css */
+.mc08e91a5b_wooga {
+    color: red
+}

--- a/test/results/browserify-fb-deps.css
+++ b/test/results/browserify-fb-deps.css
@@ -1,0 +1,8 @@
+/* test/specimens/folder/folder.css */
+.mc04bb002b_folder {
+    margin: 2px
+}
+/* test/specimens/local.css */
+.mc04cb4cb2_booga {
+    background: green
+}

--- a/test/specimens/browserify-fb-deps-a.js
+++ b/test/specimens/browserify-fb-deps-a.js
@@ -1,0 +1,3 @@
+require("./browserify-fb-deps-common");
+require("./simple.css");
+require("./local.css");

--- a/test/specimens/browserify-fb-deps-b.js
+++ b/test/specimens/browserify-fb-deps-b.js
@@ -1,0 +1,2 @@
+require("./browserify-fb-deps-common");
+require("./local.css");

--- a/test/specimens/browserify-fb-deps-common.js
+++ b/test/specimens/browserify-fb-deps-common.js
@@ -1,0 +1,1 @@
+require("./folder/folder.css");


### PR DESCRIPTION
The test for which files to include in the common bundle had some issues, it would skip files that only appeared in common JS files.

So now it only excludes files that appear in a single bundle, which is the original intention anyways.

This PR also adds a small test helper that cleans up a bunch of test cases for browserify.