### PR TITLE
Don't explode on unknown files in remove() calls

### DIFF
--- a/src/processor.js
+++ b/src/processor.js
@@ -113,7 +113,12 @@ Processor.prototype = {
             files = [ files ];
         }
 
-        files.forEach(function(file) {
+        files.filter(function(file) {
+            var key = relative(file);
+            
+            return self._graph.hasNode(key);
+        })
+        .forEach(function(file) {
             var key = relative(file);
             
             // Remove everything that depends on this too, it'll all need

--- a/test/issue-66.js
+++ b/test/issue-66.js
@@ -1,0 +1,23 @@
+"use strict";
+
+var assert = require("assert"),
+    
+    Processor = require("../src/processor");
+
+describe("modular-css", function() {
+    describe("issue 66", function() {
+        it("should ignore remove calls for unknown files", function(done) {
+            var processor = new Processor();
+
+            processor.string("./test/specimens/a.css", ".aooga { }")
+            .then(function() {
+                assert.doesNotThrow(function() {
+                    processor.remove("./fooga.js");
+                });
+
+                done();
+            })
+            .catch(done);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #66

Filter all files passed into `Processor.remove()` by checking to ensure that they're part of the dependency graph.