### PR TITLE
Add modular-css-paths to solve pathing pain

### DIFF
--- a/packages/core/lib/resolve.js
+++ b/packages/core/lib/resolve.js
@@ -2,15 +2,25 @@
 
 var path = require("path"),
 
-    find = require("resolve-from");
+    resolve = require("resolve-from");
 
-module.exports = function resolve(src, file) {
-    var dir   = path.dirname(src),
-        found = find(dir, file);
+exports.resolve = (src, file) =>
+    resolve(path.dirname(src), file);
 
-    if(!found) {
-        throw new Error("Unable to locate \"" + file + "\" from \"" + dir + "\"");
-    }
+exports.resolvers = (resolvers) => {
+    resolvers.push(exports.resolve);
     
-    return found;
+    return (src, file) => {
+        var result;
+    
+        resolvers.some((fn) =>
+            (result = fn(src, file, exports.resolve))
+        );
+        
+        if(!result) {
+            throw new Error(`Unable to locate "${file}" from "${src}"`);
+        }
+
+        return result;
+    };
 };

--- a/packages/core/plugins/composition.js
+++ b/packages/core/plugins/composition.js
@@ -7,7 +7,6 @@ var Graph = require("dependency-graph").DepGraph,
     mapvalues = require("lodash.mapvalues"),
 
     message     = require("../lib/message.js"),
-    resolve     = require("../lib/resolve.js").resolve,
     identifiers = require("../lib/identifiers.js"),
     
     parser = require("../parsers/parser.js"),
@@ -48,7 +47,7 @@ module.exports = (css, result) => {
         }
 
         if(details.source) {
-            details.source = resolve(opts.from, details.source);
+            details.source = opts.resolve(opts.from, details.source);
 
             if(!opts.files || !opts.files[details.source]) {
                 throw decl.error("Invalid file reference", { word : decl.value });

--- a/packages/core/plugins/composition.js
+++ b/packages/core/plugins/composition.js
@@ -7,7 +7,7 @@ var Graph = require("dependency-graph").DepGraph,
     mapvalues = require("lodash.mapvalues"),
 
     message     = require("../lib/message.js"),
-    resolve     = require("../lib/resolve.js"),
+    resolve     = require("../lib/resolve.js").resolve,
     identifiers = require("../lib/identifiers.js"),
     
     parser = require("../parsers/parser.js"),

--- a/packages/core/processor.js
+++ b/packages/core/processor.js
@@ -25,21 +25,10 @@ function params(processor, args) {
         {
             files   : processor._files,
             graph   : processor._graph,
-            resolve : processor.resolve
+            resolve : processor._resolve
         },
         args || Object.create(null)
     );
-}
-
-// Resolve a file using this._options.resolvers
-function resolver(processor, src, file) {
-    var result;
-    
-    processor._options.resolvers.some((fn) =>
-        (result = fn(src, file, resolve))
-    );
-    
-    return result || resolve(src, file);
 }
 
 function Processor(opts) {
@@ -67,9 +56,8 @@ function Processor(opts) {
         this._options.resolvers = [];
     }
 
-    // Bind since it's being used from a different object
-    this.resolve = resolver.bind(null, this);
-    
+    this._resolve = resolve.resolvers(this._options.resolvers);
+
     this._files = Object.create(null);
     this._graph = new Graph();
     

--- a/packages/core/test/issue-191.test.js
+++ b/packages/core/test/issue-191.test.js
@@ -5,7 +5,7 @@ var fs     = require("fs"),
     
     compare = require("./lib/compare.js"),
 
-    Processor = require("..//processor.js");
+    Processor = require("../processor.js");
 
 describe("/issues", function() {
     describe("/191", function() {

--- a/packages/core/test/issue-24.test.js
+++ b/packages/core/test/issue-24.test.js
@@ -5,7 +5,7 @@ var path   = require("path"),
     
     leading = require("dentist").dedent,
 
-    Processor = require("..//processor.js");
+    Processor = require("../processor.js");
 
 describe("/issues", function() {
     describe("/24", function() {

--- a/packages/core/test/issue-56.test.js
+++ b/packages/core/test/issue-56.test.js
@@ -4,7 +4,7 @@ var assert = require("assert"),
 
     leading = require("dentist").dedent,
     
-    Processor = require("..//processor.js"),
+    Processor = require("../processor.js"),
     compare   = require("./lib/compare.js");
 
 describe("/issues", function() {

--- a/packages/core/test/issue-66.test.js
+++ b/packages/core/test/issue-66.test.js
@@ -2,7 +2,7 @@
 
 var assert = require("assert"),
     
-    Processor = require("..//processor.js");
+    Processor = require("../processor.js");
 
 describe("/issues", function() {
     describe("/66", function() {

--- a/packages/core/test/issue-98.test.js
+++ b/packages/core/test/issue-98.test.js
@@ -4,7 +4,7 @@ var assert    = require("assert"),
 
     leading = require("dentist").dedent,
     
-    Processor = require("..//processor.js"),
+    Processor = require("../processor.js"),
     compare   = require("./lib/compare.js");
 
 describe("/issues", function() {

--- a/packages/core/test/keyframes.test.js
+++ b/packages/core/test/keyframes.test.js
@@ -5,8 +5,8 @@ var path   = require("path"),
 
     postcss = require("postcss"),
     
-    scoping   = require("..//plugins/scoping.js"),
-    keyframes = require("..//plugins/keyframes.js");
+    scoping   = require("../plugins/scoping.js"),
+    keyframes = require("../plugins/keyframes.js");
 
 function namer(file, selector) {
     return `${path.basename(file, path.extname(file))}_${selector}`;

--- a/packages/core/test/lib.identifiers.test.js
+++ b/packages/core/test/lib.identifiers.test.js
@@ -2,7 +2,7 @@
 
 var assert = require("assert"),
 
-    identifiers = require("..//lib/identifiers.js");
+    identifiers = require("../lib/identifiers.js");
 
 describe("/lib", function() {
     describe("/identifiers.js", function() {

--- a/packages/core/test/lib.message.test.js
+++ b/packages/core/test/lib.message.test.js
@@ -2,7 +2,7 @@
 
 var assert = require("assert"),
 
-    message   = require("..//lib/message.js");
+    message   = require("../lib/message.js");
 
 describe("/lib", function() {
     describe("/message.js", function() {

--- a/packages/core/test/lib.output.test.js
+++ b/packages/core/test/lib.output.test.js
@@ -2,8 +2,8 @@
 
 var assert = require("assert"),
 
-    Processor = require("..//processor.js"),
-    output   = require("..//lib/output.js");
+    Processor = require("../processor.js"),
+    output   = require("../lib/output.js");
 
 function compositions(css) {
     var processor = new Processor();

--- a/packages/core/test/lib.relative.test.js
+++ b/packages/core/test/lib.relative.test.js
@@ -3,7 +3,7 @@
 var path   = require("path"),
     assert = require("assert"),
     
-    relative = require("..//lib/relative.js");
+    relative = require("../lib/relative.js");
 
 describe("/lib", function() {
     describe("/relative.js", function() {

--- a/packages/core/test/lib/relative.js
+++ b/packages/core/test/lib/relative.js
@@ -1,3 +1,3 @@
 "use strict";
 
-module.exports = require("../..//lib/relative.js").bind(null, process.cwd());
+module.exports = require("../../lib/relative.js").bind(null, process.cwd());

--- a/packages/core/test/plugin.composition.test.js
+++ b/packages/core/test/plugin.composition.test.js
@@ -68,18 +68,9 @@ describe("/plugins", function() {
             assert.throws(() => out.css, /Invalid file reference/);
         });
 
-        it("should fail if composing from a file that doesn't exist", function() {
-            var out = process(".wooga { composes: googa from \"./fooga.css\"; }", {
-                    from  : "test/specimens/wooga.css",
-                    files : {}
-                });
-            
-            assert.throws(() => out.css, /Unable to locate/);
-        });
-
         it("should fail if non-existant imports are referenced", function() {
             var files = {},
-                out;
+            out;
                 
             files[path.resolve("./test/specimens/local.css")] = {
                 exports : {}

--- a/packages/core/test/plugin.composition.test.js
+++ b/packages/core/test/plugin.composition.test.js
@@ -5,8 +5,8 @@ var path   = require("path"),
 
     postcss = require("postcss"),
     
-    scoping     = require("..//plugins/scoping.js"),
-    composition = require("..//plugins/composition.js");
+    scoping     = require("../plugins/scoping.js"),
+    composition = require("../plugins/composition.js");
 
 function msg(classes) {
     return {

--- a/packages/core/test/plugin.composition.test.js
+++ b/packages/core/test/plugin.composition.test.js
@@ -5,6 +5,8 @@ var path   = require("path"),
 
     postcss = require("postcss"),
     
+    resolve = require("../lib/resolve.js").resolve,
+
     scoping     = require("../plugins/scoping.js"),
     composition = require("../plugins/composition.js");
 
@@ -23,10 +25,15 @@ describe("/plugins", function() {
         beforeEach(function() {
             var processor = postcss([ scoping, composition ]);
             
-            process = (css, opts) => processor.process(css, Object.assign(Object.create(null), {
-                namer : (file, selector) =>
-                    file ? `${path.basename(file, path.extname(file))}_${selector}` : selector
-            }, opts));
+            process = (css, opts) => processor.process(css, Object.assign(
+                Object.create(null),
+                {
+                    resolve,
+                    namer : (file, selector) =>
+                        file ? `${path.basename(file, path.extname(file))}_${selector}` : selector
+                },
+                opts
+            ));
         });
 
         it("should fail if the selector is not a simple, singular selector", function() {

--- a/packages/core/test/plugin.externals.test.js
+++ b/packages/core/test/plugin.externals.test.js
@@ -5,8 +5,8 @@ var path   = require("path"),
 
     postcss = require("postcss"),
     
-    plugin  = require("..//plugins/externals.js"),
-    resolve = require("..//lib/resolve.js"),
+    plugin  = require("../plugins/externals.js"),
+    resolve = require("../lib/resolve.js").resolve,
     
     processor = postcss([ plugin ]);
 

--- a/packages/core/test/plugin.graph-nodes.test.js
+++ b/packages/core/test/plugin.graph-nodes.test.js
@@ -6,8 +6,8 @@ var path   = require("path"),
     postcss = require("postcss"),
     Graph   = require("dependency-graph").DepGraph,
     
-    plugin  = require("..//plugins/graph-nodes.js"),
-    resolve = require("..//lib/resolve.js"),
+    plugin  = require("../plugins/graph-nodes.js"),
+    resolve = require("../lib/resolve.js").resolve,
     
     processor = require("postcss")([ plugin ]);
 

--- a/packages/core/test/plugin.scoping.test.js
+++ b/packages/core/test/plugin.scoping.test.js
@@ -5,7 +5,7 @@ var path   = require("path"),
     
     leading = require("dentist").dedent,
 
-    plugin = require("..//plugins/scoping.js"),
+    plugin = require("../plugins/scoping.js"),
     
     processor = require("postcss")([ plugin ]);
 

--- a/packages/core/test/plugin.values-composed.test.js
+++ b/packages/core/test/plugin.values-composed.test.js
@@ -3,8 +3,8 @@
 var path   = require("path"),
     assert = require("assert"),
     
-    plugin  = require("..//plugins/values-composed.js"),
-    resolve = require("..//lib/resolve.js"),
+    plugin  = require("../plugins/values-composed.js"),
+    resolve = require("../lib/resolve.js").resolve,
     
     processor = require("postcss")([ plugin ]);
 

--- a/packages/core/test/plugin.values-local.test.js
+++ b/packages/core/test/plugin.values-local.test.js
@@ -2,7 +2,7 @@
 
 var assert = require("assert"),
     
-    plugin = require("..//plugins/values-local.js"),
+    plugin = require("../plugins/values-local.js"),
     
     processor = require("postcss")([ plugin ]);
 

--- a/packages/core/test/plugin.values-namespaced.test.js
+++ b/packages/core/test/plugin.values-namespaced.test.js
@@ -3,8 +3,8 @@
 var path   = require("path"),
     assert = require("assert"),
     
-    plugin  = require("..//plugins/values-namespaced.js"),
-    resolve = require("..//lib/resolve.js"),
+    plugin  = require("../plugins/values-namespaced.js"),
+    resolve = require("../lib/resolve.js").resolve,
 
     processor = require("postcss")([ plugin ]);
 

--- a/packages/core/test/plugin.values-replace.test.js
+++ b/packages/core/test/plugin.values-replace.test.js
@@ -12,7 +12,7 @@ var path   = require("path"),
     exported   = require("../plugins/values-export.js"),
     namespaced = require("../plugins/values-namespaced.js"),
     
-    resolve = require("..//lib/resolve.js");
+    resolve = require("../lib/resolve.js").resolve;
 
 describe("/plugins", function() {
     describe("/values-replace.js", function() {

--- a/packages/core/test/plugin.values-replace.test.js
+++ b/packages/core/test/plugin.values-replace.test.js
@@ -6,11 +6,11 @@ var path   = require("path"),
     postcss = require("postcss"),
     dedent  = require("dentist").dedent,
 
-    plugin     = require("..//plugins/values-replace.js"),
-    local      = require("..//plugins/values-local.js"),
-    composed   = require("..//plugins/values-composed.js"),
-    exported   = require("..//plugins/values-export.js"),
-    namespaced = require("..//plugins/values-namespaced.js"),
+    plugin     = require("../plugins/values-replace.js"),
+    local      = require("../plugins/values-local.js"),
+    composed   = require("../plugins/values-composed.js"),
+    exported   = require("../plugins/values-export.js"),
+    namespaced = require("../plugins/values-namespaced.js"),
     
     resolve = require("..//lib/resolve.js");
 

--- a/packages/core/test/processor.methods.test.js
+++ b/packages/core/test/processor.methods.test.js
@@ -203,7 +203,7 @@ describe("/processor.js", function() {
             });
         });
 
-        describe(".resolve()", function() {
+        describe("._resolve()", function() {
             it("should run resolvers until a match is found", function() {
                 var ran = false,
 
@@ -219,7 +219,7 @@ describe("/processor.js", function() {
                     });
                 
                 assert.equal(
-                    processor.resolve(
+                    processor._resolve(
                         require.resolve("./specimens/simple.css"),
                         "./local.css"
                     ),
@@ -237,7 +237,7 @@ describe("/processor.js", function() {
                     });
                 
                 assert.equal(
-                    processor.resolve(
+                    processor._resolve(
                         require.resolve("./specimens/simple.css"),
                         "./local.css"
                     ),

--- a/packages/core/test/processor.methods.test.js
+++ b/packages/core/test/processor.methods.test.js
@@ -4,7 +4,7 @@ var fs      = require("fs"),
     path    = require("path"),
     assert  = require("assert"),
     
-    Processor = require("..//processor.js"),
+    Processor = require("../processor.js"),
     
     compare = require("./lib/compare.js");
 

--- a/packages/core/test/processor.options.test.js
+++ b/packages/core/test/processor.options.test.js
@@ -6,7 +6,7 @@ var fs      = require("fs"),
     
     leading = require("dentist").dedent,
 
-    Processor = require("..//processor.js"),
+    Processor = require("../processor.js"),
     
     compare = require("./lib/compare.js");
 

--- a/packages/core/test/processor.test.js
+++ b/packages/core/test/processor.test.js
@@ -6,7 +6,7 @@ var fs      = require("fs"),
 
     leading = require("dentist").dedent,
     
-    Processor = require("..//processor.js"),
+    Processor = require("../processor.js"),
     
     compare = require("./lib/compare.js");
 

--- a/packages/core/test/processor.test.js
+++ b/packages/core/test/processor.test.js
@@ -50,14 +50,15 @@ describe("/processor.js", function() {
         });
         
         describe("bad imports", function() {
-            var invalid = `Unable to locate "../local.css" from "${path.resolve("invalid")}"`;
-            
             it("should fail if a value imports a non-existant reference", function() {
                 return this.processor.string(
                     "./invalid/value.css",
                     "@value not-real from \"../local.css\";"
                 )
-                .catch((error) => assert.equal(error.message, invalid));
+                .catch((error) => assert.equal(
+                    error.message,
+                    `Unable to locate "../local.css" from "${path.resolve("./invalid/value.css")}"`
+                ));
             });
             
             it("should fail if a composition imports a non-existant reference", function() {
@@ -65,7 +66,10 @@ describe("/processor.js", function() {
                     "./invalid/composition.css",
                     ".wooga { composes: fake from \"../local.css\"; }"
                 )
-                .catch((error) => assert.equal(error.message, invalid));
+                .catch((error) => assert.equal(
+                    error.message,
+                    `Unable to locate "../local.css" from "${path.resolve("./invalid/composition.css")}"`
+                ));
             });
         });
 

--- a/packages/paths/.npmignore
+++ b/packages/paths/.npmignore
@@ -1,0 +1,4 @@
+coverage/
+profiling/
+test/
+.*

--- a/packages/paths/LICENSE
+++ b/packages/paths/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Pat Cavit
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/paths/README.md
+++ b/packages/paths/README.md
@@ -1,0 +1,40 @@
+modular-css-paths  [![NPM Version](https://img.shields.io/npm/v/modular-css-paths.svg)](https://www.npmjs.com/package/modular-css-paths) [![NPM License](https://img.shields.io/npm/l/modular-css-paths.svg)](https://www.npmjs.com/package/modular-css-paths) [![NPM Downloads](https://img.shields.io/npm/dm/modular-css-paths.svg)](https://www.npmjs.com/package/modular-css-paths) [![Build Status](https://img.shields.io/travis/tivac/modular-css/master.svg)](https://travis-ci.org/tivac/modular-css)
+===========
+
+A resolver for `modular-css` that will let you resolve file references against arbitrary paths. Useful to avoid code like
+
+```css
+@value foo from "../../../../../../../../some/other/directory/file.css";
+```
+
+which is annoying to write, annoying to read, and also super-brittle.
+
+## Install
+
+`$ npm i modular-css-paths`
+
+## Usage
+
+Pass as part of the `resolvers` array in the `modular-css` options (via JS API/Rollup/Browserify/WebPack/etc). When `modular-css` is trying to resolve `@value` or `composes` file references it'll use the default node resolution algorithm against whichever paths you specified.
+
+```js
+var Processor = require("modular-css-core"),
+    paths     = require("modular-css-paths")
+
+    processor = new Processor({
+        resolvers : [
+            paths({
+                paths : [
+                    "./path/one",
+                    "../../some/other/path"
+                ]
+            })
+        ]
+    });
+```
+
+### Options
+
+#### `paths`
+
+An array of string file paths, they can be relative to the `cwd` of the `Processor` instance or absolute paths.

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "modular-css-paths",
+  "version": "4.1.0",
+  "description": "A streamlined reinterpretation of CSS Modules via CLI, API, Browserify, Rollup, Webpack, or PostCSS",
+  "main": "./paths.js",
+  "repository": "tivac/modular-css",
+  "bugs": {
+    "url": "https://github.com/tivac/modular-css/issues"
+  },
+  "scripts": {
+    "cover": "nyc mocha",
+    "test": "mocha"
+  },
+  "author": "Pat Cavit <npm@patcavit.com>",
+  "license": "MIT",
+  "keywords": [
+    "css",
+    "css-modules",
+    "modular-css",
+    "paths"
+  ],
+  "devDependencies": {
+    "dentist": "^1.0.3",
+    "mocha": "^3.2.0",
+    "nyc": "^10.1.2",
+    "test-utils": "^4.0.4",
+    "modular-css-core": "^4.0.4"
+  },
+  "dependencies": {
+    "resolve-from": "^2.0.0"
+  }
+}

--- a/packages/paths/paths.js
+++ b/packages/paths/paths.js
@@ -1,0 +1,25 @@
+"use strict";
+
+var from = require("resolve-from");
+
+module.exports = function(args) {
+    var options = Object.assign(
+            Object.create(null),
+            {
+                paths : []
+            },
+            args
+        );
+    
+    options.paths = options.paths.map((dir) => from.bind(null, dir));
+
+    return (src, file) => {
+        var result;
+
+        options.paths.some((fn) =>
+            (result = fn(file))
+        );
+        
+        return result;
+    };
+};

--- a/packages/paths/test/paths.test.js
+++ b/packages/paths/test/paths.test.js
@@ -1,0 +1,74 @@
+"use strict";
+
+var assert = require("assert"),
+
+    dedent = require("dentist").dedent,
+    
+    Processor = require("modular-css-core"),
+
+    paths = require("../paths.js");
+
+describe("/paths.js", function() {
+    it("should return a falsey value if a file isn't found", function() {
+        var fn = paths({
+            paths : [
+                "./test/specimens"
+            ]
+        });
+
+        assert.ok(!fn(".", "./fooga.css"));
+    });
+
+    it("should return the absolute path if a file is found", function() {
+        var fn = paths({
+            paths : [
+                "./test/specimens/one"
+            ]
+        });
+
+        assert.equal(
+            fn(".", "./one.css"),
+            require.resolve("./specimens/one/one.css")
+        );
+    });
+
+    it("should check multiple paths for files & return the first match", function() {
+        var fn = paths({
+            paths : [
+                "./test/specimens/one",
+                "./test/specimens/one/sub"
+            ]
+        });
+
+        assert.equal(
+            fn(".", "./sub.css"),
+            require.resolve("./specimens/one/sub/sub.css")
+        );
+    });
+
+    it("should be usable as a modular-css resolver", function() {
+        var processor = new Processor({
+                resolvers : [
+                    paths({
+                        paths : [
+                            "./test/specimens/one/sub",
+                            "./test/specimens/two"
+                        ]
+                    })
+                ]
+            });
+        
+        return processor.string(
+            "./test/one/start.css",
+            dedent(`
+                @value sub from "./sub.css";
+                
+                .rule {
+                    composes: two from "./two.css";
+                }
+            `)
+        )
+        .then(() => processor.output())
+        .then((result) => console.log(result));
+    });
+});

--- a/packages/paths/test/paths.test.js
+++ b/packages/paths/test/paths.test.js
@@ -59,7 +59,7 @@ describe("/paths.js", function() {
             });
         
         return processor.string(
-            "./test/one/start.css",
+            "./test/specimens/one/start.css",
             dedent(`
                 @value sub from "./sub.css";
                 
@@ -69,6 +69,21 @@ describe("/paths.js", function() {
             `)
         )
         .then(() => processor.output())
-        .then((result) => console.log(result));
+        .then((result) => assert.deepEqual(
+            result.compositions,
+            {
+                "test/specimens/one/start.css" : {
+                    rule : "mc16fc57c4_two mc2632bbcb_rule"
+                },
+
+                "test/specimens/one/sub/sub.css" : {
+                    "sub" : "mc8e516949_sub"
+                },
+
+                "test/specimens/two/two.css" : {
+                    "two" : "mc16fc57c4_two"
+                }
+            }
+        ));
     });
 });

--- a/packages/paths/test/specimens/one/one.css
+++ b/packages/paths/test/specimens/one/one.css
@@ -1,0 +1,3 @@
+@value one: "one";
+
+.one { color: red; }

--- a/packages/paths/test/specimens/one/sub/sub.css
+++ b/packages/paths/test/specimens/one/sub/sub.css
@@ -1,0 +1,3 @@
+@value sub: "sub";
+
+.sub { color: blue; }

--- a/packages/paths/test/specimens/two/two.css
+++ b/packages/paths/test/specimens/two/two.css
@@ -1,0 +1,3 @@
+@value two: "two";
+
+.two { color: blue; }

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "postcss-modular-css",
   "version": "4.1.0",
-  "description": "A streamlined reinterpretation of CSS Modules via CLI, API, Browserify, Rollup, Webpack, or PostCSS",
+  "description": "Use modular-css via postcss",
   "main": "./postcss.js",
   "repository": "tivac/modular-css",
   "bugs": {


### PR DESCRIPTION
Fixes #252, inspired by #246

This is the first (that I know of) `modular-css` resolver function. Likely to also be the **only** one for a good long while but who knows what people might need someday?

From the readme:

```js
var Processor = require("modular-css-core"),
    paths     = require("modular-css-paths")

    processor = new Processor({
        resolvers : [
            paths({
                paths : [
                    "./path/one",
                    "../../some/other/path"
                ]
            })
        ]
    });
```

Now any `@value` or `composes` rule that references a file will attempt to resolve against `./path/one` and `../../some/other/path` (relative to the `cwd`, which in this case will just be `process.cwd()`) before attempting to resolve against the directory of the including file.

Death to `../../../../../../../../`! :tada: