### PR TITLE
More flexible postcss support for options

### DIFF
--- a/packages/core/processor.js
+++ b/packages/core/processor.js
@@ -238,6 +238,11 @@ Processor.prototype = {
         return this._files;
     },
 
+    // Expose combined options object
+    get options() {
+        return this._options;
+    },
+
     // Process files and walk their composition/value dependency tree to find
     // new files we need to process
     _walk : function(name, text) {

--- a/packages/core/test/processor.test.js
+++ b/packages/core/test/processor.test.js
@@ -48,6 +48,12 @@ describe("/processor.js", function() {
                     });
                 });
             });
+
+            describe(".options", function() {
+                it("should return the merged options object", function() {
+                    expect(typeof this.processor.options).toBe("object");
+                });
+            });
         });
         
         describe("bad imports", function() {

--- a/packages/postcss/postcss.js
+++ b/packages/postcss/postcss.js
@@ -12,8 +12,8 @@ module.exports = postcss.plugin("modular-css", (opts) =>
     (root, result) => {
         var processor = new Processor(Object.assign(
                 Object.create(null),
-                opts || /* istanbul ignore next */ {},
-                result.opts || /* istanbul ignore next */ {}
+                opts || {},
+                result.opts || {}
             )),
             classes;
 
@@ -24,15 +24,18 @@ module.exports = postcss.plugin("modular-css", (opts) =>
                 return processor.output();
             })
             .then((output) => {
+                var json = processor.options.json;
+                
                 result.messages.push({
                     type    : "modular-css-exports",
                     exports : classes
                 });
                 
-                if(result.opts.json) {
-                    mkdirp.sync(path.dirname(result.opts.json));
+                if(json) {
+                    mkdirp.sync(path.dirname(json));
+                    
                     fs.writeFileSync(
-                        result.opts.json,
+                        json,
                         JSON.stringify(output.compositions, null, 4)
                     );
                 }

--- a/packages/postcss/test/postcss.test.js
+++ b/packages/postcss/test/postcss.test.js
@@ -127,4 +127,21 @@ describe("/postcss.js", function() {
         )
         .then(() => compare.results("simple.json"));
     });
+
+    it("should accept json args in either position with postcss", function() {
+        var processor = postcss([
+            plugin({
+                namer,
+                json : "./packages/postcss/test/output/simple.json"
+            })
+        ]);
+        
+        return processor.process(
+            fs.readFileSync("./packages/postcss/test/specimens/simple.css"),
+            {
+                from : "./packages/postcss/test/specimens/simple.css"
+            }
+        )
+        .then(() => compare.results("simple.json"));
+    });
 });


### PR DESCRIPTION
PostCSS plugins can get options two ways, previously `postcss-modular-css` only really supported one of those ways for the `json` option. Now it supports both.

Also exposed the already-merged `processor.options` value as a getter because it simplified this.

See #270 for the original issue.