### PR TITLE
Better handle errors within rollup

### DIFF
--- a/src/rollup.js
+++ b/src/rollup.js
@@ -90,6 +90,9 @@ module.exports = function(opts) {
                         JSON.stringify(data.compositions, null, 4)
                     );
                 }
+            })
+            .catch(function(error) {
+                throw error;
             });
         }
     };

--- a/test/glob.test.js
+++ b/test/glob.test.js
@@ -6,11 +6,6 @@ var assert  = require("assert"),
     
     compare = require("./lib/compare-files");
 
-// Catch unhandled promise rejections and fail the test
-process.on("unhandledRejection", function(reason) {
-    throw reason;
-});
-
 describe("/glob.js", function() {
     it("should be a function", function() {
         assert.equal(typeof glob, "function");

--- a/test/lib/warn.js
+++ b/test/lib/warn.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = function(css, result) {
+    result.warn("warning");
+};
+
+module.exports.postcssPlugin = "Warning Plugin";

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -7,7 +7,8 @@ var fs      = require("fs"),
     Promise   = require("../src/lib/promise"),
     Processor = require("../src/processor"),
     
-    compare = require("./lib/compare-files");
+    compare = require("./lib/compare-files"),
+    warn    = require("./lib/warn");
 
 // Catch unhandled promise rejections and fail the test
 process.on("unhandledRejection", function(reason) {
@@ -26,10 +27,6 @@ function async(css) {
             resolve();
         }, 0);
     });
-}
-
-function warn(css, result) {
-    result.warn("warning");
 }
 
 describe("/processor.js", function() {

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -10,11 +10,6 @@ var fs      = require("fs"),
     compare = require("./lib/compare-files"),
     warn    = require("./lib/warn");
 
-// Catch unhandled promise rejections and fail the test
-process.on("unhandledRejection", function(reason) {
-    throw reason;
-});
-
 function sync(css) {
     css.append({ selector : "a" });
 }


### PR DESCRIPTION
Make sure that warnings (in strict mode) from plugins are actually bubble all the way up to the proper Promises in rollup.

Previously if a `done` plugin was throwing warnings they'd just be silently ignored, which is terrible.