### PR TITLE
Fix error reporting in initial walk of graph

### DIFF
--- a/test/plugin.graph-nodes.test.js
+++ b/test/plugin.graph-nodes.test.js
@@ -57,5 +57,18 @@ describe("/plugins", function() {
                 from
             ]));
         });
+
+        it("should return useful errors when parsing", () => {
+            var graph = new Graph(),
+                from  = path.resolve("./test/specimens/simple.css");
+
+            graph.addNode(from);
+            
+            return plugin.process(
+                `@value sm, md, lg "../../shared.css";`,
+                { from, graph }
+            )
+            .catch((e) => assert(e.message.indexOf(`SyntaxError: Expected "from"`) > -1));
+        });
     });
 });


### PR DESCRIPTION
Since the parser wasn't in a `try`/`catch` block errors weren't nice PostCSS errors with proper locations and file names. Fixed now so that you can actually figure out wtf broke.