### PR TITLE
test: fix broken snapshots

### DIFF
--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -60,3 +60,17 @@ var css = {
 console.log(css, fooga);
 "
 `;
+
+exports[`/rollup.js watch should generate correct builds in watch mode when files change 1`] = `
+"/* packages/rollup/test/output/watched.css */
+.mc580619a9_one {
+    color: red
+}"
+`;
+
+exports[`/rollup.js watch should generate correct builds in watch mode when files change 2`] = `
+"/* packages/rollup/test/output/watched.css */
+.mc580619a9_two {
+    color: blue
+}"
+`;

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -243,7 +243,10 @@ describe("/rollup.js", function() {
         
         it("should generate correct builds in watch mode when files change", function(done) {
             // Create v1 of the file
-            fs.writeFileSync("./packages/rollup/test/output/watched.css", ".one { color: red; }");
+            fs.writeFileSync(
+                "./packages/rollup/test/output/watched.css",
+                ".one { color: red; }"
+            );
 
             // Start watching (re-requiring rollup because it needs root obj reference)
             watcher = watch(require("rollup"), {
@@ -259,13 +262,16 @@ describe("/rollup.js", function() {
             });
 
             // Create v2 of the file after a bit
-            setTimeout(() => fs.writeFileSync("./packages/rollup/test/output/watched.css", ".two { color: blue; }"), 200);
+            setTimeout(() => fs.writeFileSync(
+                "./packages/rollup/test/output/watched.css",
+                ".two { color: blue; }"
+            ), 200);
             
             watcher.on("event", (details) => {
                 /* eslint consistent-return:0 */
                 if(details.code === "BUILD_END" && details.initial) {
                     try {
-                        expect(read("watch-output.css").toMatchSnapshot());
+                        expect(read("watch-output.css")).toMatchSnapshot();
                     } catch(e) {
                         return done(e);
                     }
@@ -273,7 +279,7 @@ describe("/rollup.js", function() {
 
                 if(details.code === "BUILD_END" && !details.initial) {
                     try {
-                        expect(read("watch-output.css").toMatchSnapshot());
+                        expect(read("watch-output.css")).toMatchSnapshot();
                     } catch(e) {
                         return done(e);
                     }


### PR DESCRIPTION
`rollup-watch` test had some bad formatting that was preventing the tests from actually running (still passing ok though wtf?)

Related to #288 but doesn't necessarily solve that issue.