### PR TITLE
Add strict mode concept

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "istanbul": "^0.4.2",
     "mocha": "^2.3.4",
     "postcss-color-rebeccapurple": "^2.0.0",
+    "postcss-import": "^8.1.2",
     "rimraf": "^2.5.0",
     "rollup": "^0.26.0",
     "shelljs": "^0.7.0",

--- a/src/browserify.js
+++ b/src/browserify.js
@@ -138,7 +138,7 @@ module.exports = function(browserify, opts) {
         bundler.on("end", function() {
             var bundling = Object.keys(bundles).length > 0,
                 common;
-                
+            
             if(options.json) {
                 mkdirp.sync(path.dirname(options.json));
                 
@@ -178,9 +178,12 @@ module.exports = function(browserify, opts) {
                     processor.output({
                         files : files,
                         to    : dest
-                    }).then(function(result) {
-                        fs.writeFileSync(dest, result.css);
-                    });
+                    }).then(
+                        function(result) {
+                            fs.writeFileSync(dest, result.css);
+                        },
+                        bundler.emit.bind(bundler, "error")
+                    );
                 });
                 
                 // No common CSS files to write out, so don't (unless they asked nicely)
@@ -195,9 +198,12 @@ module.exports = function(browserify, opts) {
             processor.output({
                 files : bundling && common,
                 to    : options.css
-            }).then(function(result) {
-                fs.writeFileSync(options.css, result.css);
-            });
+            }).then(
+                function(result) {
+                    fs.writeFileSync(options.css, result.css);
+                },
+                bundler.emit.bind(bundler, "error")
+            );
         });
     });
 };

--- a/src/processor.js
+++ b/src/processor.js
@@ -26,9 +26,10 @@ function Processor(opts) {
     }
     
     this._options = defaults({}, options || {}, {
-        cwd   : process.cwd(),
-        map   : false,
-        namer : this._namer.bind(this)
+        cwd    : process.cwd(),
+        map    : false,
+        namer  : this._namer.bind(this),
+        strict : true
     });
     
     this._files = {};
