### PR TITLE
First pass at rollup plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "mocha": "^2.3.4",
     "postcss-color-rebeccapurple": "^2.0.0",
     "rimraf": "^2.5.0",
+    "rollup": "^0.25.4",
     "shelljs": "^0.6.0",
     "watchify": "^3.7.0"
   },
@@ -59,6 +60,7 @@
     "postcss-value-parser": "^3.2.3",
     "promiscuous": "^0.6.0",
     "resolve-from": "^2.0.0",
+    "rollup-pluginutils": "^1.3.1",
     "sink-transform": "^1.0.0",
     "through2": "^2.0.0",
     "unique-slug": "^2.0.0",

--- a/rollup.js
+++ b/rollup.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = require("./src/rollup");

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -1,0 +1,47 @@
+"use strict";
+
+var fs   = require("fs"),
+    path = require("path"),
+
+    utils  = require("rollup-pluginutils"),
+    assign = require("lodash.assign"),
+    mkdirp = require("mkdirp"),
+    
+    Processor = require("./processor");
+
+module.exports = function(opts) {
+    var options = assign({
+            ext : ".css"
+        }, opts || {}),
+        
+        filter = utils.createFilter(options.include, options.exclude),
+        
+        processor = new Processor(options);
+        
+    return {
+        transform : function(code, id) {
+            if(!filter(id) || id.slice(-1 * options.ext.length) !== options.ext) {
+                return null;
+            }
+            
+            return processor.string(id, code).then(function(result) {
+                return {
+                    code : "export default " + JSON.stringify(result.exports, null, 4)
+                };
+            });
+        },
+        
+        // This is a bit of a hack, see this rollup PR for details
+        // https://github.com/rollup/rollup/pull/353#issuecomment-164358181
+        footer : function() {
+            mkdirp.sync(path.dirname(options.css));
+            
+            // Write out common/all css depending on bundling status
+            processor.output({
+                to : options.css
+            }).then(function(result) {
+                fs.writeFileSync(options.css, result.css);
+            });
+        }
+    };
+};

--- a/test/exports.js
+++ b/test/exports.js
@@ -21,5 +21,14 @@ describe("modular-css", function() {
                 assert.equal(browserify, require("../src/browserify"));
             });
         });
+        
+        describe("/rollup", function() {
+            it("should be the rollup plugin", function() {
+                var rollup = require("../rollup");
+                
+                assert.equal(typeof rollup, "function");
+                assert.equal(rollup, require("../src/rollup"));
+            });
+        });
     });
 });

--- a/test/results/rollup/simple.css
+++ b/test/results/rollup/simple.css
@@ -1,0 +1,4 @@
+/* test/specimens/rollup/simple.css */
+.mcad949cca_fooga {
+    color: red
+}

--- a/test/results/rollup/simple.js
+++ b/test/results/rollup/simple.js
@@ -1,0 +1,5 @@
+var css = {
+    "fooga": "mcad949cca_fooga"
+}
+
+console.log(css);

--- a/test/rollup.js
+++ b/test/rollup.js
@@ -1,0 +1,66 @@
+"use strict";
+
+var fs     = require("fs"),
+    assert = require("assert"),
+    
+    rollup = require("rollup").rollup,
+    
+    plugin = require("../src/rollup"),
+    
+    compare = require("./lib/compare-files");
+
+describe("modular-css", function() {
+    describe("rollup plugin", function() {
+        after(function(done) {
+            require("rimraf")("./test/output/rollup", done);
+        });
+        
+        it("should be a function", function() {
+            assert.equal(typeof plugin, "function");
+        });
+        
+        it("should generate exports", function(done) {
+            rollup({
+                entry   : "./test/specimens/rollup/simple.js",
+                plugins : [
+                    plugin()
+                ]
+            }).then(
+                function(bundle) {
+                    var out = bundle.generate();
+                    
+                    assert.equal(
+                        out.code + "\n",
+                        fs.readFileSync("./test/results/rollup/simple.js", "utf8")
+                    );
+                    
+                    done();
+                }
+            ).catch(done);
+        });
+        
+        it("should generate CSS", function(done) {
+            rollup({
+                entry   : "./test/specimens/rollup/simple.js",
+                plugins : [
+                    plugin({
+                        css : "./test/output/rollup/simple.css"
+                    })
+                ]
+            })
+            .then(function(bundle) {
+                // Have to call this so the output fn is invoked
+                bundle.generate();
+                
+                // And since that's "sync", but generation isn't, this is necessary...
+                // UGH UGH UGH UGH UGH UGH UGH UGH UGH UGH UGH UGH UGH UGH UGH UGH UGH
+                setTimeout(function() {
+                    compare.results("rollup/simple.css");
+                        
+                    done();
+                }, 100);
+            })
+            .catch(done);
+        });
+    });
+});

--- a/test/specimens/rollup/simple.css
+++ b/test/specimens/rollup/simple.css
@@ -1,0 +1,3 @@
+.fooga {
+    color: red;
+}

--- a/test/specimens/rollup/simple.js
+++ b/test/specimens/rollup/simple.js
@@ -1,0 +1,3 @@
+import css from "./simple.css";
+
+console.log(css);


### PR DESCRIPTION
Pretty basic atm, but rollup doesn't support much yet! No need to support output splitting, watching, or anything else exotic yet that I've seen. Should be easy to add once those exist assuming the plugin API provides reasonable hooks.

Their story around outputting non-rollup managed files is a little clunky at the moment, see https://github.com/rollup/rollup/pull/353 for details on the workaround being used (`footer` lifecycle fn that doesn't return a string). It's a bit weird since the output from modular-css is async and `footer` is expected to be sync, but it'll work well enough.