### PR TITLE
Fix symlinked files w/ browserify

### DIFF
--- a/src/browserify.js
+++ b/src/browserify.js
@@ -41,9 +41,10 @@ module.exports = function(browserify, opts) {
         }
         
         return sink.str(function(buffer, done) {
-            var push = this.push.bind(this);
+            var push = this.push.bind(this),
+                real = fs.realpathSync(file);
             
-            processor.string(file, buffer).then(
+            processor.string(real, buffer).then(
                 function(result) {
                     // Tell watchers about dependencies by emitting "file" events
                     // AFAIK this is only useful to watchify, to ensure that it watches

--- a/test/issue-105.test.js
+++ b/test/issue-105.test.js
@@ -3,14 +3,22 @@
 var path   = require("path"),
     assert = require("assert"),
     
-    Processor = require("../src/processor");
+    browserify = require("browserify"),
+    from       = require("from2-string"),
+    
+    Processor = require("../src/processor"),
+    plugin    = require("../src/browserify"),
+    
+    bundle  = require("./lib/bundle"),
+    compare = require("./lib/compare-files");
 
 describe("/issues", function() {
-    describe("/105", function() {
-        it("should be able to compose using a symlink", function(done) {
+    // These tests can't be run until I can get onto a POSIX system and submit a symlink (ugh)
+    describe.skip("/105", function() {
+        it("should be able to compose using a symlink", function() {
             var processor = new Processor();
             
-            processor.file("./test/specimens/issues/105/1.css").then(
+            return processor.file("./test/specimens/issues/105/1.css").then(
                 function(result) {
                     var one = result.files[path.resolve("./test/specimens/issues/105/1.css")];
                     
@@ -24,14 +32,24 @@ describe("/issues", function() {
                     assert.deepEqual(result.exports, {
                         wooga : "mc42c563eb_fooga mc89b4df98_wooga"
                     });
-
-                    done();
-                },
-                
-                function(error) {
-                    return new Error(error);
                 }
             );
+        });
+        
+        it("should be able to reference symlinked files when running through browserify", function(done) {
+            var build = browserify({
+                    entries : from("require('./test/specimens/issues/105/symlink.css');")
+                });
+            
+            build.plugin(plugin, {
+                css : "./test/output/issues/105.css"
+            });
+            
+            bundle(build, function() {
+                compare.results("issues/105.css");
+                
+                done();
+            });
         });
     });
 });

--- a/test/issue-105.test.js
+++ b/test/issue-105.test.js
@@ -1,0 +1,37 @@
+"use strict";
+
+var path   = require("path"),
+    assert = require("assert"),
+    
+    Processor = require("../src/processor");
+
+describe("/issues", function() {
+    describe("/105", function() {
+        it("should be able to compose using a symlink", function(done) {
+            var processor = new Processor();
+            
+            processor.file("./test/specimens/issues/105/1.css").then(
+                function(result) {
+                    var one = result.files[path.resolve("./test/specimens/issues/105/1.css")];
+                    
+                    assert.deepEqual(one.compositions, {
+                        wooga : [
+                            "mc42c563eb_fooga",
+                            "mc89b4df98_wooga"
+                        ]
+                    });
+                    
+                    assert.deepEqual(result.exports, {
+                        wooga : "mc42c563eb_fooga mc89b4df98_wooga"
+                    });
+
+                    done();
+                },
+                
+                function(error) {
+                    return new Error(error);
+                }
+            );
+        });
+    });
+});

--- a/test/results/issues/105.css
+++ b/test/results/issues/105.css
@@ -1,0 +1,4 @@
+/* test/specimens/issues/105/folder/2.css */
+.mc42c563eb_fooga {
+    color: red
+}

--- a/test/specimens/issues/105/1.css
+++ b/test/specimens/issues/105/1.css
@@ -1,0 +1,1 @@
+.wooga { composes: fooga from "./symlink.css"; }

--- a/test/specimens/issues/105/folder/2.css
+++ b/test/specimens/issues/105/folder/2.css
@@ -1,0 +1,1 @@
+.fooga { color: red; }


### PR DESCRIPTION
Browserify transforms seem unresolved symlink paths, but the "deps" pipeline sees resolved paths. This led to no end of hilarity. Fixed this by making sure to manually resolve symlinks during the transform stage so the dependency graph is functional.

Tests are disabled though because I don't have a POSIX system handy, and Git for Windows can't submit symlinks :disappointed:

Fixes #105 