### PR TITLE
Fix + tests for #35

### DIFF
--- a/src/processor.js
+++ b/src/processor.js
@@ -121,7 +121,10 @@ Processor.prototype = {
             
             // Rewrite relative URLs before adding
             // Have to do this every time because target file might be different!
-            css = urls.process(self._files[dep].parsed.root, {
+            // NOTE: the call to .clone() is really important here, otherwise this call
+            // modifies the .parsed root itself and you can process URLs multiple times
+            // See https://github.com/tivac/modular-css/issues/35
+            css = urls.process(self._files[dep].parsed.root.clone(), {
                 from : dep,
                 to   : opts.to
             });

--- a/test/results/watchify-relative.css
+++ b/test/results/watchify-relative.css
@@ -1,0 +1,9 @@
+/* test/specimens/relative.css */
+.mc592b2d8f_wooga {
+    color: red;
+    background: url("specimens/folder/to.png")
+}
+/* test/specimens/watchify-relative.css */
+.mc0893bc0d_booga {
+    background: url("specimens/to.png")
+}

--- a/test/specimens/relative.css
+++ b/test/specimens/relative.css
@@ -1,1 +1,4 @@
-.wooga { color: red; background: url("./folder/to.png"); }
+.wooga {
+    color: red;
+    background: url("./folder/to.png");
+}

--- a/test/specimens/watchify-relative.css
+++ b/test/specimens/watchify-relative.css
@@ -1,0 +1,7 @@
+.booga {
+    background: url("./to.png");
+}
+
+.wooga {
+    composes: wooga from "./relative.css";
+}

--- a/test/specimens/watchify-relative.js
+++ b/test/specimens/watchify-relative.js
@@ -1,0 +1,1 @@
+require("./watchify-relative.css");


### PR DESCRIPTION
Need to clone parsed nodes before rewriting relative URLs, otherwise they can be processed multiple times. Probably a bit slower.

Fixes #35 