### PR TITLE
Fix watchify caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "jscs": "^2.7.0",
     "jscs-preset-arenanet": "^1.0.1",
     "mocha": "^2.3.4",
-    "shelljs": "^0.5.3"
+    "shelljs": "^0.5.3",
+    "watchify": "^3.6.1"
   },
   "dependencies": {
     "dependency-graph": "^0.4.1",

--- a/src/browserify.js
+++ b/src/browserify.js
@@ -23,8 +23,7 @@ module.exports = function(browserify, opts) {
             empty  : false
         }, opts),
         
-        processor = new Processor(options),
-        bundles   = {};
+        bundles, processor;
 
     if(!options.ext || options.ext.charAt(0) !== ".") {
         return browserify.emit("error", "Missing or invalid \"ext\" option: " + options.ext);
@@ -36,7 +35,7 @@ module.exports = function(browserify, opts) {
         if(path.extname(file) !== options.ext) {
             return through();
         }
-        
+
         identifier = relative(file);
         
         return sink.str(function(buffer, done) {
@@ -81,6 +80,10 @@ module.exports = function(browserify, opts) {
     });
     
     browserify.on("bundle", function(bundler) {
+        // Set up a new processor each time bundling starts
+        processor = new Processor(options);
+        bundles   = {};
+
         bundler.on("end", function() {
             var bundling = Object.keys(bundles).length > 0,
                 common;

--- a/test/results/watchify-1.css
+++ b/test/results/watchify-1.css
@@ -1,0 +1,4 @@
+/* test/specimens/watchify.css */
+.mc9b94da22_wooga {
+    color: red
+}

--- a/test/results/watchify-2.css
+++ b/test/results/watchify-2.css
@@ -1,0 +1,4 @@
+/* test/specimens/watchify.css */
+.mc9b94da22_wooga {
+    color: blue
+}

--- a/test/specimens/blue.css
+++ b/test/specimens/blue.css
@@ -1,0 +1,1 @@
+.wooga { color: blue; }

--- a/test/specimens/watchify.js
+++ b/test/specimens/watchify.js
@@ -1,0 +1,1 @@
+require("./watchify.css");


### PR DESCRIPTION
Processor objects don't re-process the same files, so we were always building based on the first time we saw any file.

Now, it'll create a new Processor instance every time `bundle()` is called. This may be a bit inefficient, but it's more correct behavior.

Would be nice to see about hooking into watchify's update notifications so we could invalidate our processing cache based on the changed files and have the best of both worlds. Someday!