### PR TITLE
Fix dependencies going missing with rollup

### DIFF
--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -25,6 +25,7 @@
     "mocha": "^3.2.0",
     "nyc": "^10.1.2",
     "rollup": "^0.41.4",
+    "rollup-watch": "^3.2.2",
     "shelljs": "^0.7.3",
     "test-utils": "^4.0.9"
   },

--- a/packages/rollup/test/results/rollup/watch1.css
+++ b/packages/rollup/test/results/rollup/watch1.css
@@ -1,0 +1,4 @@
+/* test/output/watched.css */
+.mcbb92782a_one {
+    color: red
+}

--- a/packages/rollup/test/results/rollup/watch2.css
+++ b/packages/rollup/test/results/rollup/watch2.css
@@ -1,0 +1,4 @@
+/* test/output/watched.css */
+.mcbb92782a_two {
+    color: blue
+}

--- a/packages/rollup/test/specimens/rollup/watch.js
+++ b/packages/rollup/test/specimens/rollup/watch.js
@@ -1,0 +1,3 @@
+import css from "../../output/watched.css";
+
+console.log(css);


### PR DESCRIPTION
A slightly hacky fix I introduced to work around #158 ended up finally having some consequences, so going back to the other hacky fix which should be a bit safer.

Fixes #265 