### PR TITLE
Add before/after options for running postcss plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "jscs": "^2.8.0",
     "jscs-preset-arenanet": "^1.0.1",
     "mocha": "^2.3.4",
+    "postcss-color-rebeccapurple": "^2.0.0",
     "shelljs": "^0.5.3",
     "watchify": "^3.6.1"
   },


### PR DESCRIPTION
So you can do

```js
new Processor({
    after : [ require("postcss-import") ]
})
```

and suddenly `@import` calls in your CSS are inlined, but haven't been rewritten.