### PR TITLE
Remove export stripping

### DIFF
--- a/test/browserify.test.js
+++ b/test/browserify.test.js
@@ -17,9 +17,9 @@ var fs     = require("fs"),
 
 describe("/browserify.js", function() {
     describe("basic functionality", function() {
-        // after(function(done) {
-        //     rimraf("./test/output/browserify", done);
-        // });
+        after(function(done) {
+            rimraf("./test/output/browserify", done);
+        });
         
         it("should not error if no options are supplied", function() {
             var build = browserify();

--- a/test/composition.test.js
+++ b/test/composition.test.js
@@ -105,7 +105,7 @@ describe("/plugins", function() {
             
             assert.deepEqual(messages, [ msg({
                 wooga : [ "wooga" ],
-                fooga : [ "wooga" ]
+                fooga : [ "wooga", "fooga" ]
             }) ]);
         });
 
@@ -140,10 +140,7 @@ describe("/plugins", function() {
             assert.deepEqual(out.messages, [ msg({
                 wooga : [ "wooga" ],
                 booga : [ "booga" ],
-                tooga : [
-                    "booga",
-                    "wooga"
-                ]
+                tooga : [ "booga", "wooga", "tooga" ]
             }) ]);
         });
         
@@ -151,7 +148,7 @@ describe("/plugins", function() {
             var out = composition.process(".wooga { composes: booga; } .booga { color: red; }");
             
             assert.deepEqual(out.messages, [ msg({
-                wooga : [ "booga" ],
+                wooga : [ "booga", "wooga" ],
                 booga : [ "booga" ]
             }) ]);
         });
@@ -162,7 +159,7 @@ describe("/plugins", function() {
             assert.deepEqual(out.messages, [ msg({
                 wooga : [ "wooga" ],
                 booga : [ "booga" ],
-                tooga : [ "wooga", "booga" ]
+                tooga : [ "wooga", "booga", "tooga" ]
             }) ]);
         });
         
@@ -172,13 +169,13 @@ describe("/plugins", function() {
             out = composition.process(".wooga { composes: global(booga); }");
             
             assert.deepEqual(out.messages, [ msg({
-                wooga : [ "booga" ]
+                wooga : [ "booga", "wooga" ]
             }) ]);
 
             out = composition.process(".wooga { composes: global(booga), global(tooga); }");
             
             assert.deepEqual(out.messages, [ msg({
-                wooga : [ "booga", "tooga" ]
+                wooga : [ "booga", "tooga", "wooga" ]
             }) ]);
 
             out = composition.process(".wooga { composes: global(booga); color: red; }");
@@ -191,7 +188,7 @@ describe("/plugins", function() {
             
             assert.deepEqual(out.messages, [ msg({
                 tooga : [ "tooga" ],
-                wooga : [ "booga", "tooga" ]
+                wooga : [ "booga", "tooga", "wooga" ]
             }) ]);
 
             out = composition.process(".tooga { } .wooga { composes: global(booga), tooga; color: red; }");
@@ -205,7 +202,7 @@ describe("/plugins", function() {
             
             assert.deepEqual(out.messages, [ msg({
                 tooga : [ "tooga" ],
-                wooga : [ "booga", "tooga" ]
+                wooga : [ "booga", "tooga", "wooga" ]
             }) ]);
 
             out = composition.process(".tooga { } .wooga { composes: global(booga); composes: tooga; color: red; }");
@@ -216,18 +213,6 @@ describe("/plugins", function() {
             }) ]);
         });
         
-        it("should dedupe repeated dependencies", function() {
-            var out = composition.process(
-                    ".wooga { color: red; } .booga { composes: wooga; } .tooga { composes: booga; }"
-                );
-            
-            assert.deepEqual(out.messages, [ msg({
-                wooga : [ "wooga" ],
-                booga : [ "wooga" ],
-                tooga : [ "wooga" ]
-            }) ]);
-        });
-        
         it("should handle multi-level dependencies", function() {
             var out = composition.process(
                     ".wooga { color: red; } .booga { composes: wooga; background: blue; } .tooga { composes: booga; display: block; }"
@@ -235,27 +220,8 @@ describe("/plugins", function() {
             
             assert.deepEqual(out.messages, [ msg({
                 wooga : [ "wooga" ],
-                booga : [
-                    "wooga",
-                    "booga"
-                ],
-                tooga : [
-                    "wooga",
-                    "booga",
-                    "tooga"
-                ]
-            }) ]);
-        });
-        
-        it("should handle multi-level dependencies with empty elements", function() {
-            var out = composition.process(
-                    ".wooga { color: red; } .booga { composes: wooga; } .tooga { composes: booga; }"
-                );
-            
-            assert.deepEqual(out.messages, [ msg({
-                wooga : [ "wooga" ],
-                booga : [ "wooga" ],
-                tooga : [ "wooga" ]
+                booga : [ "wooga", "booga" ],
+                tooga : [ "wooga", "booga", "tooga" ]
             }) ]);
         });
         
@@ -278,7 +244,7 @@ describe("/plugins", function() {
                     wooga : "simple_wooga"
                 }
             }, msg({
-                googa : [ "simple_wooga" ],
+                googa : [ "simple_wooga", "simple_googa" ],
                 wooga : [ "simple_wooga" ]
             }) ]);
         });
@@ -299,7 +265,7 @@ describe("/plugins", function() {
                 type   : "modularcss",
                 plugin : "fake-plugin"
             }, msg({
-                googa : [ "wooga" ],
+                googa : [ "wooga", "googa" ],
                 wooga : [ "wooga" ]
             }) ]);
         });
@@ -321,7 +287,7 @@ describe("/plugins", function() {
             });
 
             assert.deepEqual(out.messages, [ msg({
-                wooga : [ "googa", "tooga" ]
+                wooga : [ "googa", "tooga", "wooga" ]
             }) ]);
         });
 
@@ -342,7 +308,7 @@ describe("/plugins", function() {
             });
 
             assert.deepEqual(out.messages, [ msg({
-                wooga : [ "googa" ]
+                wooga : [ "googa", "wooga" ]
             }) ]);
         });
     });

