### PR TITLE
refactor: use cwd for .glob()

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ modular-css [![NPM Version](https://img.shields.io/npm/v/modular-css.svg)](https
 Provides a subset of [css-modules](https://github.com/css-modules/css-modules) via:
 
 - [API](#api)
+  - [Processor](#processor)
+  - [Globbing](#globbing)
 - [CLI](#cli)
 - [Browserify](#browserify) Plugin
 - [Rollup](#rollup) Plugin
@@ -21,6 +23,8 @@ Provides a subset of [css-modules](https://github.com/css-modules/css-modules) v
 ## Usage
 
 ### API
+
+#### Processor
 
 Instantiate a new `Processor` instance, call it's `.file(<path>)` or `.string(<name>, <contents>)` methods, and then use the returned Promise to get access to the results/output.
 
@@ -52,18 +56,18 @@ Promise.all([
 });
 ```
 
-#### API Options
+##### Processor Options
 
-##### `before`
+###### `before`
 
 Specify an array of PostCSS plugins to be run against each file before it is processed.
 
 ```js
 new Processor({
     before : [ require("postcss-import") ]
-});    
+});
 ```
-##### `after`
+###### `after`
 
 Specify an array of PostCSS plugins to be run after files are processed, but before they are combined. Plugin will be passed a `to` and `from` option.
 
@@ -75,17 +79,17 @@ new Processor({
 });
 ```
 
-##### `done`
+###### `done`
 
 Specify an array of PostCSS plugins to be run against the complete combined CSS.
 
 ```js
 new Processor({
     done : [ require("cssnano")()]
-});    
+});
 ```
 
-##### `map`
+###### `map`
 
 Enable source map generation. Can also be passed to `.output()`.
 
@@ -97,7 +101,7 @@ new Processor({
 });
 ```
 
-##### `cwd`
+###### `cwd`
 
 Specify the current working directory for this Processor instance, used when resolving `composes`/`@value` rules that reference other files.
 
@@ -109,7 +113,7 @@ new Processor({
 })
 ```
 
-##### `namer`
+###### `namer`
 
 Specify a function (that takes `filename` & `selector` as arguments to produce scoped selectors.
 
@@ -122,6 +126,31 @@ new Processor({
     }
 });
 ```
+
+#### Globbing
+
+If you don't care about the dependency tree from your code you can also use the globbing API to find files to process.
+
+```js
+var glob = require("modular-css/glob");
+
+glob({
+    search : [
+        "**/*.css"
+    ]
+})
+.then(function(processor) {
+    // returns a filled-out Processor instance you can use
+})
+```
+
+`glob()` accepts all of the same options as a [`Processor` instance](#processor-options) with the addition of the [`search`](#search) property.
+
+##### Glob Options
+
+###### `search`
+
+Array of glob patterns to pass to [`globule`](https://www.npmjs.com/package/globule) for searching.
 
 ### CLI
 

--- a/src/glob.js
+++ b/src/glob.js
@@ -1,4 +1,3 @@
-/* global Promise */
 "use strict";
 
 var globule = require("globule"),
@@ -6,15 +5,16 @@ var globule = require("globule"),
     Processor = require("./processor.js");
 
 module.exports = function(opts) {
-    var options   = opts || {},
-        processor = new Processor(options),
-        files     = globule.find(options.search, {
-            cwd        : options.dir || process.cwd(),
-            prefixBase : true
-        });
+    var options   = opts || false,
+        processor = new Processor(options);
         
     return Promise.all(
-        files.map(function(file) {
+        globule.find({
+            src        : options.search,
+            cwd        : processor._options.cwd,
+            prefixBase : true
+        })
+        .map(function(file) {
             return processor.file(file);
         })
     )

--- a/test/glob.test.js
+++ b/test/glob.test.js
@@ -13,7 +13,7 @@ describe("/glob.js", function() {
 
     it("should find files on disk & output css", function() {
         return glob({
-            dir    : "./test/specimens/glob",
+            cwd    : "./test/specimens/glob",
             search : [
                 "**/*.css"
             ]
@@ -28,7 +28,7 @@ describe("/glob.js", function() {
 
     it("should support exclusion patterns", function() {
         return glob({
-            dir    : "./test/specimens/glob",
+            cwd    : "./test/specimens/glob",
             search : [
                 "**/*.css",
                 "!**/exclude/**"

--- a/test/results/glob/glob-excludes.css
+++ b/test/results/glob/glob-excludes.css
@@ -1,12 +1,12 @@
-/* test/specimens/glob/1.css */
-.mc7747055b_one {
+/* 1.css */
+.mceb37c9fc_one {
     color: red
 }
-/* test/specimens/glob/dir/3.css */
-.mcac0cd894_three {
+/* dir/3.css */
+.mcfd4d674b_three {
     color: white
 }
-/* test/specimens/glob/dir/2.css */
-.mc650bdf6f_two {
+/* dir/2.css */
+.mc7426d22b_two {
     background: blue
 }

--- a/test/results/glob/glob.css
+++ b/test/results/glob/glob.css
@@ -1,16 +1,16 @@
-/* test/specimens/glob/1.css */
-.mc7747055b_one {
+/* 1.css */
+.mceb37c9fc_one {
     color: red
 }
-/* test/specimens/glob/dir/3.css */
-.mcac0cd894_three {
+/* dir/3.css */
+.mcfd4d674b_three {
     color: white
 }
-/* test/specimens/glob/exclude/4.css */
-.mcfb470b25_four {
+/* exclude/4.css */
+.mc2ec3d6d7_four {
     color: red
 }
-/* test/specimens/glob/dir/2.css */
-.mc650bdf6f_two {
+/* dir/2.css */
+.mc7426d22b_two {
     background: blue
 }


### PR DESCRIPTION
Using the same cwd indicator for both `Processor` and `.glob()` reduces issues when dealing with junctions and makes it less likely to be misused

BREAKING CHANGE:

`dir` is no longer accepted as a property when invoking `.glob()` and will be ignored.