### PR TITLE
Include dependencies in transform output

### DIFF
--- a/src/browserify.js
+++ b/src/browserify.js
@@ -30,7 +30,7 @@ module.exports = function(browserify, opts) {
     }
     
     function depReducer(curr, next) {
-        curr["./" + relative(options.cwd, next)] = next;
+        curr[relative.prefixed(options.cwd, next)] = next;
         
         return curr;
     }

--- a/src/lib/relative.js
+++ b/src/lib/relative.js
@@ -2,10 +2,21 @@
 
 var path = require("path"),
 
-    regex = /\\/g;
+    sepRegex    = /\\/g,
+    prefixRegex = /^\.\.?\//;
 
 // Get a relative version of an absolute path w/ cross-platform/URL-friendly
 // directory separators
 module.exports = function(cwd, file) {
-    return path.relative(cwd, file).replace(regex, "/");
+    return path.relative(cwd, file).replace(sepRegex, "/");
+};
+
+module.exports.prefixed = function(cwd, file) {
+    var out = module.exports(cwd, file);
+
+    if(!prefixRegex.test(out)) {
+        out = "./" + out;
+    }
+
+    return out;
 };

--- a/src/processor.js
+++ b/src/processor.js
@@ -125,7 +125,13 @@ Processor.prototype = {
     
     // Get the dependency order for a file or the entire tree
     dependencies : function(file) {
-        return file ? this._graph.dependenciesOf(file) : this._graph.overallOrder();
+        if(file) {
+            return this._graph.dependenciesOf(
+                path.normalize(file)
+            );
+        }
+
+        return this._graph.overallOrder();
     },
     
     // Get the ultimate output for specific files or the entire tree

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -9,7 +9,8 @@ var fs   = require("fs"),
     mkdirp  = require("mkdirp"),
     
     Processor = require("./processor"),
-    output    = require("./lib/output");
+    output    = require("./lib/output"),
+    relative  = require("./lib/relative");
 
 module.exports = function(opts) {
     var options = assign({
@@ -35,10 +36,13 @@ module.exports = function(opts) {
             }
             
             return processor.string(id, code).then(function(result) {
-                var classes = output.join(result.exports);
-                
+                var classes = output.join(result.exports),
+                    imports = processor.dependencies(id).map(function(file) {
+                        return "import \"" + relative.prefixed(path.dirname(id), file) + "\";";
+                    }).join("\n");
+
                 return {
-                    code : Object.keys(classes).reduce(function(prev, curr) {
+                    code : (imports.length ? imports + "\n" : "") + Object.keys(classes).reduce(function(prev, curr) {
                         // Warn if any of the exported CSS wasn't able to be used as a valid JS identifier
                         if(keyword.isReservedWordES6(curr) || !keyword.isIdentifierNameES6(curr)) {
                             options.onwarn("Invalid JS identifier \"" + curr + "\", unable to export");


### PR DESCRIPTION
Mostly so `rollup --watch` monitors the files correctly. Those deps will be tree-shaken out anyways since nothing else references them.

Also adds a central place to create path-friendly relative paths, because browserify AND rollup doing it in code was stupid.