### PR TITLE
Only remove if selector isn't used again

### DIFF
--- a/test/issue-56.js
+++ b/test/issue-56.js
@@ -1,0 +1,32 @@
+"use strict";
+
+var assert    = require("assert"),
+    Processor = require("../src/processor");
+
+describe("modular-css", function() {
+    describe("issue 56", function() {
+        it("shouldn't prune classes that have pseudo-classed variants", function(done) {
+            var processor = new Processor();
+            
+            processor.string(
+                    "./test/specimens/issues/56.css",
+                    ".booga { color: red } " +
+                    ".fooga { composes: booga } " +
+                    ".fooga:hover { color: blue } " +
+                    ".wooga { composes: booga }"
+            )
+            .then(function(result) {
+                var file = result.files["test/specimens/issues/56.css"];
+
+                assert.deepEqual(result.exports, {
+                    booga : "mc13e7db14_booga",
+                    fooga : "mc13e7db14_booga mc13e7db14_fooga",
+                    wooga : "mc13e7db14_booga"
+                });
+
+                done();
+            })
+            .catch(done);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #56

When a declaration like

```css
.fooga { composes: booga; }
```

is found now the code makes a note of the selector, checks all the declarations in the file to see if that selector is used elsewhere, and then if it's only used in that one place it's deleted. This probably has some edge cases around other stuff that I'm not thinking of, but seems pretty conservative and safe to my mind.