### PR TITLE
Hack in rollup-watch support

### DIFF
--- a/src/processor.js
+++ b/src/processor.js
@@ -100,22 +100,28 @@ Processor.prototype = {
     },
     
     // Remove a file from the dependency graph
-    remove : function(input) {
+    remove : function(input, options) {
         var self  = this,
             files = input;
 
         if(!Array.isArray(files)) {
             files = [ files ];
         }
+        
+        if(!options) {
+            options = false;
+        }
 
         files.filter(function(key) {
             return self._graph.hasNode(key);
         })
         .forEach(function(key) {
-            // Remove everything that depends on this too, it'll all need
-            // to be recalculated
-            self.remove(self._graph.dependantsOf(key));
-            
+            if(!options.shallow) {
+                // Remove everything that depends on this too, it'll all need
+                // to be recalculated
+                self.remove(self._graph.dependantsOf(key));
+            }
+
             delete self._files[key];
             
             self._graph.removeNode(key);

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -23,7 +23,7 @@ module.exports = function(opts) {
         
         filter = utils.createFilter(options.include, options.exclude),
         
-        processor;
+        processor = new Processor(options);
         
     if(!options.onwarn) {
         options.onwarn = console.warn.bind(console); // eslint-disable-line
@@ -35,13 +35,6 @@ module.exports = function(opts) {
         transform : function(code, id) {
             if(!filter(id) || id.slice(slice) !== options.ext) {
                 return null;
-            }
-
-            // JIT processor creation to support dumping it at the end of each generation pass
-            // since rollup-watch doesn't notify us which files have changed
-            // https://github.com/tivac/modular-css/issues/158
-            if(!processor) {
-                 processor = new Processor(options);
             }
             
             return processor.string(id, code).then(function(result) {
@@ -77,12 +70,6 @@ module.exports = function(opts) {
         ongenerate : function(bundle, result) {
             result.css = processor.output({
                 to : options.css
-            })
-            .then(function(data) {
-                // Remove our reference to the processor so it'll be re-created on the next run
-                processor = null;
-
-                return data;
             });
         },
 

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -23,7 +23,7 @@ module.exports = function(opts) {
         
         filter = utils.createFilter(options.include, options.exclude),
         
-        processor = new Processor(options);
+        processor;
         
     if(!options.onwarn) {
         options.onwarn = console.warn.bind(console); // eslint-disable-line
@@ -35,6 +35,13 @@ module.exports = function(opts) {
         transform : function(code, id) {
             if(!filter(id) || id.slice(slice) !== options.ext) {
                 return null;
+            }
+
+            // JIT processor creation to support dumping it at the end of each generation pass
+            // since rollup-watch doesn't notify us which files have changed
+            // https://github.com/tivac/modular-css/issues/158
+            if(!processor) {
+                 processor = new Processor(options);
             }
             
             return processor.string(id, code).then(function(result) {
@@ -70,6 +77,12 @@ module.exports = function(opts) {
         ongenerate : function(bundle, result) {
             result.css = processor.output({
                 to : options.css
+            })
+            .then(function(data) {
+                // Remove our reference to the processor so it'll be re-created on the next run
+                processor = null;
+
+                return data;
             });
         },
 


### PR DESCRIPTION
#158 is because `rollup-watch` never tells the plugin which files have changed. This does some gross stuff to make it work which probably has bad edge-cases that lead to bloated bundles.

But at least it regenerates the CSS when a file changes! 😒 