### PR TITLE
Rename .css() & fix up after

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,13 +192,13 @@ var Processor = require("modular-css").Processor,
 //     after  : [ require("postcss-fooga") ]
 // });
 
-processor.file("./entry.css").then(function(output) {
-    // output now contains
+processor.file("./entry.css").then(function(result) {
+    // result now contains
     //  .exports - Scoped selector mappings
     //  .files - metadata about the file hierarchy
     
-    // Transformed CSS is available from the css method    
-    processor.css();
+    // Transformed CSS is available from the .output() method    
+    return processor.output().css;
 });
 
 // or

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,29 +8,30 @@ var fs   = require("fs"),
     map    = require("lodash.mapValues"),
     
     Processor = require("../").Processor,
-
-    processor;
     
+    processor = new Processor(),
+    
+    src = process.argv[2],
+    out = process.argv[3];
+
 // Update checking
 require("update-notifier")({ pkg : require("../package.json" ) }).notify({ defer : true });
 
-processor = new Processor();
-
-processor.file(process.argv[2]).then(function() {
+processor.file(src).then(function() {
+    return processor.output({ to : out });
+})
+.then(function(result) {
     /* eslint no-console:0 */
-    var file = process.argv[3],
-        css  = processor.css();
-    
-    if(!file) {
-        return console.log(css);
+    if(!out) {
+        console.log(result.css);
     }
+    
+    mkdirp.sync(path.dirname(out));
 
-    mkdirp.sync(path.dirname(file));
-
-    fs.writeFileSync(file, css);
+    fs.writeFileSync(out, result.css);
     fs.writeFileSync(
-        path.basename(file, path.extname(file)) + ".json",
-        JSON.stringify(map(processor.files, function(part) {
+        path.basename(out, path.extname(out)) + ".json",
+        JSON.stringify(map(processor.out, function(part) {
             return part.compositions;
         }), null, 4)
     );

--- a/src/browserify.js
+++ b/src/browserify.js
@@ -147,6 +147,7 @@ module.exports = function(browserify, opts) {
         
         bundler = current;
         
+        // Listen for bundling to finish
         bundler.on("end", function() {
             var bundling = Object.keys(bundles).length > 0,
                 common;
@@ -186,15 +187,17 @@ module.exports = function(browserify, opts) {
 
                     dest = path.join(
                         path.dirname(options.css),
-                        path.basename(bundle, path.extname(bundle)) + options.ext
+                        path.basename(bundle, path.extname(bundle)) + ".css"
                     );
                     
                     mkdirp.sync(path.dirname(dest));
                     
-                    fs.writeFileSync(dest, processor.css({
+                    processor.output({
                         files : files,
                         to    : dest
-                    }));
+                    }).then(function(result) {
+                        fs.writeFileSync(dest, result.css);
+                    });
                 });
                 
                 // No common CSS files to write out, so don't (unless they asked nicely)
@@ -206,10 +209,12 @@ module.exports = function(browserify, opts) {
             mkdirp.sync(path.dirname(options.css));
             
             // Write out common/all css depending on bundling status
-            fs.writeFileSync(options.css, processor.css({
+            processor.output({
                 files : bundling && common,
                 to    : options.css
-            }));
+            }).then(function(result) {
+                fs.writeFileSync(options.css, result.css);
+            });
         });
     });
 };

--- a/src/processor.js
+++ b/src/processor.js
@@ -7,13 +7,12 @@ var fs   = require("fs"),
     Graph    = require("dependency-graph").DepGraph,
     postcss  = require("postcss"),
 
-    Promise = require("./_promise"),
-
+    Promise  = require("./_promise"),
+    relative = require("./_relative"),
+    
     urls = postcss([
         require("postcss-url")
-    ]),
-
-    relative = require("./_relative");
+    ]);
 
 function sequential(promises) {
     return new Promise(function(resolve, reject) {
@@ -137,7 +136,7 @@ Processor.prototype = {
         return file ? this._graph.dependenciesOf(file) : this._graph.overallOrder();
     },
 
-    css : function(args) {
+    output : function(args) {
         var self  = this,
             root  = postcss.root(),
             opts  = args || false,
@@ -162,7 +161,7 @@ Processor.prototype = {
             root.append(css.root);
         });
         
-        return this._after.process(root);
+        return this._after.process(root, args || {});
     },
 
     get files() {

--- a/test/issue-24.js
+++ b/test/issue-24.js
@@ -17,7 +17,7 @@ describe("modular-css", function() {
                 var file = result.files["test/specimens/composition.css"];
 
                 assert.equal(
-                    file.after.root.toResult().css,
+                    file.processed.root.toResult().css,
                     ".mc29d531c6_wooga { background: #000; }"
                 );
 

--- a/test/results/processor/start.css
+++ b/test/results/processor/start.css
@@ -1,0 +1,16 @@
+/* test/specimens/folder/folder.css */
+.mc04bb002b_folder {
+    margin: 2px
+}
+/* test/specimens/local.css */
+.mc04cb4cb2_booga {
+    background: green
+}
+/* test/specimens/start.css */
+.mc61f0515a_booga {
+    color: red;
+    background: blue
+}
+.mc61f0515a_tooga {
+    border: 1px solid white
+}


### PR DESCRIPTION
This renames `.css()` to `.output()` and will actually let the `after` plugins process the entire CSS output. It also returns a PostCSS `Result` or `LazyResult` instead of just a string so it's easier to do more processing or interesting things with it.

This is a breaking API change, and will lead to `0.11.0` wheeeeee.