### PR TITLE
feat: Add support for custom resolvers

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "lodash.uniq": "^4.2.0",
     "meow": "^3.7.0",
     "mkdirp": "^0.5.1",
-    "p-series": "^1.0.0",
+    "p-each-series": "^1.0.0",
     "postcss": "^5.2.5",
     "postcss-selector-parser": "^2.0.0",
     "postcss-url": "^5.1.0",

--- a/src/plugins/externals.js
+++ b/src/plugins/externals.js
@@ -2,8 +2,7 @@
 
 var selector = require("postcss-selector-parser"),
 
-    parser  = require("../parsers/parser.js"),
-    resolve = require("../lib/resolve.js");
+    parser  = require("../parsers/parser.js");
 
 // Find :external(<rule> from <file>) references and update them to be
 // the namespaced selector instead
@@ -24,7 +23,7 @@ module.exports = (css, result) =>
                     }
 
                     try {
-                        source = result.opts.files[resolve(result.opts.from, parsed.source)];
+                        source = result.opts.files[result.opts.resolve(result.opts.from, parsed.source)];
                     } catch(e) {
                         // NO-OP
                     }

--- a/src/plugins/graph-nodes.js
+++ b/src/plugins/graph-nodes.js
@@ -2,8 +2,7 @@
 
 var selector = require("postcss-selector-parser"),
 
-    parser  = require("../parsers/parser.js"),
-    resolve = require("../lib/resolve.js");
+    parser  = require("../parsers/parser.js");
 
 function parse(options, rule, value) {
     var parsed, file;
@@ -20,7 +19,7 @@ function parse(options, rule, value) {
         return;
     }
     
-    file = resolve(options.from, parsed.source);
+    file = options.resolve(options.from, parsed.source);
     
     // Add any compositions to the dependency graph
     options.graph.addNode(file);

--- a/src/plugins/values-composed.js
+++ b/src/plugins/values-composed.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var parser  = require("../parsers/parser.js"),
-    resolve = require("../lib/resolve.js"),
     
     plugin = "modular-css-values-composed",
     offset = "@value ".length;
@@ -24,7 +23,7 @@ module.exports = (css, result) => {
         }
 
         try {
-            source = result.opts.files[resolve(result.opts.from, parsed.source)];
+            source = result.opts.files[result.opts.resolve(result.opts.from, parsed.source)];
         } catch(e) {
             // NO-OP
         }

--- a/src/plugins/values-namespaced.js
+++ b/src/plugins/values-namespaced.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var parser  = require("../parsers/parser.js"),
-    resolve = require("../lib/resolve.js"),
     
     plugin = "modular-css-values-namespaced",
     offset = "@value ".length;
@@ -24,7 +23,7 @@ module.exports = (css, result) => {
         }
 
         try {
-            source = result.opts.files[resolve(result.opts.from, parsed.source)];
+            source = result.opts.files[result.opts.resolve(result.opts.from, parsed.source)];
         } catch(e) {
             // NO-OP
         }

--- a/src/processor.js
+++ b/src/processor.js
@@ -119,7 +119,7 @@ Processor.prototype = {
                         file.result,
                         params(this, {
                             from  : dep,
-                            namer : this._options.namer,
+                            namer : this._options.namer
                         })
                     );
                 }

--- a/src/processor.js
+++ b/src/processor.js
@@ -25,9 +25,21 @@ function params(processor, args) {
         {
             files   : processor._files,
             graph   : processor._graph,
+            resolve : processor.resolve
         },
         args || Object.create(null)
     );
