### PR TITLE
Smarter value matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@studio/changes": "^1.0.5",
     "browserify": "^14.0.0",
     "cli-tester": "^2.0.0",
-    "common-tags": "^1.4.0",
+    "dentist": "^1.0.3",
     "eslint": "^3.12.0",
     "eslint-config-arenanet": "^3.0.0",
     "factor-bundle": "^2.5.0",

--- a/src/plugins/keyframes.js
+++ b/src/plugins/keyframes.js
@@ -6,10 +6,12 @@ var escape  = require("escape-string-regexp"),
 
 module.exports = (css, result) => {
     var refs   = message(result, "keyframes"),
-        inner  = Object.keys(refs)
-            .map(escape)
-            .join("\\b)|(\\b"),
-        search = new RegExp(`(\\b${inner}\\b)`, "g");
+        search = new RegExp(
+            Object.keys(refs)
+                .map((ref) => `(\\b${escape(ref)}\\b)`)
+                .join("|"),
+            "g"
+        );
     
     // Go look up "animation" declarations and rewrite their names to scoped values
     css.walkDecls(/animation$|animation-name$/, function(decl) {

--- a/test/issue-24.test.js
+++ b/test/issue-24.test.js
@@ -3,7 +3,7 @@
 var path   = require("path"),
     assert = require("assert"),
     
-    leading = require("common-tags").stripIndent,
+    leading = require("dentist").dedent,
 
     Processor = require("../src/processor.js");
 
@@ -14,14 +14,14 @@ describe("/issues", function() {
             
             return processor.string(
                 "./test/specimens/composition.css",
-                leading`
+                leading(`
                     @value simple: "./simple.css";
                     
                     .wooga {
                         composes: wooga from simple;
                         background: #000;
                     }
-                `
+                `)
             )
             .then((result) => {
                 assert.deepEqual(result.exports, {
@@ -36,7 +36,7 @@ describe("/issues", function() {
             .then((result) =>
                 assert.equal(
                     result.css,
-                    leading`
+                    leading(`
                         /* test/specimens/simple.css */
                         .mc08e91a5b_wooga {
                             color: red
@@ -45,7 +45,7 @@ describe("/issues", function() {
                         .mc29d531c6_wooga {
                             background: #000
                         }
-                    `
+                    `)
                 )
             );
         });

--- a/test/issue-56.test.js
+++ b/test/issue-56.test.js
@@ -2,7 +2,7 @@
 
 var assert = require("assert"),
 
-    leading = require("common-tags").stripIndent,
+    leading = require("dentist").dedent,
     
     Processor = require("../src/processor.js"),
     compare   = require("./lib/compare.js");
@@ -14,12 +14,12 @@ describe("/issues", function() {
             
             return processor.string(
                     "./test/specimens/issues/56.css",
-                    leading`
+                    leading(`
                         .booga { color: red }
                         .fooga { composes: booga }
                         .fooga:hover { color: blue }
                         .wooga { composes: booga }
-                    `
+                    `)
             )
             .then((result) => {
                 assert.deepEqual(result.exports, {

--- a/test/issue-98.test.js
+++ b/test/issue-98.test.js
@@ -2,7 +2,7 @@
 
 var assert    = require("assert"),
 
-    leading = require("common-tags").stripIndent,
+    leading = require("dentist").dedent,
     
     Processor = require("../src/processor.js"),
     compare   = require("./lib/compare.js");
@@ -14,11 +14,11 @@ describe("/issues", function() {
             
             return processor.string(
                 "./test/specimens/issues/98.css",
-                leading`
+                leading(`
                     .booga { color: red }
                     .fooga { composes: booga }
                     .fooga + .fooga { color: blue }
-                `
+                `)
             )
             .then((result) => {
                 assert.deepEqual(result.exports, {

--- a/test/plugin.scoping.test.js
+++ b/test/plugin.scoping.test.js
@@ -3,7 +3,7 @@
 var path   = require("path"),
     assert = require("assert"),
     
-    leading = require("common-tags").stripIndent,
+    leading = require("dentist").dedent,
 
     plugin = require("../src/plugins/scoping.js"),
     
@@ -112,14 +112,14 @@ describe("/plugins", function() {
         
         it("should expose original names in a message", function() {
             assert.deepEqual(
-                process(leading`
+                process(leading(`
                     .wooga { color: red; }
                     #booga { color: black; }
                     @keyframes fooga {
                         0% { color: red; }
                         100% { color: black; }
-                    }`
-                ).messages,
+                    }
+                `)).messages,
                 [
                     msg({
                         fooga : [ "a_fooga" ]
@@ -230,7 +230,7 @@ describe("/plugins", function() {
 
             it("should include :global(...) identifiers in a message", function() {
                 assert.deepEqual(
-                    process(leading`
+                    process(leading(`
                         :global(.wooga) { color: red; }
                         :global(#fooga) { color: red; }
                         :global(.googa .tooga) { color: red; }
@@ -242,8 +242,8 @@ describe("/plugins", function() {
                             100% {
                                 color: black;
                             }
-                        }`
-                    ).messages,
+                        }
+                    `)).messages,
                     [
                         msg({
                             yooga : [ "yooga" ]

--- a/test/plugin.values-replace.test.js
+++ b/test/plugin.values-replace.test.js
@@ -37,27 +37,66 @@ describe("/plugins", function() {
             
             it("should replace values in declarations", function() {
                 assert.equal(
-                    process("@value color: red; .wooga { color: color; }").css,
-                    ".wooga { color: red; }"
+                    process(dedent(`
+                        @value color: red;
+                        
+                        .wooga {
+                            color: color;
+                        }
+                    `)).css,
+                    dedent(`
+                        .wooga {
+                            color: red;
+                        }
+                    `)
                 );
             });
 
             it("should replace value references in @value declarations", function() {
                 assert.equal(
-                    process("@value color: red; @value value: color; .wooga { color: value; }").css,
-                    ".wooga { color: red; }"
+                    process(dedent(`
+                        @value color: red;
+                        @value value: color;
+                        
+                        .wooga {
+                            color: value;
+                        }
+                    `)).css,
+                    dedent(`
+                        .wooga {
+                            color: red;
+                        }
+                    `)
                 );
 
                 assert.equal(
-                    process("@value red: #F00; @value color: red; @value value: color; .wooga { color: value; }").css,
-                    ".wooga { color: #F00; }"
+                    process(dedent(`
+                        @value red: #F00;
+                        @value color: red;
+                        @value value: color;
+                        
+                        .wooga {
+                            color: value;
+                        }
+                    `)).css,
+                    dedent(`
+                        .wooga {
+                            color: #F00;
+                        }
+                    `)
                 );
             });
 
             it("should replace values in media queries", function() {
                 assert.equal(
-                    process("@value small: (max-width: 599px); @media small { }").css,
-                    "@media (max-width: 599px) { }"
+                    process(dedent(`
+                        @value small: (max-width: 599px);
+                        
+                        @media small { }
+                    `)).css,
+                    dedent(`
+                        @media (max-width: 599px) { }
+                    `)
                 );
             });
 
@@ -89,7 +128,12 @@ describe("/plugins", function() {
             
             it("should replace values in declarations", function() {
                 assert.equal(
-                    css.process(`@value color from "./local.css"; .wooga { color: color; }`, {
+                    css.process(dedent(`
+                        @value color from "./local.css";
+                        .wooga {
+                            color: color;
+                        }
+                    `), {
                         map   : false,
                         from  : path.resolve("./test/specimens/in.css"),
                         files : {
@@ -107,7 +151,11 @@ describe("/plugins", function() {
                             }
                         }
                     }).css,
-                    ".wooga { color: #F00; }"
+                    dedent(`
+                        .wooga {
+                            color: #F00;
+                        }
+                    `)
                 );
             });
         });
@@ -117,7 +165,12 @@ describe("/plugins", function() {
             
             it("should replace values in declarations", function() {
                 assert.equal(
-                    css.process(`@value * as colors from "./local.css"; .wooga { color: colors.red; }`, {
+                    css.process(dedent(`
+                        @value * as colors from "./local.css";
+                        .wooga {
+                            color: colors.red;
+                        }
+                    `), {
                         map   : false,
                         from  : path.resolve("./test/specimens/in.css"),
                         files : {
@@ -135,7 +188,11 @@ describe("/plugins", function() {
                             }
                         }
                     }).css,
-                    ".wooga { color: #F00; }"
+                    dedent(`
+                        .wooga {
+                            color: #F00;
+                        }
+                    `)
                 );
             });
         });
@@ -145,11 +202,16 @@ describe("/plugins", function() {
 
             it("should replace values in declarations", function() {
                 assert.equal(
-                    css.process(
-                        `@value * as colors from "./local.css";` +
-                        `@value red from "./local.css";` +
-                        `@value r: colors.red;` +
-                        `.wooga { color: colors.red; background: red; border: 1px solid r; }`, {
+                    css.process(dedent(`
+                        @value * as colors from "./local.css";
+                        @value red from "./local.css";
+                        @value r: colors.red;
+                        .wooga {
+                            color: colors.red;
+                            background: red;
+                            border: 1px solid r;
+                        }
+                    `), {
                         map   : false,
                         from  : path.resolve("./test/specimens/in.css"),
                         files : {
@@ -167,7 +229,13 @@ describe("/plugins", function() {
                             }
                         }
                     }).css,
-                    ".wooga { color: #F00; background: #F00; border: 1px solid #F00; }"
+                    dedent(`
+                        .wooga {
+                            color: #F00;
+                            background: #F00;
+                            border: 1px solid #F00;
+                        }
+                    `)
                 );
             });
         });

--- a/test/plugin.values-replace.test.js
+++ b/test/plugin.values-replace.test.js
@@ -4,6 +4,7 @@ var path   = require("path"),
     assert = require("assert"),
     
     postcss = require("postcss"),
+    dedent  = require("dentist").dedent,
 
     plugin     = require("../src/plugins/values-replace.js"),
     local      = require("../src/plugins/values-local.js"),
@@ -57,6 +58,28 @@ describe("/plugins", function() {
                 assert.equal(
                     process("@value small: (max-width: 599px); @media small { }").css,
                     "@media (max-width: 599px) { }"
+                );
+            });
+
+            it("should replace values surrounded by non-word characters (#245)", function() {
+                assert.equal(
+                    process(dedent(`
+                        @value one: 10px;
+                        @value two: calc(one - 2px);
+                        
+                        .a {
+                            height: two;
+                            width: -one;
+                            color: twoodle;
+                        }
+                    `)).css,
+                    dedent(`
+                        .a {
+                            height: calc(10px - 2px);
+                            width: -10px;
+                            color: twoodle;
+                        }
+                    `)
                 );
             });
         });

--- a/test/processor.options.test.js
+++ b/test/processor.options.test.js
@@ -4,7 +4,7 @@ var fs      = require("fs"),
     path    = require("path"),
     assert  = require("assert"),
     
-    leading = require("common-tags").stripIndent,
+    leading = require("dentist").dedent,
 
     Processor = require("../src/processor.js"),
     
@@ -101,10 +101,10 @@ describe("/processor.js", function() {
                     .then(() => processor.output())
                     .then((result) => assert.equal(
                         result.css,
-                        leading`
+                        leading(`
                             /* test/specimens/sync-before.css */
                             a {}
-                        `
+                        `)
                     ));
                 });
 
@@ -120,10 +120,10 @@ describe("/processor.js", function() {
                     .then(() => processor.output())
                     .then((result) => assert.equal(
                         result.css,
-                        leading`
+                        leading(`
                             /* test/specimens/async-before.css */
                             a {}
-                        `
+                        `)
                     ));
                 });
             });
@@ -150,14 +150,14 @@ describe("/processor.js", function() {
                     .then(() => processor.output({ to : "./test/output/relative.css" }))
                     .then((result) => assert.equal(
                         result.css,
-                        leading`
+                        leading(`
                             /* test/specimens/relative.css */
                             .mc592b2d8f_wooga {
                                 color: red;
                                 background: url("./folder/to.png")
                             }
                             a {}
-                        `
+                        `)
                     ));
                 });
                 
@@ -172,14 +172,14 @@ describe("/processor.js", function() {
                     .then(() => processor.output({ to : "./test/output/relative.css" }))
                     .then((result) => assert.equal(
                         result.css,
-                        leading`
+                        leading(`
                             /* test/specimens/relative.css */
                             .mc592b2d8f_wooga {
                                 color: red;
                                 background: url("./folder/to.png")
                             }
                             a {}
-                        `
+                        `)
                     ));
                 });
             });
@@ -197,10 +197,10 @@ describe("/processor.js", function() {
                     .then(() => processor.output())
                     .then((result) => assert.equal(
                         result.css,
-                        leading`
+                        leading(`
                             /* test/specimens/sync-done.css */
                             a {}
-                        `
+                        `)
                     ));
                 });
                 
@@ -216,10 +216,10 @@ describe("/processor.js", function() {
                     .then(() => processor.output())
                     .then((result) => assert.equal(
                         result.css,
-                        leading`
+                        leading(`
                             /* test/specimens/async-done.css */
                             a {}
-                        `
+                        `)
                     ));
                 });
             });

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -4,7 +4,7 @@ var fs      = require("fs"),
     path    = require("path"),
     assert  = require("assert"),
 
-    leading = require("common-tags").stripIndent,
+    leading = require("dentist").dedent,
     
     Processor = require("../src/processor.js"),
     
@@ -73,13 +73,13 @@ describe("/processor.js", function() {
             it("should scope classes, ids, and keyframes", function() {
                 return this.processor.string(
                     "./test/specimens/simple.css",
-                    leading`
+                    leading(`
                         @keyframes kooga { }
                         #fooga { }
                         .wooga { }
                         .one,
                         .two { }
-                    `
+                    `)
                 )
                 .then((result) => {
                     assert.deepEqual(result.exports, {
@@ -94,14 +94,14 @@ describe("/processor.js", function() {
                 .then((output) =>
                     assert.equal(
                         output.css,
-                        leading`
+                        leading(`
                             /* test/specimens/simple.css */
                             @keyframes mc08e91a5b_kooga {}
                             #mc08e91a5b_fooga {}
                             .mc08e91a5b_wooga {}
                             .mc08e91a5b_one,
                             .mc08e91a5b_two {}
-                        `
+                        `)
                     )
                 );
             });


### PR DESCRIPTION
Instead of matching on whole `word` blocks, match each `word` block w/ a regex composed of all available `value` names.

Fixes #245 