### PR TITLE
Fix up sourcemaps

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -9,7 +9,7 @@ var fs   = require("fs"),
     
     Processor = require("../").Processor,
     
-    processor = new Processor(),
+    processor = new Processor({ map : true }),
     
     src = process.argv[2],
     out = process.argv[3];

--- a/src/processor.js
+++ b/src/processor.js
@@ -153,15 +153,15 @@ Processor.prototype = {
             // NOTE: the call to .clone() is really important here, otherwise this call
             // modifies the .result root itself and you process URLs multiple times
             // See https://github.com/tivac/modular-css/issues/35
-            css = urls.process(self._files[dep].result.root.clone(), {
+            css = urls.process(self._files[dep].result.root.clone(), assign({}, self._options, {
                 from : dep,
                 to   : opts.to
-            });
+            }));
             
             root.append(css.root);
         });
         
-        return this._after.process(root, args || {});
+        return this._after.process(root, assign({}, self._options, args || {}));
     },
 
     get files() {

--- a/test/processor.js
+++ b/test/processor.js
@@ -506,6 +506,25 @@ describe("modular-css", function() {
                     });
                 });
             });
+            
+            describe("source maps", function() {
+                it("should respect the `map` config and output source maps", function(done) {
+                    var processor = new Processor({ map : true });
+
+                    processor.file("./test/specimens/start.css").then(function() {
+                        return processor.output();
+                    })
+                    .then(function(result) {
+                        assert.equal(
+                            result.css + "\n",
+                            fs.readFileSync("./test/results/processor/source-map.css", "utf8")
+                        );
+
+                        done();
+                    })
+                    .catch(done);
+                });
+            });
         });
     });
 });

--- a/test/processor.js
+++ b/test/processor.js
@@ -2,7 +2,6 @@
 
 var fs      = require("fs"),
     assert  = require("assert"),
-    postcss = require("postcss"),
     
     Promise   = require("../src/_promise"),
     Processor = require("../src/processor");

--- a/test/results/processor/source-map.css
+++ b/test/results/processor/source-map.css
@@ -1,0 +1,17 @@
+/* test/specimens/folder/folder.css */
+.mc04bb002b_folder {
+    margin: 2px
+}
+/* test/specimens/local.css */
+.mc04cb4cb2_booga {
+    background: green
+}
+/* test/specimens/start.css */
+.mc61f0515a_booga {
+    color: red;
+    background: blue
+}
+.mc61f0515a_tooga {
+    border: 1px solid white
+}
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInRlc3Qvc3BlY2ltZW5zL2ZvbGRlci9mb2xkZXIuY3NzIiwidGVzdC9zcGVjaW1lbnMvbG9jYWwuY3NzIiwidGVzdC9zcGVjaW1lbnMvc3RhcnQuY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7QUFDQTtJQUFVLFdBQVk7Q0FBRTs7QUNHeEI7SUFBUyxpQkFBa0I7Q0FBRTs7QUNGN0I7SUFBUyxXQUFXO0lBQUMsZ0JBQWdCO0NBQUU7QUFDdkM7SUFBUyx1QkFBeUI7Q0FBRSIsImZpbGUiOiJ0by5jc3MiLCJzb3VyY2VzQ29udGVudCI6WyJAdmFsdWUgZm9sZGVyOiB3aGl0ZTtcbi5mb2xkZXIgeyBtYXJnaW46IDJweDsgfVxuIiwiQHZhbHVlIG9uZTogcmVkO1xuQHZhbHVlIHR3bzogYmx1ZTtcbkB2YWx1ZSBmb2xkZXIgZnJvbSBcIi4vZm9sZGVyL2ZvbGRlci5jc3NcIjtcblxuLmJvb2dhIHsgYmFja2dyb3VuZDogZ3JlZW47IH1cbi5sb29nYSB7IGNvbXBvc2VzOiBib29nYTsgfVxuIiwiQHZhbHVlIG9uZSwgdHdvLCBmb2xkZXIgZnJvbSBcIi4vbG9jYWwuY3NzXCI7XG4ud29vZ2EgeyBjb21wb3NlczogYm9vZ2EgZnJvbSBcIi4vbG9jYWwuY3NzXCI7IH1cbi5ib29nYSB7IGNvbG9yOiBvbmU7IGJhY2tncm91bmQ6IHR3bzsgfVxuLnRvb2dhIHsgYm9yZGVyOiAxcHggc29saWQgZm9sZGVyOyB9XG4iXX0= */


### PR DESCRIPTION
Fixes #73 

Only real problem was that options weren't always being merged correctly when running through postcss. That is fixed by this PR.

This also defaults the CLI to outputting inline source maps, because that seems really useful.

Tests to follow when it's not so late. :sleepy: 