### PR TITLE
Add processor.remove & use in browserify

### DIFF
--- a/src/processor.js
+++ b/src/processor.js
@@ -86,6 +86,20 @@ Processor.prototype = {
         };
     },
 
+    remove : function(files) {
+        var self = this;
+
+        if(!Array.isArray(files)) {
+            files = [ files ];
+        }
+
+        files.forEach(function(file) {
+            var key = relative(file);
+
+            delete self._files[key];
+        });
+    },
+
     dependencies : function(file) {
         return file ? this._graph.dependenciesOf(file) : this._graph.overallOrder();
     },


### PR DESCRIPTION
So that whenever watchify sees an update we can purge cache entries w/o having to re-create everything on every call to `browserify.bundle()`.

Fixes #30