+}
+
+// Resolve a file using this._options.resolvers
+function resolver(processor, src, file) {
+    var result;
+    
+    processor._options.resolvers.some((fn) =>
+        (result = fn(src, file, resolve))
+    );
+    
+    return result || resolve(src, file);
 }
 
 function Processor(opts) {
@@ -54,6 +66,9 @@ function Processor(opts) {
     if(!Array.isArray(this._options.resolvers)) {
         this._options.resolvers = [];
     }
+
+    // Bind since it's being used from a different object
+    this.resolve = resolver.bind(null, this);
     
     this._files = Object.create(null);
     this._graph = new Graph();
@@ -226,7 +241,7 @@ Processor.prototype = {
     get files() {
         return this._files;
     },
-    
+
     // Process files and walk their composition/value dependency tree to find
     // new files we need to process
     _walk : function(name, text) {

--- a/test/plugin.externals.test.js
+++ b/test/plugin.externals.test.js
@@ -5,7 +5,8 @@ var path   = require("path"),
 
     postcss = require("postcss"),
     
-    plugin = require("../src/plugins/externals.js"),
+    plugin  = require("../src/plugins/externals.js"),
+    resolve = require("../src/lib/resolve.js"),
     
     processor = postcss([ plugin ]);
 
@@ -17,6 +18,8 @@ describe("/plugins", function() {
         // Helper to create environment where other files are already processed
         function process(css) {
             return processor.process(css, {
+                resolve,
+
                 from  : start,
                 files : {
                     // Composition source

--- a/test/plugin.graph-nodes.test.js
+++ b/test/plugin.graph-nodes.test.js
@@ -6,7 +6,8 @@ var path   = require("path"),
     postcss = require("postcss"),
     Graph   = require("dependency-graph").DepGraph,
     
-    plugin = require("../src/plugins/graph-nodes.js"),
+    plugin  = require("../src/plugins/graph-nodes.js"),
+    resolve = require("../src/lib/resolve.js"),
     
     processor = require("postcss")([ plugin ]);
 
@@ -20,7 +21,7 @@ describe("/plugins", function() {
             
             return processor.process(
                 `@value one from "./local.css";`,
-                { from, graph }
+                { from, graph, resolve }
             )
             .then(() => assert.deepEqual(graph.overallOrder(), [
                 path.resolve("./test/specimens/local.css"),
@@ -36,7 +37,7 @@ describe("/plugins", function() {
             
             return processor.process(
                 `.a { composes: booga from "./local.css"; }`,
-                { from, graph }
+                { from, graph, resolve }
             )
             .then(() => assert.deepEqual(graph.overallOrder(), [
                 path.resolve("./test/specimens/local.css"),
@@ -52,7 +53,7 @@ describe("/plugins", function() {
             
             return processor.process(
                 `.a :external(booga from "./local.css") { color: red; }`,
-                { from, graph }
+                { from, graph, resolve }
             )
             .then(() => assert.deepEqual(graph.overallOrder(), [
                 path.resolve("./test/specimens/local.css"),
@@ -68,7 +69,7 @@ describe("/plugins", function() {
             
             return processor.process(
                 `@value sm, md, lg "../../shared.css";`,
-                { from, graph }
+                { from, graph, resolve }
             )
             .catch((e) => assert(e.message.indexOf(`SyntaxError: Expected "from"`) > -1));
         });

--- a/test/plugin.values-composed.test.js
+++ b/test/plugin.values-composed.test.js
@@ -3,7 +3,8 @@
 var path   = require("path"),
     assert = require("assert"),
     
-    plugin = require("../src/plugins/values-composed.js"),
+    plugin  = require("../src/plugins/values-composed.js"),
+    resolve = require("../src/lib/resolve.js"),
     
     processor = require("postcss")([ plugin ]);
 
@@ -12,6 +13,8 @@ describe("/plugins", function() {
         // Helper to create environment where other files are already processed
         function process(css) {
             return processor.process(css, {
+                resolve,
+                
                 from  : path.resolve("./test/specimens/start.css"),
                 files : {
                     // Composition source

--- a/test/plugin.values-namespaced.test.js
+++ b/test/plugin.values-namespaced.test.js
@@ -3,7 +3,8 @@
 var path   = require("path"),
     assert = require("assert"),
     
-    plugin = require("../src/plugins/values-namespaced.js"),
+    plugin  = require("../src/plugins/values-namespaced.js"),
+    resolve = require("../src/lib/resolve.js"),
 
     processor = require("postcss")([ plugin ]);
 
@@ -12,6 +13,8 @@ describe("/plugins", function() {
         // Helper to create environment where other files are already processed
         function process(css) {
             return processor.process(css, {
+                resolve,
+                
                 from  : path.resolve("./test/specimens/start.css"),
                 files : {
                     // Composition source

--- a/test/plugin.values-replace.test.js
+++ b/test/plugin.values-replace.test.js
@@ -10,7 +10,9 @@ var path   = require("path"),
     local      = require("../src/plugins/values-local.js"),
     composed   = require("../src/plugins/values-composed.js"),
     exported   = require("../src/plugins/values-export.js"),
-    namespaced = require("../src/plugins/values-namespaced.js");
+    namespaced = require("../src/plugins/values-namespaced.js"),
+    
+    resolve = require("../src/lib/resolve.js");
 
 describe("/plugins", function() {
     describe("/values-replace.js", function() {
@@ -26,6 +28,8 @@ describe("/plugins", function() {
 
             function process(css) {
                 return processor.process(css, {
+                    resolve,
+                    
                     from  : "file",
                     files : {
                         "file" : {
@@ -134,6 +138,8 @@ describe("/plugins", function() {
                             color: color;
                         }
                     `), {
+                        resolve,
+                        
                         map   : false,
                         from  : path.resolve("./test/specimens/in.css"),
                         files : {
@@ -171,6 +177,8 @@ describe("/plugins", function() {
                             color: colors.red;
                         }
                     `), {
+                        resolve,
+
                         map   : false,
                         from  : path.resolve("./test/specimens/in.css"),
                         files : {
@@ -212,6 +220,8 @@ describe("/plugins", function() {
                             border: 1px solid r;
                         }
                     `), {
+                        resolve,
+                        
                         map   : false,
                         from  : path.resolve("./test/specimens/in.css"),
                         files : {

--- a/test/processor.methods.test.js
+++ b/test/processor.methods.test.js
@@ -202,5 +202,48 @@ describe("/processor.js", function() {
                 .then((result) => compare.stringToFile(result.css, "./test/results/processor/sorting.css"));
             });
         });
+
+        describe(".resolve()", function() {
+            it("should run resolvers until a match is found", function() {
+                var ran = false,
+
+                    processor = new Processor({
+                        resolvers : [
+                            () => {
+                                ran = true;
+                            },
+                            (src, file) => {
+                                return path.resolve(path.dirname(src), file);
+                            }
+                        ]
+                    });
+                
+                assert.equal(
+                    processor.resolve(
+                        require.resolve("./specimens/simple.css"),
+                        "./local.css"
+                    ),
+                    require.resolve("./specimens/local.css")
+                );
+
+                assert(ran);
+            });
+
+            it("should fall back to a default resolver", function() {
+                var processor = new Processor({
+                        resolvers : [
+                            () => {}
+                        ]
+                    });
+                
+                assert.equal(
+                    processor.resolve(
+                        require.resolve("./specimens/simple.css"),
+                        "./local.css"
+                    ),
+                    require.resolve("./specimens/local.css")
+                );
+            });
+        });
     });
 });


### PR DESCRIPTION
Fixes #246 

This is an implementation of the [proposal](https://github.com/tivac/modular-css/issues/246#issuecomment-280084923) in #246 of a way to specify multiple `resolver` functions for resolving file paths. Previously there was a single, hardcoded resolver that simply used the node resolution algorithm. The new method takes an array of potential resolvers and runs them in order until a non-falsey result is achieved. This matches very closely with how [rollup](https://github.com/rollup/rollup/wiki/Plugins#creating-plugins) handles 3rd party resolution and seems like a useful pattern to adopt.

I briefly toyed w/ the idea of making it compatible w/ rollup resolver plugins but decided it was too weird and unlikely to work.

This PR **does not** introduce any custom `resolvers`, it simply adds the framework for supporting their usage and necessary tests/updates to the existing codebase.

This is a semver-**minor** change, as the fallback behavior is to continue using the exact same resolution function as before.