### PR TITLE
Multiple exports to resulting JavaScript file

### DIFF
--- a/src/rollup.js
+++ b/src/rollup.js
@@ -27,9 +27,11 @@ module.exports = function(opts) {
             }
             
             return processor.string(id, code).then(function(result) {
-                return {
-                    code : "export default " + JSON.stringify(result.exports, null, 4)
-                };
+                var es6ModuleString = Object.keys(result.exports).reduceRight( function(res, key) {
+                    return "export var " + key + " = '" + result.exports[key] + "';\n" + res;
+                }, "export default " + JSON.stringify(result.exports, null, 4));
+
+                return { code : es6ModuleString };
             });
         },
         

--- a/test/results/rollup/simple.js
+++ b/test/results/rollup/simple.js
@@ -1,5 +1,7 @@
+var fooga = 'mcad949cca_fooga';
 var css = {
     "fooga": "mcad949cca_fooga"
 }
 
 console.log(css);
+console.log(fooga);

--- a/test/specimens/rollup/simple.js
+++ b/test/specimens/rollup/simple.js
@@ -1,3 +1,4 @@
-import css from "./simple.css";
+import css, {fooga} from "./simple.css";
 
 console.log(css);
+console.log(fooga);


### PR DESCRIPTION
Hi! I tried to make CSS Modules work with rollup and stumbled on your plugin. It's really great!

But I missed one thing in it and tried to make this pull request. The thing that I missed was support for Tree Shaking in Rollup. Rollup have ability to only import exports that are really used in file, but to do it you need to create `export var name = 'value';` rule for each object key.

So I made small change in returning results format – I added additional strings for each aviable key. This way I can now write code like this:

```
import {fooga} from "./simple.css";

console.log(fooga);
```

Can you look at it? Maybe it is a good idea to add this functionality by default?