### PR TITLE
Output in stable order

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "lodash.defaults": "^4.0.1",
     "lodash.difference": "^4.0.0",
     "lodash.filter": "^4.2.1",
-    "lodash.flatten": "^4.0.0",
     "lodash.foreach": "^4.0.0",
     "lodash.get": "^4.2.1",
     "lodash.invert": "^4.0.0",

--- a/src/_clone-graph.js
+++ b/src/_clone-graph.js
@@ -1,0 +1,17 @@
+"use strict";
+
+var Graph = require("dependency-graph").DepGraph;
+
+module.exports = function(graph) {
+    var clone = new Graph();
+    
+    graph.overallOrder().forEach(function(node) {
+        clone.addNode(node);
+        
+        graph.dependenciesOf(node).forEach(function(dep) {
+            clone.addDependency(node, dep);
+        });
+    });
+    
+    return clone;
+};

--- a/src/_sequential.js
+++ b/src/_sequential.js
@@ -1,0 +1,11 @@
+"use strict";
+
+var Promise = require("./_promise");
+
+module.exports = function(promises) {
+    return new Promise(function(resolve, reject) {
+        promises.reduce(function(curr, next) {
+            return curr.then(next);
+        }, Promise.resolve()).then(resolve, reject);
+    });
+};

--- a/src/processor.js
+++ b/src/processor.js
@@ -11,31 +11,11 @@ var fs   = require("fs"),
     urls     = require("postcss-url"),
     slug     = require("unique-slug"),
 
-    Promise  = require("./_promise"),
-    relative = require("./_relative"),
-    output   = require("./_output");
-
-function sequential(promises) {
-    return new Promise(function(resolve, reject) {
-        promises.reduce(function(curr, next) {
-            return curr.then(next);
-        }, Promise.resolve()).then(resolve, reject);
-    });
-}
-
-function cloneGraph(graph) {
-    var clone = new Graph();
-    
-    graph.overallOrder().forEach(function(node) {
-        clone.addNode(node);
-        
-        graph.dependenciesOf(node).forEach(function(dep) {
-            clone.addDependency(node, dep);
-        });
-    });
-    
-    return clone;
-}
+    Promise    = require("./_promise"),
+    relative   = require("./_relative"),
+    output     = require("./_output"),
+    cloneGraph = require("./_clone-graph"),
+    sequential = require("./_sequential");
 
 function Processor(opts) {
     /* eslint consistent-return:0 */

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -399,6 +399,26 @@ describe("/processor.js", function() {
                         );
                     });
                 });