@@ -172,6 +173,20 @@ Processor.prototype = {
             var root = postcss.root();
 
             results.forEach(function(result) {
+                var warnings;
+
+                // This structure is slightly awkward, but ensures the work only occurs
+                // when in strict mode
+                if(self._options.strict) {
+                    warnings = result.warnings();
+                    
+                    if(warnings.length) {
+                        throw new Error(warnings.map(function(warning) {
+                            return warning.toString();
+                        }).join("\n"));
+                    }
+                }
+
                 root.append(postcss.comment({
                     text : relative(self._options.cwd, result.opts.from)
                 }));

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -74,128 +74,6 @@ describe("/processor.js", function() {
                 });
             });
 
-            describe("before", function() {
-                it("should run sync postcss plugins before processing", function() {
-                    var processor = new Processor({
-                            before : [ sync ]
-                        });
-                    
-                    return processor.string("test/specimens/sync-before.css", "").then(function() {
-                        return processor.output();
-                    }).then(function(result) {
-                        assert.equal(
-                            result.css,
-                            "/* test/specimens/sync-before.css */\n" +
-                            "a {}"
-                        );
-                    });
-                });
-
-                it("should run async postcss plugins before processing", function() {
-                    var processor = new Processor({
-                            before : [ async ]
-                        });
-                    
-                    return processor.string("test/specimens/async-before.css", "").then(function() {
-                        return processor.output();
-                    })
-                    .then(function(result) {
-                        assert.equal(
-                            result.css,
-                            "/* test/specimens/async-before.css */\n" +
-                            "a {}"
-                        );
-                    });
-                });
-            });
-            
-            describe("after", function() {
-                var css =
-                        "/* test/specimens/relative.css */\n" +
-                        ".mc592b2d8f_wooga {\n" +
-                        "    color: red;\n" +
-                        "    background: url(\"./folder/to.png\")\n" +
-                        "}\n" +
-                        "a {}";
-                
-                it("should use postcss-url by default", function() {
-                    var processor = this.processor;
-
-                    return processor.file("./test/specimens/relative.css").then(function() {
-                        return processor.output({ to : "./test/output/relative.css" });
-                    })
-                    .then(function(result) {
-                        compare.stringToFile(result.css, "./test/results/processor/relative.css");
-                    });
-                });
-                
-                it("should run sync postcss plugins", function() {
-                    var processor = new Processor({
-                            after : [ sync ]
-                        });
-
-                    return processor.file("./test/specimens/relative.css").then(function() {
-                        return processor.output({ to : "./test/output/relative.css" });
-                    })
-                    .then(function(result) {
-                        assert.equal(
-                            result.css,
-                            css
-                        );
-                    });
-                });
-                
-                it("should run async postcss plugins", function() {
-                    var processor = new Processor({
-                            after : [ async ]
-                        });
-
-                    return processor.file("./test/specimens/relative.css").then(function() {
-                        return processor.output({ to : "./test/output/relative.css" });
-                    })
-                    .then(function(result) {
-                        assert.equal(
-                            result.css,
-                            css
-                        );
-                    });
-                });
-            });
-            
-            describe("done", function() {
-                it("should run sync postcss plugins done processing", function() {
-                    var processor = new Processor({
-                            done : [ sync ]
-                        });
-                    
-                    return processor.string("test/specimens/sync-done.css", "").then(function() {
-                        return processor.output();
-                    }).then(function(result) {
-                        assert.equal(
-                            result.css,
-                            "/* test/specimens/sync-done.css */\n" +
-                            "a {}"
-                        );
-                    });
-                });
-                
-                it("should run async postcss plugins done processing", function() {
-                    var processor = new Processor({
-                            done : [ async ]
-                        });
-                    
-                    return processor.string("test/specimens/async-done.css", "").then(function() {
-                        return processor.output();
-                    }).then(function(result) {
-                        assert.equal(
-                            result.css,
-                            "/* test/specimens/async-done.css */\n" +
-                            "a {}"
-                        );
-                    });
-                });
-            });
-            
             describe("map", function() {
                 it("should generate source maps", function() {
                     var processor = new Processor({ map : true });
@@ -205,6 +83,163 @@ describe("/processor.js", function() {
                     })
                     .then(function(result) {
                         compare.stringToFile(result.css, "./test/results/processor/source-map.css");
+                    });
+                });
+            });
+
+            describe.only("strict", function() {
+                it("should treat plugin warnings as errors by default", function() {
+                    var processor = new Processor({
+                            after : [ require("postcss-import")() ]
+                        });
+                    
+                    return processor.file("./test/specimens/invalid-import.css")
+                    .then(function() {
+                        return processor.output();
+                    })
+                    .then(
+                        function() {
+                            assert.fail("Shouldn't have succeeded");
+                        },
+                        function(error) {
+                            assert(error);
+                        }
+                    );
+                });
+
+                it("should ignore warnings when disabled", function() {
+                    var processor = new Processor({
+                            after  : [ require("postcss-import")() ],
+                            strict : false
+                        });
+                    
+                    return processor.file("./test/specimens/invalid-import.css")
+                    .then(function() {
+                        return processor.output();
+                    });
+                });
+            });
+
+            describe("lifecycle options", function() {
+                describe("before", function() {
+                    it("should run sync postcss plugins before processing", function() {
+                        var processor = new Processor({
+                                before : [ sync ]
+                            });
+                        
+                        return processor.string("test/specimens/sync-before.css", "").then(function() {
+                            return processor.output();
+                        }).then(function(result) {
+                            assert.equal(
+                                result.css,
+                                "/* test/specimens/sync-before.css */\n" +
+                                "a {}"
+                            );
+                        });
+                    });
+
+                    it("should run async postcss plugins before processing", function() {
+                        var processor = new Processor({
+                                before : [ async ]
+                            });
+                        
+                        return processor.string("test/specimens/async-before.css", "").then(function() {
+                            return processor.output();
+                        })
+                        .then(function(result) {
+                            assert.equal(
+                                result.css,
+                                "/* test/specimens/async-before.css */\n" +
+                                "a {}"
+                            );
+                        });
+                    });
+                });
+                
+                describe("after", function() {
+                    var css =
+                            "/* test/specimens/relative.css */\n" +
+                            ".mc592b2d8f_wooga {\n" +
+                            "    color: red;\n" +
+                            "    background: url(\"./folder/to.png\")\n" +
+                            "}\n" +
+                            "a {}";
+                    
+                    it("should use postcss-url by default", function() {
+                        var processor = this.processor;
+
+                        return processor.file("./test/specimens/relative.css").then(function() {
+                            return processor.output({ to : "./test/output/relative.css" });
+                        })
+                        .then(function(result) {
+                            compare.stringToFile(result.css, "./test/results/processor/relative.css");
+                        });
+                    });
+                    
+                    it("should run sync postcss plugins", function() {
+                        var processor = new Processor({
+                                after : [ sync ]
+                            });
+
+                        return processor.file("./test/specimens/relative.css").then(function() {
+                            return processor.output({ to : "./test/output/relative.css" });
+                        })
+                        .then(function(result) {
+                            assert.equal(
+                                result.css,
+                                css
+                            );
+                        });
+                    });
+                    
+                    it("should run async postcss plugins", function() {
+                        var processor = new Processor({
+                                after : [ async ]
+                            });
+
+                        return processor.file("./test/specimens/relative.css").then(function() {
+                            return processor.output({ to : "./test/output/relative.css" });
+                        })
+                        .then(function(result) {
+                            assert.equal(
+                                result.css,
+                                css
+                            );
+                        });
+                    });
+                });
+                
+                describe("done", function() {
+                    it("should run sync postcss plugins done processing", function() {
+                        var processor = new Processor({
+                                done : [ sync ]
+                            });
+                        
+                        return processor.string("test/specimens/sync-done.css", "").then(function() {
+                            return processor.output();
+                        }).then(function(result) {
+                            assert.equal(
+                                result.css,
+                                "/* test/specimens/sync-done.css */\n" +
+                                "a {}"
+                            );
+                        });
+                    });
+                    
+                    it("should run async postcss plugins done processing", function() {
+                        var processor = new Processor({
+                                done : [ async ]
+                            });
+                        
+                        return processor.string("test/specimens/async-done.css", "").then(function() {
+                            return processor.output();
+                        }).then(function(result) {
+                            assert.equal(
+                                result.css,
+                                "/* test/specimens/async-done.css */\n" +
+                                "a {}"
+                            );
+                        });
                     });
                 });
             });

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -87,10 +87,48 @@ describe("/processor.js", function() {
                 });
             });
 