--- a/test/issue-98.test.js
+++ b/test/issue-98.test.js
@@ -1,33 +1,31 @@
 "use strict";
 
-var assert = require("assert"),
+var assert    = require("assert"),
     
     Processor = require("../src/processor"),
     compare   = require("./lib/compare-files");
 
 describe("/issues", function() {
-    describe("/56", function() {
+    describe("/98", function() {
         it("should prune rules that only compose, but leave them in the exports", function(done) {
             var processor = new Processor();
             
             processor.string(
-                    "./test/specimens/issues/56.css",
-                    ".booga { color: red } " +
-                    ".fooga { composes: booga } " +
-                    ".fooga:hover { color: blue } " +
-                    ".wooga { composes: booga }"
+                "./test/specimens/issues/98.css",
+                ".booga { color: red } " +
+                ".fooga { composes: booga } " +
+                ".fooga + .fooga { color: blue }"
             )
             .then(function(result) {
                 assert.deepEqual(result.exports, {
-                    booga : "mc13e7db14_booga",
-                    fooga : "mc13e7db14_booga mc13e7db14_fooga",
-                    wooga : "mc13e7db14_booga mc13e7db14_wooga"
+                    booga : "mc2a6c9ee9_booga",
+                    fooga : "mc2a6c9ee9_booga mc2a6c9ee9_fooga"
                 });
 
                 return processor.output();
             })
             .then(function(result) {
-                compare.stringToFile(result.css, "./test/results/issues/56.css");
+                compare.stringToFile(result.css, "./test/results/issues/98.css");
                 
                 done();
             })

--- a/test/lib/compare-files.js
+++ b/test/lib/compare-files.js
@@ -4,7 +4,7 @@ var fs     = require("fs"),
     path   = require("path"),
     assert = require("assert");
 
-exports.paths = function paths(path1, path2) {
+exports.paths = function(path1, path2) {
     assert.equal(
         fs.readFileSync(path1, "utf8") + "\n",
         fs.readFileSync(path2, "utf8"),
@@ -12,11 +12,19 @@ exports.paths = function paths(path1, path2) {
     );
 };
 
-exports.results = function results(name1, name2) {
+exports.results = function(name1, name2) {
     var path1 = path.join("./test/output", name1),
         path2 = path.join("./test/results", name2 || name1);
 
     return exports.paths(path1, path2);
+};
+
+exports.stringToFile = function(str, file) {
+    assert.equal(
+        str + "\n",
+        fs.readFileSync(file, "utf8"),
+        "Expected css to match " + file
+    );
 };
 
 exports.contains = function(haystack, name) {

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -425,6 +425,34 @@ describe("/processor.js", function() {
             });
         });
         
+        describe("getters", function() {
+            beforeEach(function() {
+                this.processor = new Processor();
+            });
+            
+            describe(".file", function() {
+                it("should return all the files that have been added", function(done) {
+                    var processor = this.processor;
+                    
+                    processor.file("./test/specimens/start.css").then(function() {
+                        return processor.file("./test/specimens/local.css");
+                    })
+                    .then(function() {
+                        assert.equal(typeof processor.files, "object");
+                        
+                        assert.equal(Object.keys(processor.files).length, 3);
+                        
+                        assert(path.resolve("./test/specimens/local.css") in processor.files);
+                        assert(path.resolve("./test/specimens/start.css") in processor.files);
+                        assert(path.resolve("./test/specimens/folder/folder.css") in processor.files);
+                        
+                        done();
+                    })
+                    .catch(done);
+                });
+            });
+        });
+        
         it("should export an object of space-separated strings", function(done) {
             this.processor.string(
                 "./test/specimens/simple.css",
@@ -433,7 +461,7 @@ describe("/processor.js", function() {
                 assert.deepEqual(result.exports, {
                     fooga : "mc08e91a5b_fooga",
                     booga : "mc08e91a5b_booga",
-                    tooga : "mc08e91a5b_fooga mc08e91a5b_booga"
+                    tooga : "mc08e91a5b_fooga mc08e91a5b_booga mc08e91a5b_tooga"
                 });
                 
                 done();
@@ -480,7 +508,7 @@ describe("/processor.js", function() {
                 var file = result.files[path.resolve("./test/specimens/start.css")];
             
                 assert.deepEqual(result.exports, {
-                    wooga : "mc04cb4cb2_booga",
+                    wooga : "mc04cb4cb2_booga mc61f0515a_wooga",
                     booga : "mc61f0515a_booga",
                     tooga : "mc61f0515a_tooga"
                 });
@@ -499,7 +527,7 @@ describe("/processor.js", function() {
                 });
 
                 assert.deepEqual(file.compositions, {
-                    wooga : [ "mc04cb4cb2_booga" ],
+                    wooga : [ "mc04cb4cb2_booga", "mc61f0515a_wooga" ],
                     booga : [ "mc61f0515a_booga" ],
                     tooga : [ "mc61f0515a_tooga" ]
                 });
@@ -517,7 +545,7 @@ describe("/processor.js", function() {
 
                 assert.deepEqual(file.compositions, {
                     booga : [ "mc04cb4cb2_booga" ],
-                    looga : [ "mc04cb4cb2_booga" ]
+                    looga : [ "mc04cb4cb2_booga", "mc04cb4cb2_looga" ]
                 });
 
                 file = result.files[path.resolve("./test/specimens/folder/folder.css")];

--- a/test/results/browserify/avoid-duplicates-local.js
+++ b/test/results/browserify/avoid-duplicates-local.js
@@ -1,4 +1,4 @@
 module.exports = {
     "booga": "mc04cb4cb2_booga",
-    "looga": "mc04cb4cb2_booga"
+    "looga": "mc04cb4cb2_booga mc04cb4cb2_looga"
 };

--- a/test/results/browserify/avoid-duplicates-start.js
+++ b/test/results/browserify/avoid-duplicates-start.js
@@ -1,5 +1,5 @@
 module.exports = {
-    "wooga": "mc04cb4cb2_booga",
+    "wooga": "mc04cb4cb2_booga mc61f0515a_wooga",
     "booga": "mc61f0515a_booga",
     "tooga": "mc61f0515a_tooga"
 };

--- a/test/results/browserify/include-css-deps.js
+++ b/test/results/browserify/include-css-deps.js
@@ -1,5 +1,5 @@
 module.exports = {
-    "wooga": "mc04cb4cb2_booga",
+    "wooga": "mc04cb4cb2_booga mc61f0515a_wooga",
     "booga": "mc61f0515a_booga",
     "tooga": "mc61f0515a_tooga"
 };

--- a/test/results/issues/56.css
+++ b/test/results/issues/56.css
@@ -1,0 +1,7 @@
+/* test/specimens/issues/56.css */
+.mc13e7db14_booga {
+    color: red
+}
+.mc13e7db14_fooga:hover {
+    color: blue
+}

--- a/test/results/issues/98.css
+++ b/test/results/issues/98.css
@@ -1,0 +1,7 @@
+/* test/specimens/issues/98.css */
+.mc2a6c9ee9_booga {
+    color: red
+}
+.mc2a6c9ee9_fooga + .mc2a6c9ee9_fooga {
+    color: blue
+}


### PR DESCRIPTION
Rules that only compose something else are stripped from the CSS, but are left in the exports object. I don't see a compelling reason to remove them and it simplifies this code a lot.

Fixes #98

Example:

```css
.fooga { color: red; }
.wooga { composes: fooga; }
```

Outputs this css:

```css
.abcd123_fooga { color: red; }
```

and this JS

```js
module.exports = {
    "fooga" : "abcd123_fooga",
    "wooga" : "abcd123_fooga abcd123_wooga"
};
```

where before the JS output would have `wooga` just be `abcd123_fooga`.