### PR TITLE
Re-work reference storing so globals are prefixed

### DIFF
--- a/src/lib/composition.js
+++ b/src/lib/composition.js
@@ -140,40 +140,30 @@ function parse(input) {
     return false;
 }
 
+function process(file, input, thing, word) {
+    var parsed = parse(input);
+    
+    if(!parsed) {
+        throw thing.error("Unable to parse composition", { word : word });
+    }
+    
+    if(parsed.source && parsed.source !== "super") {
+         parsed.source = resolve(file, parsed.source);
+    }
+    
+    return parsed;
+}
+
 exports.parse = parse;
 
 exports.decl = function(file, decl) {
-    var parsed;
-    
     if(decl.prev() && decl.prev().prop !== "composes") {
         throw decl.error("composes must be the first declaration in the rule", { word : "composes" });
     }
     
-    parsed = parse(decl.value.trim());
-    
-    if(!parsed) {
-        throw decl.error("Unable to parse composition", { word : decl.value });
-    }
-    
-    if(parsed.source && parsed.source !== "super") {
-         parsed.source = resolve(file, parsed.source);
-    }
-    
-    return parsed;
+    return process(file, decl.value.trim(), decl, decl.value);
 };
 
 exports.rule = function(file, rule) {
-    var parsed;
-    
-    parsed = parse(rule.params.trim());
-    
-    if(!parsed) {
-        throw rule.error("Unable to parse composition", { word : rule.params });
-    }
-    
-    if(parsed.source && parsed.source !== "super") {
-         parsed.source = resolve(file, parsed.source);
-    }
-    
-    return parsed;
+    return process(file, rule.params.trim(), rule, rule.params);
 };

--- a/src/plugins/composition.js
+++ b/src/plugins/composition.js
@@ -41,7 +41,13 @@ module.exports = postcss.plugin(plugin, function() {
             // Add references and update graph
             details.rules.forEach(function(rule) {
                 var global = details.types[rule] === "global",
-                    scoped = global ? rule : (details.source || "") + rule;
+                    scoped;
+                    
+                if(global) {
+                    scoped = "global-" + rule;
+                } else {
+                    scoped = (details.source ? details.source + "-" : "") + rule;
+                }
 
                 graph.addNode(scoped);
 
@@ -50,7 +56,7 @@ module.exports = postcss.plugin(plugin, function() {
                 });
 
                 if(global) {
-                    refs[rule] = [ rule ];
+                    refs[scoped] = [ rule ];
 
                     return;
                 }
@@ -72,7 +78,7 @@ module.exports = postcss.plugin(plugin, function() {
             // Remove the entire rule because it only contained the composes declaration
             return decl.parent.remove();
         });
-        
+
         // Update out by walking dep graph and updating classes
         graph.overallOrder().forEach(function(selector) {
             graph.dependenciesOf(selector)
@@ -81,7 +87,7 @@ module.exports = postcss.plugin(plugin, function() {
                     out[selector] = refs[dep].concat(out[selector]);
                 });
         });
-        
+
         result.messages.push({
             type    : "modularcss",
             plugin  : plugin,

--- a/test/lib.composition.test.js
+++ b/test/lib.composition.test.js
@@ -191,6 +191,19 @@ describe("/lib", function() {
                     }
                 );
             });
+
+            it("shouldn't mix local & global values", () => {
+                assert.deepEqual(
+                    composition.decl(from, parse(".a { composes: global(a); }").first),
+                    {
+                        rules  : [ "a" ],
+                        source : false,
+                        types  : {
+                            a : "global"
+                        }
+                    }
+                );
+            });
         });
         
         describe(".rule()", function() {

--- a/test/plugin.composition.test.js
+++ b/test/plugin.composition.test.js
@@ -237,6 +237,17 @@ describe("/plugins", function() {
                 wooga : [ "booga", "tooga", "wooga" ]
             }));
         });
+
+        it("should support composing against global identifiers w/ the same name", () => {
+            var out = process(".wooga { composes: global(wooga); color: red; }", {
+                    from : "test/specimens/simple.css"
+                });
+            
+            assert.equal(out.messages.length, 2);
+            assert.deepEqual(out.messages[1], msg({
+                wooga : [ "wooga", "simple_wooga" ]
+            }));
+        });
         
         it("should handle multi-level dependencies", function() {
             var out = process(


### PR DESCRIPTION
Fixes #184 by no longer accidentally overwriting the global w/ the local
ref.

Also!

- Clean up some composition lib repetition
- Verify the issue isn't in the composition lib
- Add failing test for #184