-            describe.only("strict", function() {
-                it("should treat plugin warnings as errors by default", function() {
+            describe("strict", function() {
+                it("should treat plugin warnings as errors by default (before)", function() {
+                    var processor = new Processor({
+                            before : [ require("postcss-import")() ]
+                        });
+                    
+                    return processor.file("./test/specimens/invalid-import.css")
+                    .then(function() {
+                        return processor.output();
+                    })
+                    .then(
+                        function() {
+                            assert.fail("Shouldn't have succeeded");
+                        },
+                        function(error) {
+                            assert(error);
+                        }
+                    );
+                });
+                
+                it("should treat plugin warnings as errors by default (after)", function() {
                     var processor = new Processor({
                             after : [ require("postcss-import")() ]
+                        });
+                    
+                    return processor.file("./test/specimens/invalid-import.css")
+                    .then(function() {
+                        return processor.output();
+                    })
+                    .then(
+                        function() {
+                            assert.fail("Shouldn't have succeeded");
+                        },
+                        function(error) {
+                            assert(error);
+                        }
+                    );
+                });
+
+                it("should treat plugin warnings as errors by default (done)", function() {
+                    var processor = new Processor({
+                            done : [ require("postcss-import")() ]
                         });
                     
                     return processor.file("./test/specimens/invalid-import.css")

--- a/test/specimens/invalid-import.css
+++ b/test/specimens/invalid-import.css
@@ -1,0 +1,3 @@
+.fooga { color: red; }
+
+@import "./blue.css";


### PR DESCRIPTION
Strict mode is the default, and treats any warnings from plugins when processing files as an error and blows up. This check occurs on all three lifecycle methods, so it may trigger multiple times if you have bad files causing the `before` hook to explode.

Disable strict mode by setting `strict : false` in options passed in.

Fixes #82