### PR TITLE
Add require() hook to load css

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Provides a subset of [css-modules](https://github.com/css-modules/css-modules) v
 - [Rollup](#rollup) Plugin
 - [CLI](#cli)
 - [JS API](#api)
+- [require() hook](#require-hook)
 
 ## Install
 
@@ -241,6 +242,18 @@ new Processor({
         return file.replace(/:\/\\ /g, "") + "_" + selector;
     }
 });
+```
+
+## require() hook
+
+Modular CSS can be used within node.js by using the `require()` hook. Requiring `modular-css/register` will return a function that accepts the standard [options](#options) and will let you call `require()` on any `.css` files. The return value of requiring a CSS file is the usual object of exported classnames.
+
+```js
+require("modular-css/register")({
+    css : "./output/out.css"
+});
+
+var css = require("./file.css");
 ```
 
 ## Why?

--- a/register.js
+++ b/register.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = require("./src/register");

--- a/src/register.js
+++ b/src/register.js
@@ -1,0 +1,66 @@
+"use strict";
+
+var fs   = require("fs"),
+    path = require("path"),
+
+    assign  = require("lodash.assign"),
+    postcss = require("postcss"),
+    mkdirp  = require("mkdirp"),
+    
+    scoping   = require("./plugins/scoping"),
+    Processor = require("./processor");
+
+module.exports = function(opts) {
+    var options = assign({
+            ext : ".css",
+            map : process.env.NODE_ENV === "development"
+        }, opts),
+        
+        processor = new Processor(options),
+        scoper    = postcss([ scoping ]);
+    
+    options.namer = processor._namer.bind(processor);
+    
+    if(options.css) {
+        mkdirp.sync(path.dirname(options.css));
+    }
+    
+    require.extensions[options.ext] = function(m, filename) {
+        var contents = fs.readFileSync(filename, "utf8"),
+            msg;
+        
+        // Run scoping plugin, then find its output message which contains
+        // the classes we're looking for
+        scoper.process(contents, assign({}, options, { from : filename })).messages.some(function(item) {
+            if(item.type === "modularcss" && item.plugin === "postcss-modular-css-scoping") {
+                msg = item;
+            }
+            
+            return msg;
+        });
+        
+        // If an output file was specified we should also be running the full
+        // processor instance against each file
+        if(options.css) {
+            processor.string(filename, contents).then(function() {
+                return processor.output({
+                    to : options.css
+                });
+            })
+            .then(function(result) {
+                fs.writeFileSync(options.css, result.css);
+            })
+            .catch(function(err) {
+                throw new Error(err);
+            });
+        }
+        
+        return m._compile("module.exports = " + JSON.stringify(msg.classes, null, 4) + ";", filename);
+    };
+    
+    options.remove = function() {
+        delete require.extensions[options.ext];
+    };
+    
+    return options;
+};

--- a/test/exports.test.js
+++ b/test/exports.test.js
@@ -29,4 +29,13 @@ describe("module exports", function() {
             assert.equal(rollup, require("../src/rollup"));
         });
     });
+    
+    describe("/register", function() {
+        it("should be the function that registers the require hook", function() {
+            var register = require("../register");
+            
+            assert.equal(typeof register, "function");
+            assert.equal(register, require("../src/register"));
+        });
+    });
 });

--- a/test/register.test.js
+++ b/test/register.test.js
@@ -1,0 +1,105 @@
+"use strict";
+
+var assert = require("assert"),
+    
+    rimraf = require("rimraf"),
+    
+    register = require("../src/register"),
+    compare  = require("./lib/compare-files");
+
+function unhook(ext) {
+    delete require.extensions[ext || ".css"];
+}
+
+describe("modular-css", function() {
+    describe("require() hook", function() {
+        afterEach(function() {
+            process.env.NODE_ENV = "";
+            
+            unhook();
+        });
+        
+        after(function(done) {
+            rimraf("./test/output/register", done);
+        });
+        
+        it("should attach a handler to require.extensions", function() {
+            register();
+            
+            assert.equal(typeof require.extensions[".css"], "function");
+        });
+        
+        it("should return the options object", function() {
+            var opts = register();
+            
+            assert.equal(typeof opts, "object");
+            assert.equal(opts.ext, ".css");
+            assert.equal(opts.map, false);
+        });
+        
+        it("should supply a cleanup function", function() {
+            var opts = register();
+            
+            assert.equal(typeof require.extensions[".css"], "function");
+            
+            assert.equal(typeof opts.remove, "function");
+            
+            opts.remove();
+            
+            assert.equal(typeof require.extensions[".css"], "undefined");
+        });
+        
+        it("should accept options", function() {
+            var opts = register({
+                    ext : ".less",
+                    map : true,
+                    css : "./fooga.css"
+                });
+            
+            assert.equal(opts.ext, ".less");
+            assert.equal(opts.map, true);
+            assert.equal(opts.css, "./fooga.css");
+        });
+        
+        it("should use NODE_ENV to determine whether to include source maps", function() {
+            var opts;
+            
+            opts = register();
+            
+            assert.equal(opts.map, false);
+            
+            process.env.NODE_ENV = "development";
+            
+            opts = register();
+            
+            assert.equal(opts.map, true);
+        });
+        
+        it("should process the file and return its exported classnames", function() {
+            var css;
+            
+            register();
+            
+            css = require("./specimens/simple.css");
+            
+            assert.equal(typeof css, "object");
+            assert.deepEqual(css, {
+                wooga : "mc08e91a5b_wooga"
+            });
+        });
+        
+        it("should write out css to disk", function(done) {
+            register({
+                css : "./test/output/register/start.css"
+            });
+            
+            require("./specimens/start.css");
+            
+            setTimeout(function() {
+                compare.results("register/start.css");
+                
+                done();
+            }, 10);
+        });
+    });
+});

--- a/test/results/register/start.css
+++ b/test/results/register/start.css
@@ -1,0 +1,16 @@
+/* test/specimens/folder/folder.css */
+.mc04bb002b_folder {
+    margin: 2px
+}
+/* test/specimens/local.css */
+.mc04cb4cb2_booga {
+    background: green
+}
+/* test/specimens/start.css */
+.mc61f0515a_booga {
+    color: red;
+    background: blue
+}
+.mc61f0515a_tooga {
+    border: 1px solid white
+}


### PR DESCRIPTION
Runs the scoping plugin by itself, since that can run synchronously. Also processes files in the background and writes them out as it can using a processor intstance.

Fixes #95 