### PR TITLE
fix: allow comments before composes in a rule

### DIFF
--- a/packages/core/test/__snapshots__/plugin.composition.test.js.snap
+++ b/packages/core/test/__snapshots__/plugin.composition.test.js.snap
@@ -1,5 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`/plugins /composition.js should allow comments before composes 1`] = `
+Array [
+  Object {
+    "classes": Object {
+      "a": Array [
+        "a",
+      ],
+      "b": Array [
+        "b",
+      ],
+      "c": Array [
+        "c",
+      ],
+    },
+    "plugin": "modular-css-scoping",
+    "type": "modular-css",
+  },
+  Object {
+    "classes": Object {
+      "a": Array [
+        "a",
+      ],
+      "b": Array [
+        "b",
+      ],
+      "c": Array [
+        "a",
+        "b",
+        "c",
+      ],
+    },
+    "plugin": "modular-css-composition",
+    "type": "modular-css",
+  },
+]
+`;
+
 exports[`/plugins /composition.js should allow multiple composes declarations 1`] = `
 Array [
   Object {

--- a/packages/core/test/plugin.composition.test.js
+++ b/packages/core/test/plugin.composition.test.js
@@ -55,6 +55,28 @@ describe("/plugins", function() {
             
             expect(() => out.css).toThrow(/composes must be the first declaration/);
         });
+
+        it("should allow comments before composes", function() {
+            expect(process(dedent(`
+                .a {
+                    color: red;
+                }
+
+                .b {
+                    color: blue;
+                }
+
+                .c {
+                    /* Comment */
+                    /* Comment */
+                    /* Comment */
+                    composes: a;
+                    /* Comment */
+                    composes: b;
+                }
+            `)).messages)
+            .toMatchSnapshot();
+        });
         
         it("should fail if classes have a cyclic dependency", function() {
             var out = process(".a { composes: b; } .b { composes: a; }");


### PR DESCRIPTION
Fixes #273 

Also loop through EVERY previous declaration, just in case. Doing a bit more work but it's probably worth it to ensure nothing nasty is sneaking in.