### PR TITLE
Sort output before generating

### DIFF
--- a/src/processor.js
+++ b/src/processor.js
@@ -144,7 +144,7 @@ Processor.prototype = {
             opts  = args || false,
             files = opts.files || this.dependencies();
         
-        return Promise.all(files.map(function(dep) {
+        return Promise.all(files.sort().map(function(dep) {
             // Rewrite relative URLs before adding
             // Have to do this every time because target file might be different!
             // NOTE: the call to .clone() is really important here, otherwise this call

--- a/test/results/issues/58.css
+++ b/test/results/issues/58.css
@@ -1,3 +1,10 @@
+/* test/specimens/issues/58/issue.css */
+.mc0c6149b1_issue1 {
+    color: teal
+}
+.mc0c6149b1_issue2 {
+    color: aqua
+}
 /* test/specimens/issues/58/other.css */
 .mc8fe42003_other1 {
     color: green
@@ -7,11 +14,4 @@
 }
 .mc8fe42003_other3 {
     background: white
-}
-/* test/specimens/issues/58/issue.css */
-.mc0c6149b1_issue1 {
-    color: teal
-}
-.mc0c6149b1_issue2 {
-    color: aqua
 }

--- a/test/results/processor/output-all.css
+++ b/test/results/processor/output-all.css
@@ -6,6 +6,10 @@
 .mc04cb4cb2_booga {
     background: green
 }
+/* test/specimens/simple.css */
+.mc08e91a5b_wooga {
+    color: red
+}
 /* test/specimens/start.css */
 .mc61f0515a_booga {
     color: red;
@@ -13,8 +17,4 @@
 }
 .mc61f0515a_tooga {
     border: 1px solid white
-}
-/* test/specimens/simple.css */
-.mc08e91a5b_wooga {
-    color: red
 }


### PR DESCRIPTION
Makes output stable, despite the order browserify/watchify/etc add files. Was seeing spurious commits where files looked changed, but only because they had their sections re-ordered.