+                
+                it.only("should order output by dependencies, then alphabetically", function() {
+                    var processor = this.processor;
+
+                    return processor.file("./test/specimens/start.css").then(function() {
+                        return processor.file("./test/specimens/local.css");
+                    })
+                    .then(function() {
+                        return processor.file("./test/specimens/composes.css");
+                    })
+                    .then(function() {
+                        return processor.output();
+                    })
+                    .then(function(result) {
+                        assert.equal(
+                            result.css + "\n",
+                            fs.readFileSync("./test/results/processor/avoid-duplicates.css", "utf8")
+                        );
+                    });
+                });
             });
         });
         

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -384,12 +384,12 @@ describe("/processor.js", function() {
                                 "test/specimens/folder/folder.css" : {
                                     folder : "mc04bb002b_folder"
                                 },
-                             
+                                
                                 "test/specimens/local.css" : {
                                     booga : "mc04cb4cb2_booga",
                                     looga : "mc04cb4cb2_booga mc04cb4cb2_looga"
                                 },
-                             
+                                
                                 "test/specimens/start.css" : {
                                     booga : "mc61f0515a_booga",
                                     tooga : "mc61f0515a_tooga",
@@ -400,22 +400,22 @@ describe("/processor.js", function() {
                     });
                 });
                 
-                it.only("should order output by dependencies, then alphabetically", function() {
+                it("should order output by dependencies, then alphabetically", function() {
                     var processor = this.processor;
-
-                    return processor.file("./test/specimens/start.css").then(function() {
-                        return processor.file("./test/specimens/local.css");
-                    })
-                    .then(function() {
-                        return processor.file("./test/specimens/composes.css");
-                    })
+                    
+                    return Promise.all([
+                        processor.file("./test/specimens/start.css"),
+                        processor.file("./test/specimens/local.css"),
+                        processor.file("./test/specimens/composes.css"),
+                        processor.file("./test/specimens/deep.css")
+                    ])
                     .then(function() {
                         return processor.output();
                     })
                     .then(function(result) {
                         assert.equal(
                             result.css + "\n",
-                            fs.readFileSync("./test/results/processor/avoid-duplicates.css", "utf8")
+                            fs.readFileSync("./test/results/processor/sorting.css", "utf8")
                         );
                     });
                 });

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -270,14 +270,12 @@ describe("/processor.js", function() {
                 
                 it("should remove multiple files", function() {
                     var processor = this.processor;
-
-                    processor.string("./test/specimens/a.css", ".aooga { }")
-                    .then(function() {
-                        return processor.string("./test/specimens/b.css", ".booga { }");
-                    })
-                    .then(function() {
-                        return processor.string("./test/specimens/c.css", ".cooga { }");
-                    })
+                    
+                    return Promise.all([
+                        processor.string("./test/specimens/a.css", ".aooga { }"),
+                        processor.string("./test/specimens/b.css", ".booga { }"),
+                        processor.string("./test/specimens/c.css", ".cooga { }")
+                    ])
                     .then(function() {
                         processor.remove([
                             path.resolve("./test/specimens/a.css"),
@@ -337,9 +335,10 @@ describe("/processor.js", function() {
                 it("should generate css representing the output from all added files", function() {
                     var processor = this.processor;
 
-                    return processor.file("./test/specimens/start.css").then(function() {
-                        return processor.file("./test/specimens/simple.css");
-                    })
+                    return Promise.all([
+                        processor.file("./test/specimens/start.css"),
+                        processor.file("./test/specimens/simple.css")
+                    ])
                     .then(function() {
                         return processor.output();
                     })
@@ -354,9 +353,10 @@ describe("/processor.js", function() {
                 it("should avoid duplicating files in the output", function() {
                     var processor = this.processor;
 
-                    return processor.file("./test/specimens/start.css").then(function() {
-                        return processor.file("./test/specimens/local.css");
-                    })
+                    return Promise.all([
+                        processor.file("./test/specimens/start.css"),
+                        processor.file("./test/specimens/local.css")
+                    ])
                     .then(function() {
                         return processor.output();
                     })

--- a/test/results/issues/58.css
+++ b/test/results/issues/58.css
@@ -1,10 +1,3 @@
-/* test/specimens/issues/58/issue.css */
-.mc0c6149b1_issue1 {
-    color: teal
-}
-.mc0c6149b1_issue2 {
-    color: aqua
-}
 /* test/specimens/issues/58/other.css */
 .mc8fe42003_other1 {
     color: green
@@ -14,4 +7,11 @@
 }
 .mc8fe42003_other3 {
     background: white
+}
+/* test/specimens/issues/58/issue.css */
+.mc0c6149b1_issue1 {
+    color: teal
+}
+.mc0c6149b1_issue2 {
+    color: aqua
 }

--- a/test/results/processor/sorting.css
+++ b/test/results/processor/sorting.css
@@ -2,9 +2,18 @@
 .mc04bb002b_folder {
     margin: 2px
 }
-/* test/specimens/simple.css */
-.mc08e91a5b_wooga {
-    color: red
+/* test/specimens/folder/folder2.css */
+.mc0a0b0aff_folder2 {
+    color: green
+}
+/* test/specimens/folder/subfolder/subfolder.css */
+.mc85c09a4a_subfolder {
+    color: yellow
+}
+/* test/specimens/composes.css */
+/* test/specimens/deep.css */
+.mc25934484_deep {
+    color: black
 }
 /* test/specimens/local.css */
 .mc04cb4cb2_booga {

--- a/test/specimens/composes.css
+++ b/test/specimens/composes.css
@@ -1,0 +1,3 @@
+.composes {
+    composes: folder2 from "./folder/folder2.css";
+}

--- a/test/specimens/deep.css
+++ b/test/specimens/deep.css
@@ -1,0 +1,5 @@
+.deep {
+    composes: subfolder from "./folder/subfolder/subfolder.css";
+    
+    color: black;
+}

--- a/test/specimens/folder/folder2.css
+++ b/test/specimens/folder/folder2.css
@@ -1,0 +1,1 @@
+.folder2 { color: green; }

--- a/test/specimens/folder/subfolder/subfolder.css
+++ b/test/specimens/folder/subfolder/subfolder.css
@@ -1,0 +1,1 @@
+.subfolder { color: yellow; }


### PR DESCRIPTION
By traversing the dependency graph, finding all the leaf nodes, removing them, then continuing until we've pruned the entire tree. Also sorting each tier alphabetically to help keep things stable no matter the add order.

Fixes #119 