### PR TITLE
Only export valid identifiers from rollup plugin

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,9 +1,0 @@
-{
-    "preset" : "arenanet",
-    "excludeFiles" : [
-        "coverage/**",
-        "test/specimens/**",
-        "test/results/**",
-        "test/output/**"
-    ]
-}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "dependency-graph": "^0.4.1",
+    "esutils": "^2.0.2",
     "lodash.assign": "^4.0.0",
     "lodash.defaults": "^4.0.1",
     "lodash.difference": "^4.0.0",

--- a/test/results/rollup/invalid-name.js
+++ b/test/results/rollup/invalid-name.js
@@ -1,0 +1,7 @@
+var fooga = "mce24b2248_fooga";
+var css = {
+    "fooga": "mce24b2248_fooga",
+    "fooga-wooga": "mce24b2248_fooga-wooga"
+};
+
+console.log(css, fooga);

--- a/test/rollup.test.js
+++ b/test/rollup.test.js
@@ -24,16 +24,15 @@ describe("/rollup.js", function() {
             plugins : [
                 plugin()
             ]
-        }).then(
-            function(bundle) {
-                var out = bundle.generate();
-                
-                assert.equal(
-                    out.code + "\n",
-                    fs.readFileSync("./test/results/rollup/simple.js", "utf8")
-                );
-            }
-        );
+        })
+        .then(function(bundle) {
+            var out = bundle.generate();
+            
+            assert.equal(
+                out.code + "\n",
+                fs.readFileSync("./test/results/rollup/simple.js", "utf8")
+            );
+        });
     });
     
     it("should be able to tree-shake results", function() {
@@ -42,16 +41,15 @@ describe("/rollup.js", function() {
             plugins : [
                 plugin()
             ]
-        }).then(
-            function(bundle) {
-                var out = bundle.generate();
-                
-                assert.equal(
-                    out.code + "\n",
-                    fs.readFileSync("./test/results/rollup/tree-shaking.js", "utf8")
-                );
-            }
-        );
+        })
+        .then(function(bundle) {
+            var out = bundle.generate();
+            
+            assert.equal(
+                out.code + "\n",
+                fs.readFileSync("./test/results/rollup/tree-shaking.js", "utf8")
+            );
+        });
     });
     
     it("should generate CSS", function(done) {
@@ -101,5 +99,26 @@ describe("/rollup.js", function() {
             }, 100);
         })
         .catch(done);
+    });
+    
+    it("should warn & not export individual keys when they are not valid identifiers", function() {
+        return rollup({
+            entry   : "./test/specimens/rollup/invalid-name.js",
+            plugins : [
+                plugin({
+                    onwarn : function(msg) {
+                        assert(msg === "Invalid JS identifier \"fooga-wooga\", unable to export");
+                    }
+                })
+            ]
+        })
+        .then(function(bundle) {
+            var out = bundle.generate();
+            
+            assert.equal(
+                out.code + "\n",
+                fs.readFileSync("./test/results/rollup/invalid-name.js", "utf8")
+            );
+        });
     });
 });

--- a/test/specimens/rollup/invalid-name.css
+++ b/test/specimens/rollup/invalid-name.css
@@ -1,0 +1,2 @@
+.fooga { color: red; }
+.fooga-wooga { color: red; }

--- a/test/specimens/rollup/invalid-name.js
+++ b/test/specimens/rollup/invalid-name.js
@@ -1,0 +1,3 @@
+import css, {fooga} from "./invalid-name.css";
+
+console.log(css, fooga);


### PR DESCRIPTION
The changes in #114 had one pretty serious issue, if any of the CSS classes were not valid JS identifiers they would still be output and then generate invalid JS.

Now any invalid identifiers are skipped, and a warning is emitted.

CC @iAdramelk