### PR TITLE
Use webpack's built-in assets support

### DIFF
--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -10,11 +10,11 @@ You will need to use **both** in tandem for things to work!
 
 ### `css`
 
-Location to write the generated CSS file to.
+Location to write the generated CSS file to, relative to `output.path` just like `output.filename`
 
 ### `json`
 
-Location to write out the JSON mapping file for use in server rendering.
+Location to write out the JSON mapping file to, relative to `output.path` just like `output.filename`
 
 ### Shared Options
 
@@ -44,7 +44,8 @@ module.exports = {
     },
     plugins : [
         new CSSPlugin({
-            css : path.resolve(__dirname, "dist/output.css")
+            css  : "./output.css",
+            json : "./output.json"
         })
     ]
 });

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "rollup-pluginutils": "^2.0.0",
     "sink-transform": "^2.0.0",
     "through2": "^2.0.0",
-    "unique-slug": "^2.0.0"
+    "unique-slug": "^2.0.0",
+    "webpack-sources": "^0.1.3"
   },
   "eslintConfig": {
     "extends": "arenanet",

--- a/test/webpack.test.js
+++ b/test/webpack.test.js
@@ -36,7 +36,7 @@ describe("/webpack.js", function() {
             },
             plugins : [
                 new Plugin({
-                    css : "./test/output/webpack/simple.css"
+                    css : "./simple.css"
                 })
             ]
         }, (err, stats) => {
@@ -67,7 +67,7 @@ describe("/webpack.js", function() {
             },
             plugins : [
                 new Plugin({
-                    json : "./test/output/webpack/simple.json"
+                    json : "./simple.json"
                 })
             ]
         }, (err, stats) => {
@@ -127,8 +127,8 @@ describe("/webpack.js", function() {
             },
             plugins : [
                 new Plugin({
-                    css  : "./test/output/webpack/start.css",
-                    json : "./test/output/webpack/start.json"
+                    css  : "./start.css",
+                    json : "./start.json"
                 })
             ]
         }, (err, stats) => {


### PR DESCRIPTION
Instead of writing my own files to disk using `fs`, take advantage of webpack's `compiler.assets` object and add assets there instead.

Not *technically* a breaking change, though very likely to cause breakage.