### PR TITLE
Use ES2015 exports in webpack

### DIFF
--- a/packages/webpack/loader.js
+++ b/packages/webpack/loader.js
@@ -2,8 +2,7 @@
 
 var keyword = require("esutils").keyword,
     
-    output   = require("modular-css-core/lib/output.js"),
-    relative = require("modular-css-core/lib/relative.js");
+    output = require("modular-css-core/lib/output.js");
 
 module.exports = function(source) {
     var done      = this.async(),
@@ -14,16 +13,12 @@ module.exports = function(source) {
     return processor.string(this.resourcePath, source)
         .then((result) => {
             var classes = output.join(result.exports),
-                deps    = processor.dependencies(this.resourcePath),
-                imports = deps.map((file) =>
-                    `import "${relative.prefixed(this.context, file)}";`
-                );
+                deps    = processor.dependencies(this.resourcePath);
 
             deps.forEach((dep) => this.addDependency(dep));
             
             return done(
                 null,
-                (imports.length ? `${imports.join("\n")}\n` : "") +
                 Object.keys(classes).reduce(
                     (prev, curr) => {
                         // Warn if any of the exported CSS wasn't able to be used as a valid JS identifier

--- a/packages/webpack/loader.js
+++ b/packages/webpack/loader.js
@@ -1,6 +1,11 @@
 "use strict";
 
-var output = require("modular-css-core/lib/output.js");
+var path = require("path"),
+
+    keyword = require("esutils").keyword,
+    
+    output   = require("modular-css-core/lib/output.js"),
+    relative = require("modular-css-core/lib/relative.js");
 
 module.exports = function(source) {
     var done      = this.async(),
@@ -10,11 +15,30 @@ module.exports = function(source) {
 
     return processor.string(this.resourcePath, source)
         .then((result) => {
-            processor.dependencies(this.resourcePath).forEach((dep) => this.addDependency(dep));
+            var classes = output.join(result.exports),
+                deps    = processor.dependencies(this.resourcePath),
+                imports = deps.map((file) =>
+                    `import "${relative.prefixed(path.dirname(this.resourcePath), file)}";`
+                );
+
+            deps.forEach((dep) => this.addDependency(dep));
             
             return done(
                 null,
-                `module.exports = ${JSON.stringify(output.join(result.exports), null, 4)};`
+                (imports.length ? `${imports.join("\n")}\n` : "") +
+                Object.keys(classes).reduce(
+                    (prev, curr) => {
+                        // Warn if any of the exported CSS wasn't able to be used as a valid JS identifier
+                        if(keyword.isReservedWordES6(curr) || !keyword.isIdentifierNameES6(curr)) {
+                            this.emitWarning(new Error(`Invalid JS identifier "${curr}", unable to export`));
+                            
+                            return prev;
+                        }
+                        
+                        return `export var ${curr} = "${classes[curr]}";\n${prev}`;
+                    },
+                    `export default ${JSON.stringify(classes, null, 4)};\n`
+                )
             );
         })
         .catch(done);

--- a/packages/webpack/loader.js
+++ b/packages/webpack/loader.js
@@ -1,8 +1,6 @@
 "use strict";
 
-var path = require("path"),
-
-    keyword = require("esutils").keyword,
+var keyword = require("esutils").keyword,
     
     output   = require("modular-css-core/lib/output.js"),
     relative = require("modular-css-core/lib/relative.js");
@@ -18,7 +16,7 @@ module.exports = function(source) {
             var classes = output.join(result.exports),
                 deps    = processor.dependencies(this.resourcePath),
                 imports = deps.map((file) =>
-                    `import "${relative.prefixed(path.dirname(this.resourcePath), file)}";`
+                    `import "${relative.prefixed(this.context, file)}";`
                 );
 
             deps.forEach((dep) => this.addDependency(dep));

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "loader-utils": "^1.1.0",
+    "esutils": "^2.0.2",
     "modular-css-core": "^4.2.1",
     "webpack-sources": "^0.2.3"
   }

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -15,8 +15,8 @@
   "license": "MIT",
   "keywords": [
     "webpack",
-    "webpac-plugin",
-    "webpac-loader",
+    "webpack-plugin",
+    "webpack-loader",
     "css",
     "css-modules",
     "modular-css",

--- a/packages/webpack/test/__snapshots__/webpack.test.js.snap
+++ b/packages/webpack/test/__snapshots__/webpack.test.js.snap
@@ -66,24 +66,66 @@ exports[`/webpack.js should handle dependencies 1`] = `
 /******/ 	__webpack_require__.p = \\"\\";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ 	return __webpack_require__(__webpack_require__.s = 3);
 /******/ })
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ (function(module, exports) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-module.exports = {
-    \\"wooga\\": \\"booga wooga\\",
-    \\"booga\\": \\"booga\\",
-    \\"tooga\\": \\"tooga\\"
-};
+\\"use strict\\";
+/* unused harmony export folder */
+var folder = \\"folder\\";
+/* unused harmony default export */ var _unused_webpack_default_export = ({
+    \\"folder\\": \\"folder\\"
+});
+
 
 /***/ }),
 /* 1 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+\\"use strict\\";
+Object.defineProperty(__webpack_exports__, \\"__esModule\\", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__folder_folder_css__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__local_css__ = __webpack_require__(2);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \\"tooga\\", function() { return tooga; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \\"booga\\", function() { return booga; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \\"wooga\\", function() { return wooga; });
+
+
+var tooga = \\"tooga\\";
+var booga = \\"booga\\";
+var wooga = \\"booga wooga\\";
+/* harmony default export */ __webpack_exports__[\\"default\\"] = ({
+    \\"wooga\\": \\"booga wooga\\",
+    \\"booga\\": \\"booga\\",
+    \\"tooga\\": \\"tooga\\"
+});
+
+
+/***/ }),
+/* 2 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+\\"use strict\\";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__folder_folder_css__ = __webpack_require__(0);
+/* unused harmony export looga */
+/* unused harmony export booga */
+
+var looga = \\"booga looga\\";
+var booga = \\"booga\\";
+/* unused harmony default export */ var _unused_webpack_default_export = ({
+    \\"booga\\": \\"booga\\",
+    \\"looga\\": \\"booga looga\\"
+});
+
+
+/***/ }),
+/* 3 */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(0);
+__webpack_require__(1);
 
 
 /***/ })
@@ -197,11 +239,16 @@ exports[`/webpack.js should output css to disk 1`] = `
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ (function(module, exports) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-module.exports = {
+\\"use strict\\";
+Object.defineProperty(__webpack_exports__, \\"__esModule\\", { value: true });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \\"wooga\\", function() { return wooga; });
+var wooga = \\"wooga\\";
+/* harmony default export */ __webpack_exports__[\\"default\\"] = ({
     \\"wooga\\": \\"wooga\\"
-};
+});
+
 
 /***/ }),
 /* 1 */
@@ -292,11 +339,16 @@ exports[`/webpack.js should output json to disk 1`] = `
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ (function(module, exports) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-module.exports = {
+\\"use strict\\";
+Object.defineProperty(__webpack_exports__, \\"__esModule\\", { value: true });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \\"wooga\\", function() { return wooga; });
+var wooga = \\"wooga\\";
+/* harmony default export */ __webpack_exports__[\\"default\\"] = ({
     \\"wooga\\": \\"wooga\\"
-};
+});
+
 
 /***/ }),
 /* 1 */

--- a/packages/webpack/test/__snapshots__/webpack.test.js.snap
+++ b/packages/webpack/test/__snapshots__/webpack.test.js.snap
@@ -66,7 +66,7 @@ exports[`/webpack.js should handle dependencies 1`] = `
 /******/ 	__webpack_require__.p = \\"\\";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 3);
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
 /******/ })
 /************************************************************************/
 /******/ ([
@@ -74,26 +74,10 @@ exports[`/webpack.js should handle dependencies 1`] = `
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 \\"use strict\\";
-/* unused harmony export folder */
-var folder = \\"folder\\";
-/* unused harmony default export */ var _unused_webpack_default_export = ({
-    \\"folder\\": \\"folder\\"
-});
-
-
-/***/ }),
-/* 1 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-\\"use strict\\";
 Object.defineProperty(__webpack_exports__, \\"__esModule\\", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__folder_folder_css__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__local_css__ = __webpack_require__(2);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \\"tooga\\", function() { return tooga; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \\"booga\\", function() { return booga; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \\"wooga\\", function() { return wooga; });
-
-
 var tooga = \\"tooga\\";
 var booga = \\"booga\\";
 var wooga = \\"booga wooga\\";
@@ -105,27 +89,10 @@ var wooga = \\"booga wooga\\";
 
 
 /***/ }),
-/* 2 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-\\"use strict\\";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__folder_folder_css__ = __webpack_require__(0);
-/* unused harmony export looga */
-/* unused harmony export booga */
-
-var looga = \\"booga looga\\";
-var booga = \\"booga\\";
-/* unused harmony default export */ var _unused_webpack_default_export = ({
-    \\"booga\\": \\"booga\\",
-    \\"looga\\": \\"booga looga\\"
-});
-
-
-/***/ }),
-/* 3 */
+/* 1 */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(1);
+__webpack_require__(0);
 
 
 /***/ })

--- a/packages/webpack/test/__snapshots__/webpack.test.js.snap
+++ b/packages/webpack/test/__snapshots__/webpack.test.js.snap
@@ -368,3 +368,223 @@ exports[`/webpack.js should output json to disk 2`] = `
     }
 }"
 `;
+
+exports[`/webpack.js should support ES2015 default exports 1`] = `
+"/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = \\"\\";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+\\"use strict\\";
+/* unused harmony export b */
+/* unused harmony export a */
+var b = \\"b\\";
+var a = \\"a\\";
+/* harmony default export */ __webpack_exports__[\\"a\\"] = ({
+    \\"a\\": \\"a\\",
+    \\"b\\": \\"b\\"
+});
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+\\"use strict\\";
+Object.defineProperty(__webpack_exports__, \\"__esModule\\", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__es2015_css__ = __webpack_require__(0);
+
+
+console.log(__WEBPACK_IMPORTED_MODULE_0__es2015_css__[\\"a\\" /* default */]);
+
+
+/***/ })
+/******/ ]);"
+`;
+
+exports[`/webpack.js should support ES2015 default exports 2`] = `
+"/* packages/webpack/test/specimens/es2015.css */
+.a {
+    color: red
+}
+.b {
+    color: blue
+}"
+`;
+
+exports[`/webpack.js should support ES2015 named exports 1`] = `
+"/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = \\"\\";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+\\"use strict\\";
+/* unused harmony export b */
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \\"a\\", function() { return a; });
+var b = \\"b\\";
+var a = \\"a\\";
+/* unused harmony default export */ var _unused_webpack_default_export = ({
+    \\"a\\": \\"a\\",
+    \\"b\\": \\"b\\"
+});
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+\\"use strict\\";
+Object.defineProperty(__webpack_exports__, \\"__esModule\\", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__es2015_css__ = __webpack_require__(0);
+
+
+console.log(__WEBPACK_IMPORTED_MODULE_0__es2015_css__[\\"a\\"]);
+
+
+/***/ })
+/******/ ]);"
+`;
+
+exports[`/webpack.js should support ES2015 named exports 2`] = `
+"/* packages/webpack/test/specimens/es2015.css */
+.a {
+    color: red
+}
+.b {
+    color: blue
+}"
+`;

--- a/packages/webpack/test/specimens/es2015-default.js
+++ b/packages/webpack/test/specimens/es2015-default.js
@@ -1,0 +1,3 @@
+import css from "./es2015.css";
+
+console.log(css);

--- a/packages/webpack/test/specimens/es2015-missing.js
+++ b/packages/webpack/test/specimens/es2015-missing.js
@@ -1,0 +1,3 @@
+import { c } from "./es2015.css";
+
+console.log(c);

--- a/packages/webpack/test/specimens/es2015-named.js
+++ b/packages/webpack/test/specimens/es2015-named.js
@@ -1,0 +1,3 @@
+import { a } from "./es2015.css";
+
+console.log(a);

--- a/packages/webpack/test/specimens/es2015.css
+++ b/packages/webpack/test/specimens/es2015.css
@@ -1,0 +1,2 @@
+.a { color: red; }
+.b { color: blue; }

--- a/packages/webpack/test/specimens/invalid-name.css
+++ b/packages/webpack/test/specimens/invalid-name.css
@@ -1,0 +1,2 @@
+.fooga { color: red; }
+.fooga-wooga { color: red; }

--- a/packages/webpack/test/specimens/invalid-name.js
+++ b/packages/webpack/test/specimens/invalid-name.js
@@ -1,0 +1,3 @@
+import css, {fooga} from "./invalid-name.css";
+
+console.log(css, fooga);

--- a/packages/webpack/test/webpack.test.js
+++ b/packages/webpack/test/webpack.test.js
@@ -117,6 +117,38 @@ describe("/webpack.js", function() {
         });
     });
 
+    it("should report warnings on invalid property names", function(done) {
+        webpack({
+            entry  : "./packages/webpack/test/specimens/invalid-name.js",
+            output : {
+                path     : output,
+                filename : "./invalid-name.js"
+            },
+            module : {
+                rules : [
+                    {
+                        test,
+                        use
+                    }
+                ]
+            },
+            plugins : [
+                new Plugin({
+                    namer
+                })
+            ]
+        }, (err, stats) => {
+            // Why is err not truthy?
+            expect(err).toBeFalsy();
+            
+            expect(stats.hasWarnings()).toBeTruthy();
+
+            expect(stats.toJson().warnings[0]).toMatch("Invalid JS identifier");
+
+            done();
+        });
+    });
+
     it("should handle dependencies", function(done) {
         webpack({
             entry  : "./packages/webpack/test/specimens/start.js",

--- a/packages/webpack/test/webpack.test.js
+++ b/packages/webpack/test/webpack.test.js
@@ -182,4 +182,68 @@ describe("/webpack.js", function() {
             done();
         });
     });
+
+    it("should support ES2015 default exports", function(done) {
+        webpack({
+            entry  : "./packages/webpack/test/specimens/es2015-default.js",
+            output : {
+                path     : output,
+                filename : "./es2015-default.js"
+            },
+            module : {
+                rules : [
+                    {
+                        test,
+                        use
+                    }
+                ]
+            },
+            plugins : [
+                new Plugin({
+                    namer,
+                    css : "./es2015-default.css"
+                })
+            ]
+        }, (err, stats) => {
+            expect(err).toBeFalsy();
+            expect(stats.hasErrors()).toBeFalsy();
+
+            expect(read("es2015-default.js")).toMatchSnapshot();
+            expect(read("es2015-default.css")).toMatchSnapshot();
+
+            done();
+        });
+    });
+
+    it("should support ES2015 named exports", function(done) {
+        webpack({
+            entry  : "./packages/webpack/test/specimens/es2015-named.js",
+            output : {
+                path     : output,
+                filename : "./es2015-named.js"
+            },
+            module : {
+                rules : [
+                    {
+                        test,
+                        use
+                    }
+                ]
+            },
+            plugins : [
+                new Plugin({
+                    namer,
+                    css : "./es2015-named.css"
+                })
+            ]
+        }, (err, stats) => {
+            expect(err).toBeFalsy();
+            expect(stats.hasErrors()).toBeFalsy();
+
+            expect(read("es2015-named.js")).toMatchSnapshot();
+            expect(read("es2015-named.css")).toMatchSnapshot();
+
+            done();
+        });
+    });
 });


### PR DESCRIPTION
This is mostly a copy/paste of the rollup code. It could be extracted out into some sort of shared package but it's just different enough to not make it worth that work.

@TrySound, this about what you were looking for?

Fixes #280 