### PR TITLE
Remove Promise polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "postcss-selector-parser": "^2.0.0",
     "postcss-url": "^5.1.0",
     "postcss-value-parser": "^3.2.3",
-    "promiscuous": "^0.6.0",
     "resolve-from": "^2.0.0",
     "rollup-pluginutils": "^1.3.1",
     "sink-transform": "^2.0.0",
@@ -75,6 +74,9 @@
     "env": {
       "node": true,
       "mocha": true
+    },
+    "globals": {
+        "Promise": true
     },
     "rules": {
       "prefer-template": "off"

--- a/src/lib/promise.js
+++ b/src/lib/promise.js
@@ -1,8 +1,0 @@
-"use strict";
-
-/* istanbul ignore next: never run in node that supports Promises natively */
-if(!global.Promise) {
-    global.Promise = require("promiscuous");
-}
-
-module.exports = global.Promise;

--- a/src/lib/sequential.js
+++ b/src/lib/sequential.js
@@ -1,7 +1,5 @@
 "use strict";
 
-var Promise = require("./promise");
-
 module.exports = function(fns) {
     return new Promise(function(resolve, reject) {
         fns.reduce(function(curr, next) {

--- a/src/processor.js
+++ b/src/processor.js
@@ -10,7 +10,6 @@ var fs   = require("fs"),
     urls     = require("postcss-url"),
     slug     = require("unique-slug"),
 
-    Promise    = require("./lib/promise"),
     output     = require("./lib/output"),
     message    = require("./lib/message"),
     relative   = require("./lib/relative"),

--- a/test/lib.sequential.test.js
+++ b/test/lib.sequential.test.js
@@ -2,7 +2,6 @@
 
 var assert = require("assert"),
     
-    Promise    = require("../src/lib/promise"),
     sequential = require("../src/lib/sequential");
 
 describe("/lib", function() {

--- a/test/lib/wait.js
+++ b/test/lib/wait.js
@@ -1,8 +1,6 @@
 "use strict";
     
-var fs = require("fs"),
-    
-    Promise = require("../../src/lib/promise");
+var fs = require("fs");
     
 module.exports = function(file) {
     return new Promise(function(resolve) {

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -4,7 +4,6 @@ var fs      = require("fs"),
     path    = require("path"),
     assert  = require("assert"),
     
-    Promise   = require("../src/lib/promise"),
     Processor = require("../src/processor"),
     
     compare = require("./lib/compare-files"),


### PR DESCRIPTION
`node@4.x` is where it's at, so dropping support for a `Promise` polyfill to streamline the package.