### PR TITLE
Use rollup ongenerate & onwrite hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "postcss-import": "^8.1.2",
     "publish-please": "^2.1.4",
     "rimraf": "^2.5.0",
-    "rollup": "^0.33.0",
+    "rollup": "^0.34.0",
     "shelljs": "^0.7.0",
     "watchify": "^3.7.0"
   },

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -65,16 +65,19 @@ module.exports = function(opts) {
         },
 
         // Hook for when bundle.generate() is called
-        ongenerate : function() {
-            processor.output({
+        ongenerate : function(bundle, result) {
+            result.css = processor.output({
                 to : options.css
-            })
-            .then(function(result) {
+            });
+        },
+
+        onwrite : function(bundle, result) {
+            result.css.then(function(data) {
                 if(options.css) {
                     mkdirp.sync(path.dirname(options.css));
                     fs.writeFileSync(
                         options.css,
-                        result.css
+                        data.css
                     );
                 }
                 
@@ -82,13 +85,10 @@ module.exports = function(opts) {
                     mkdirp.sync(path.dirname(options.json));
                     fs.writeFileSync(
                         options.json,
-                        JSON.stringify(result.compositions, null, 4)
+                        JSON.stringify(data.compositions, null, 4)
                     );
                 }
             });
-            
-            // TODO: Figure out if it's necessary to return a useful value
-            // https://github.com/rollup/rollup/pull/742#issuecomment-230836980
         }
     };
 };

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -30,6 +30,8 @@ module.exports = function(opts) {
     }
     
     return {
+        name : "modular-css",
+
         transform : function(code, id) {
             if(!filter(id) || id.slice(slice) !== options.ext) {
                 return null;
@@ -61,10 +63,9 @@ module.exports = function(opts) {
                 };
             });
         },
-        
-        // This is a bit of a hack, see this rollup PR for details
-        // https://github.com/rollup/rollup/pull/353#issuecomment-164358181
-        footer : function() {
+
+        // Hook for when bundle.generate() is called
+        ongenerate : function() {
             processor.output({
                 to : options.css
             })
@@ -85,6 +86,9 @@ module.exports = function(opts) {
                     );
                 }
             });
+            
+            // TODO: Figure out if it's necessary to return a useful value
+            // https://github.com/rollup/rollup/pull/742#issuecomment-230836980
         }
     };
 };


### PR DESCRIPTION
Now that rollup/rollup#742 & rollup/rollup#773 have landed the terrible `footer` hack can finally be banished!

This also gives the rollup plugin a `name` field because IIRC that is becoming important soon.