### PR TITLE
Throw if a selector is used locally and globally

### DIFF
--- a/src/plugins/scoping.js
+++ b/src/plugins/scoping.js
@@ -46,6 +46,10 @@ module.exports = postcss.plugin(plugin, function() {
                     if(!key) {
                         return;
                     }
+
+                    if(key in lookup) {
+                        throw current.error("Unable to re-use the same selector for global & local", { word : key });
+                    }
                     
                     lookup[key] = [ child.value ];
                     child.ignore = true;
@@ -58,7 +62,7 @@ module.exports = postcss.plugin(plugin, function() {
                 if(!key || node.ignore) {
                     return;
                 }
-                
+
                 node.value = result.opts.namer(result.opts.from, node.value);
                 
                 lookup[key] = [ node.value ];

--- a/src/plugins/scoping.js
+++ b/src/plugins/scoping.js
@@ -1,7 +1,7 @@
 "use strict";
 
-var postcss      = require("postcss"),
-    createParser = require("postcss-selector-parser"),
+var postcss   = require("postcss"),
+    processor = require("postcss-selector-parser"),
         
     identifiers = require("../lib/identifiers"),
     
@@ -25,10 +25,8 @@ module.exports = postcss.plugin(plugin, function() {
             return false;
         }
 
-        parser = createParser(function(selectors) {
+        parser = processor(function(selectors) {
             selectors.walkPseudos(function(node) {
-                var replacement;
-                
                 if(node.value !== ":global") {
                     return;
                 }
@@ -38,10 +36,9 @@ module.exports = postcss.plugin(plugin, function() {
                 }
                 
                 // Replace the :global(...) with its contents
-                replacement = createParser.selector();
-                replacement.nodes = node.nodes;
-                
-                node.replaceWith(replacement);
+                node.replaceWith(processor.selector({
+                    nodes : node.nodes
+                }));
                 
                 node.walk(function(child) {
                     var key = rename(child);

--- a/src/plugins/scoping.js
+++ b/src/plugins/scoping.js
@@ -9,7 +9,8 @@ var postcss   = require("postcss"),
 
 module.exports = postcss.plugin(plugin, function() {
     return function(css, result) {
-        var lookup = {},
+        var lookup  = {},
+            globals = {},
             parser, current;
             
         // Validate whether a selector should be renamed, returns the key to use
@@ -51,6 +52,7 @@ module.exports = postcss.plugin(plugin, function() {
                         throw current.error("Unable to re-use the same selector for global & local", { word : key });
                     }
                     
+                    globals[key] = true;
                     lookup[key] = [ child.value ];
                     child.ignore = true;
                 });
@@ -61,6 +63,10 @@ module.exports = postcss.plugin(plugin, function() {
                 
                 if(!key || node.ignore) {
                     return;
+                }
+
+                if(key in globals) {
+                    throw current.error("Unable to re-use the same selector for global & local", { word : key });
                 }
 
                 node.value = result.opts.namer(result.opts.from, node.value);

--- a/test/plugin.scoping.test.js
+++ b/test/plugin.scoping.test.js
@@ -173,6 +173,11 @@ describe("/plugins", function() {
                     process(".wooga :global(.booga) { color: red; }").css,
                     ".simple_wooga .booga { color: red; }"
                 );
+
+                assert.equal(
+                    process(".b { color: red; } :global(.b) { color: blue; }").css,
+                    ".simple_b { color: red; } .b { color: blue; }"
+                )
                 
                 assert.equal(
                     process(".wooga :global(.booga) .fooga { color: red; }").css,

--- a/test/plugin.scoping.test.js
+++ b/test/plugin.scoping.test.js
@@ -136,6 +136,13 @@ describe("/plugins", function() {
                 }, /must not be empty/);
             });
 
+            it("should throw if global & local selectors overlap (issue 192)", function() {
+                /* eslint no-unused-expressions:0 */
+                assert.throws(function() {
+                    process(".b { color: b; } :global(.b) { color: b; }").css;
+                }, /Unable to re-use the same selector for global & local/);
+            })
+
             it("shouldn't transform global selectors", function() {
                 assert.equal(
                     process(":global(.wooga) { color: red; }").css,
@@ -175,8 +182,8 @@ describe("/plugins", function() {
                 );
 
                 assert.equal(
-                    process(".b { color: red; } :global(.b) { color: blue; }").css,
-                    ".simple_b { color: red; } .b { color: blue; }"
+                    process(".b { color: red; } :global(.c) { color: blue; }").css,
+                    ".simple_b { color: red; } .c { color: blue; }"
                 )
                 
                 assert.equal(

--- a/test/plugin.scoping.test.js
+++ b/test/plugin.scoping.test.js
@@ -141,6 +141,10 @@ describe("/plugins", function() {
                 assert.throws(function() {
                     process(".b { color: b; } :global(.b) { color: b; }").css;
                 }, /Unable to re-use the same selector for global & local/);
+
+                assert.throws(function() {
+                    process(":global(.b) { color: b; } .b { color: b; }").css;
+                }, /Unable to re-use the same selector for global & local/);
             })
 
             it("shouldn't transform global selectors", function() {

--- a/test/plugin.scoping.test.js
+++ b/test/plugin.scoping.test.js
@@ -19,9 +19,9 @@ function process(src, options) {
     return plugin.process(
         src,
         assign({
-            from  : "test/specimens/simple.css",
+            from  : "test/specimens/a.css",
             namer : function(file, selector) {
-                return path.basename(file, path.extname(file)) + "_" + selector;
+                return `a_${selector}`;
             }
         },
         options || {})
@@ -33,14 +33,14 @@ describe("/plugins", function() {
         it("should generate a prefix for class names", function() {
             assert.equal(
                 process(".wooga { color: red; }").css,
-                ".simple_wooga { color: red; }"
+                ".a_wooga { color: red; }"
             );
         });
         
         it("should generate a prefix for ids", function() {
             assert.equal(
                 process("#wooga { color: red; }").css,
-                "#simple_wooga { color: red; }"
+                "#a_wooga { color: red; }"
             );
         });
         
@@ -54,51 +54,51 @@ describe("/plugins", function() {
         it("should transform class/id selectors", function() {
             assert.equal(
                 process(".wooga p { color: red; }").css,
-                ".simple_wooga p { color: red; }"
+                ".a_wooga p { color: red; }"
             );
 
             assert.equal(
                 process("#wooga p { color: red; }").css,
-                "#simple_wooga p { color: red; }"
+                "#a_wooga p { color: red; }"
             );
             
             assert.equal(
                 process("#wooga .booga { color: red; }").css,
-                "#simple_wooga .simple_booga { color: red; }"
+                "#a_wooga .a_booga { color: red; }"
             );
 
             assert.equal(
                 process("#wooga { color: red; } #wooga:hover { color: blue; }").css,
-                "#simple_wooga { color: red; } #simple_wooga:hover { color: blue; }"
+                "#a_wooga { color: red; } #a_wooga:hover { color: blue; }"
             );
 
             assert.equal(
                 process(".wooga { color: red; } .wooga:hover { color: black; }").css,
-                ".simple_wooga { color: red; } .simple_wooga:hover { color: black; }"
+                ".a_wooga { color: red; } .a_wooga:hover { color: black; }"
             );
         });
         
         it("should transform selectors within media queries", function() {
             assert.equal(
                 process("@media (max-width: 100px) { .booga { color: red; } }").css,
-                "@media (max-width: 100px) { .simple_booga { color: red; } }"
+                "@media (max-width: 100px) { .a_booga { color: red; } }"
             );
         });
 
         it("should transform the names of @keyframes rules", function() {
             assert.equal(
                 process("@keyframes fooga { }").css,
-                "@keyframes simple_fooga { }"
+                "@keyframes a_fooga { }"
             );
 
             assert.equal(
                 process("@-webkit-keyframes fooga { }").css,
-                "@-webkit-keyframes simple_fooga { }"
+                "@-webkit-keyframes a_fooga { }"
             );
 
             assert.equal(
                 process("@-moz-keyframes fooga { }").css,
-                "@-moz-keyframes simple_fooga { }"
+                "@-moz-keyframes a_fooga { }"
             );
         });
         
@@ -110,9 +110,9 @@ describe("/plugins", function() {
                     "@keyframes fooga { 0% { color: red; } 100% { color: black; } }"
                 ).messages,
                 [ msg({
-                    booga : [ "simple_booga" ],
-                    fooga : [ "simple_fooga" ],
-                    wooga : [ "simple_wooga" ]
+                    booga : [ "a_booga" ],
+                    fooga : [ "a_fooga" ],
+                    wooga : [ "a_wooga" ]
                 }) ]
             );
         });
@@ -171,28 +171,28 @@ describe("/plugins", function() {
             
             it("should support mixed local & global selectors", function() {
                 assert.equal(
-                    process(":global(#wooga), .wooga { color: red; }").css,
-                    "#wooga, .simple_wooga { color: red; }"
+                    process(":global(#wooga), .booga { color: red; }").css,
+                    "#wooga, .a_booga { color: red; }"
                 );
                 
                 assert.equal(
                     process(":global(.wooga) .booga { color: red; }").css,
-                    ".wooga .simple_booga { color: red; }"
+                    ".wooga .a_booga { color: red; }"
                 );
                 
                 assert.equal(
                     process(".wooga :global(.booga) { color: red; }").css,
-                    ".simple_wooga .booga { color: red; }"
+                    ".a_wooga .booga { color: red; }"
                 );
 
                 assert.equal(
                     process(".b { color: red; } :global(.c) { color: blue; }").css,
-                    ".simple_b { color: red; } .c { color: blue; }"
+                    ".a_b { color: red; } .c { color: blue; }"
                 )
                 
                 assert.equal(
                     process(".wooga :global(.booga) .fooga { color: red; }").css,
-                    ".simple_wooga .booga .simple_fooga { color: red; }"
+                    ".a_wooga .booga .a_fooga { color: red; }"
                 );
             });
             
@@ -226,13 +226,13 @@ describe("/plugins", function() {
                 
                 assert.equal(
                     processed.css,
-                    ".simple_fooga .wooga { color: red; }"
+                    ".a_fooga .wooga { color: red; }"
                 );
                 
                 assert.deepEqual(
                     processed.messages,
                     [ msg({
-                        fooga : [ "simple_fooga" ],
+                        fooga : [ "a_fooga" ],
                         wooga : [ "wooga" ]
                     }) ]
                 );


### PR DESCRIPTION
It's fine to re-use a selector normally, because it'll be always be transformed to the same name.

```css
.fooga { color: red; }
.fooga:hover { color: blue; }

/* becomes */

.abc123_fooga { color: red; }
.abc123_fooga:hover { color: blue; }
```

but when you introduce `:global()` things get more complicated, since those are **not** renamed.

```css
.fooga { color: red; }
:global(.fooga) { color: blue }

/* becomes */

.abc123_fooga { color: red; }
.fooga { color: blue }
```

which looks fine, until you consider the mapping object that creates.

```js
{
    fooga : "fooga",
}
```

since the `:global()` came second and the names overlap it blows up any existing definition. It could also blow up the other way if the global came first.

That's bad for user expectations, so make it such that globals & locals that overlap throw an exception.
    