### PR TITLE
fix: barf in a nicer manner for webpack

### DIFF
--- a/.dangerfile.js
+++ b/.dangerfile.js
@@ -18,16 +18,18 @@ function link(file, anchor) {
     return `<a href='${repo}/blob/${ref}/${file}${anchor || ""}'>${file}</a>`;
 }
 
-// Every JS file should start with "use strict";
-jsfiles.forEach((file) => {
-    var loc = fs.readFileSync(file, "utf8").indexOf(`"use strict";`);
+// Every non-specimen JS file should start with "use strict";
+jsfiles
+    .filter((file) => file.indexOf("test/specimens") === -1)
+    .forEach((file) => {
+        var loc = fs.readFileSync(file, "utf8").indexOf(`"use strict";`);
 
-    if(loc === 0) {
-        return;
-    }
+        if(loc === 0) {
+            return;
+        }
 
-    fail(`${link(file, "#L1")} does not declare strict mode immediately`);
-});
+        fail(`${link(file, "#L1")} does not declare strict mode immediately`);
+    });
 
 // Be careful of leaving testing shortcuts in the codebase
 jsfiles

--- a/src/processor.js
+++ b/src/processor.js
@@ -186,18 +186,22 @@ Processor.prototype = {
         // Rewrite relative URLs before adding
         // Have to do this every time because target file might be different!
         //
-        return Promise.all(files.map((dep) => this._after.process(
-            // NOTE: the call to .clone() is really important here, otherwise this call
-            // modifies the .result root itself and you process URLs multiple times
-            // See https://github.com/tivac/modular-css/issues/35
-            //
-            this._files[dep].result.root.clone(),
-            
-            params(this, {
-                from : dep,
-                to   : opts.to
-            })
-        )))
+        return Promise.all(files
+            // Protect from any files that errored out (#248)
+            .filter((dep) => dep in this._files && this._files[dep].result)
+            .map((dep) => this._after.process(
+                // NOTE: the call to .clone() is really important here, otherwise this call
+                // modifies the .result root itself and you process URLs multiple times
+                // See https://github.com/tivac/modular-css/issues/35
+                //
+                this._files[dep].result.root.clone(),
+                
+                params(this, {
+                    from : dep,
+                    to   : opts.to
+                })
+            ))
+        )
         .then((results) => {
             var root = postcss.root();
 

--- a/src/webpack-loader.js
+++ b/src/webpack-loader.js
@@ -8,14 +8,14 @@ module.exports = function(source) {
 
     this.cacheable();
 
-    processor.string(this.resourcePath, source)
+    return processor.string(this.resourcePath, source)
         .then((result) => {
             processor.dependencies(this.resourcePath).forEach((dep) => this.addDependency(dep));
             
-            done(
+            return done(
                 null,
                 `module.exports = ${JSON.stringify(output.join(result.exports), null, 4)};`
             );
         })
-        .catch((error) => done(error));
+        .catch(done);
 };

--- a/test/issue-248.test.js
+++ b/test/issue-248.test.js
@@ -1,0 +1,43 @@
+"use strict";
+
+var path   = require("path"),
+    assert = require("assert"),
+
+    webpack = require("webpack"),
+
+    Plugin  = require("../src/webpack-plugin.js"),
+    
+    use  = path.resolve("./src/webpack-loader.js"),
+    test = /\.css$/;
+
+describe("/issues", function() {
+    describe("/248", function() {
+        it("should output css to disk", function(done) {
+            webpack({
+                entry   : "./test/specimens/issues/248/index.js",
+                output  : {
+                    path : path.resolve("./test/output/webpack"),
+                    filename : "./issue-248.js"
+                },
+                module : {
+                    rules : [
+                        {
+                            test,
+                            use
+                        }
+                    ]
+                },
+                plugins : [
+                    new Plugin({
+                        css : "./issue-248.css"
+                    })
+                ]
+            }, (err, stats) => {
+                // I don't understand why err is null here?
+                assert.equal(stats.hasErrors(), true);
+
+                done();
+            });
+        });
+    });
+});

--- a/test/specimens/issues/248/index.css
+++ b/test/specimens/issues/248/index.css
@@ -1,0 +1,3 @@
+.a {
+    composes: a from "./not-a-file.css";
+}

--- a/test/specimens/issues/248/index.js
+++ b/test/specimens/issues/248/index.js
@@ -1,0 +1,1 @@
+require("./index.css");


### PR DESCRIPTION
Fixes #248 

When a loader calls the callback with an error, webpack apparently just marks it and continues on its merry way. This meant that `processor.output()` was being invoked with an incomplete set of `._files` since it assumed that errors would bail on whatever was using it.

It now filters out invalid `._files` entries before trying to process them. Not sure that's the right behavior, but it does prevent this particular explosion. If someone w/ more webpack experience wants to explain a better way to handle this I'm all 👂s!