### PR TITLE
Rollup exports individual declarations as well

### DIFF
--- a/src/rollup.js
+++ b/src/rollup.js
@@ -16,22 +16,24 @@ module.exports = function(opts) {
             json : false
         }, opts || {}),
         
+        slice = -1 * options.ext.length,
+        
         filter = utils.createFilter(options.include, options.exclude),
         
         processor = new Processor(options);
         
     return {
         transform : function(code, id) {
-            if(!filter(id) || id.slice(-1 * options.ext.length) !== options.ext) {
+            if(!filter(id) || id.slice(slice) !== options.ext) {
                 return null;
             }
             
             return processor.string(id, code).then(function(result) {
-                var es6ModuleString = Object.keys(result.exports).reduceRight( function(res, key) {
-                    return "export var " + key + " = '" + result.exports[key] + "';\n" + res;
-                }, "export default " + JSON.stringify(result.exports, null, 4));
-
-                return { code : es6ModuleString };
+                var generated = Object.keys(result.exports).reduceRight(function(prev, curr) {
+                    return "export var " + curr + " = \"" + result.exports[curr] + "\";\n" + prev;
+                }, "export default " + JSON.stringify(result.exports, null, 4) + ";\n");
+                
+                return { code : generated };
             });
         },
         

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -27,9 +27,11 @@ module.exports = function(opts) {
             }
             
             return processor.string(id, code).then(function(result) {
-                return {
-                    code : "export default " + JSON.stringify(result.exports, null, 4)
-                };
+                var es6ModuleString = Object.keys(result.exports).reduceRight( function(res, key) {
+                    return "export var " + key + " = '" + result.exports[key] + "';\n" + res;
+                }, "export default " + JSON.stringify(result.exports, null, 4));
+
+                return { code : es6ModuleString };
             });
         },
         

--- a/test/results/rollup/simple.js
+++ b/test/results/rollup/simple.js
@@ -1,5 +1,7 @@
+var fooga = 'mcad949cca_fooga';
 var css = {
     "fooga": "mcad949cca_fooga"
 }
 
 console.log(css);
+console.log(fooga);

--- a/test/results/rollup/simple.js
+++ b/test/results/rollup/simple.js
@@ -1,7 +1,7 @@
-var fooga = 'mcad949cca_fooga';
+var fooga = "mcad949cca_fooga";
 var css = {
     "fooga": "mcad949cca_fooga"
-}
+};
 
 console.log(css);
 console.log(fooga);

--- a/test/results/rollup/tree-shaking.js
+++ b/test/results/rollup/tree-shaking.js
@@ -1,0 +1,3 @@
+var fooga = "mccbbaee09_fooga";
+
+console.log(fooga);

--- a/test/rollup.test.js
+++ b/test/rollup.test.js
@@ -36,6 +36,24 @@ describe("/rollup.js", function() {
         );
     });
     
+    it("should be able to tree-shake results", function() {
+        return rollup({
+            entry   : "./test/specimens/rollup/tree-shaking.js",
+            plugins : [
+                plugin()
+            ]
+        }).then(
+            function(bundle) {
+                var out = bundle.generate();
+                
+                assert.equal(
+                    out.code + "\n",
+                    fs.readFileSync("./test/results/rollup/tree-shaking.js", "utf8")
+                );
+            }
+        );
+    });
+    
     it("should generate CSS", function(done) {
         rollup({
             entry   : "./test/specimens/rollup/simple.js",

--- a/test/specimens/rollup/simple.js
+++ b/test/specimens/rollup/simple.js
@@ -1,3 +1,4 @@
-import css from "./simple.css";
+import css, {fooga} from "./simple.css";
 
 console.log(css);
+console.log(fooga);

--- a/test/specimens/rollup/tree-shaking.css
+++ b/test/specimens/rollup/tree-shaking.css
@@ -1,0 +1,2 @@
+.fooga { color: red; }
+.wooga { color: blue; }

--- a/test/specimens/rollup/tree-shaking.js
+++ b/test/specimens/rollup/tree-shaking.js
@@ -1,0 +1,3 @@
+import { fooga } from "./tree-shaking.css";
+
+console.log(fooga);


### PR DESCRIPTION
So tree-shaking can do its thing and reduce the size of the bundle. Huge props to @iAdramelk for doing the majority of the work in #113, I just reformatted a bit and added an extra test case.