### PR TITLE
Fix webpack watch cache staleness

### DIFF
--- a/packages/webpack/plugin.js
+++ b/packages/webpack/plugin.js
@@ -3,35 +3,43 @@
 var sources   = require("webpack-sources"),
     Processor = require("modular-css-core");
 
-function Webpack(args) {
+function ModularCSS(args) {
     var options = Object.assign(
             Object.create(null),
             args
         );
 
-    this.processor = new Processor(options);
-    this.options   = options;
+    this.options = options;
 }
 
-Webpack.prototype.apply = function(compiler) {
+ModularCSS.prototype.apply = function(compiler) {
+    var processor;
+    
     compiler.plugin("emit", (compilation, done) => {
-        this.processor.output().then((data) => {
+        processor.output().then((data) => {
             if(this.options.css) {
                 compilation.assets[this.options.css] = new sources.RawSource(data.css);
             }
             
             if(this.options.json) {
-                compilation.assets[this.options.json] = new sources.RawSource(JSON.stringify(data.compositions, null, 4));
+                compilation.assets[this.options.json] = new sources.RawSource(
+                    JSON.stringify(data.compositions, null, 4)
+                );
             }
+
+            processor = null;
 
             done();
         });
     });
     
     compiler.plugin("this-compilation", (compilation) => {
+        // Avoid caching issues by dumping the entire processor instance on each run
+        processor = new Processor(this.options);
+        
         // Make our processor instance available to the loader
-        compilation.options.processor = this.processor;
+        compilation.options.processor = processor;
     });
 };
 
-module.exports = Webpack;
+module.exports = ModularCSS;

--- a/packages/webpack/test/__snapshots__/webpack.test.js.snap
+++ b/packages/webpack/test/__snapshots__/webpack.test.js.snap
@@ -555,3 +555,211 @@ exports[`/webpack.js should support ES2015 named exports 2`] = `
     color: blue
 }"
 `;
+
+exports[`webpack watching.css 1 1`] = `
+"/* packages/webpack/test/output/watched.css */
+.one {
+    color: red
+}"
+`;
+
+exports[`webpack watching.css 2 1`] = `
+"/* packages/webpack/test/output/watched.css */
+.two {
+    color: blue
+}"
+`;
+
+exports[`webpack watching.js 1 1`] = `
+"/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = \\"\\";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+\\"use strict\\";
+/* unused harmony export one */
+var one = \\"one\\";
+/* harmony default export */ __webpack_exports__[\\"a\\"] = ({
+    \\"one\\": \\"one\\"
+});
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+\\"use strict\\";
+Object.defineProperty(__webpack_exports__, \\"__esModule\\", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__output_watched_css__ = __webpack_require__(0);
+
+
+console.log(__WEBPACK_IMPORTED_MODULE_0__output_watched_css__[\\"a\\" /* default */]);
+
+
+/***/ })
+/******/ ]);"
+`;
+
+exports[`webpack watching.js 2 1`] = `
+"/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = \\"\\";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+\\"use strict\\";
+/* unused harmony export two */
+var two = \\"two\\";
+/* harmony default export */ __webpack_exports__[\\"a\\"] = ({
+    \\"two\\": \\"two\\"
+});
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+\\"use strict\\";
+Object.defineProperty(__webpack_exports__, \\"__esModule\\", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__output_watched_css__ = __webpack_require__(0);
+
+
+console.log(__WEBPACK_IMPORTED_MODULE_0__output_watched_css__[\\"a\\" /* default */]);
+
+
+/***/ })
+/******/ ]);"
+`;

--- a/packages/webpack/test/__snapshots__/webpack.test.js.snap
+++ b/packages/webpack/test/__snapshots__/webpack.test.js.snap
@@ -9,9 +9,9 @@ exports[`/webpack.js should generate correct builds when files change 1`] = `
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -76,9 +76,9 @@ exports[`/webpack.js should generate correct builds when files change 1`] = `
 \\"use strict\\";
 /* unused harmony export one */
 var one = \\"one\\";
-/* harmony default export */ __webpack_exports__[\\"a\\"] = {
+/* harmony default export */ __webpack_exports__[\\"a\\"] = ({
     \\"one\\": \\"one\\"
-};
+});
 
 
 /***/ }),
@@ -113,9 +113,9 @@ exports[`/webpack.js should generate correct builds when files change 3`] = `
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -180,9 +180,9 @@ exports[`/webpack.js should generate correct builds when files change 3`] = `
 \\"use strict\\";
 /* unused harmony export two */
 var two = \\"two\\";
-/* harmony default export */ __webpack_exports__[\\"a\\"] = {
+/* harmony default export */ __webpack_exports__[\\"a\\"] = ({
     \\"two\\": \\"two\\"
-};
+});
 
 
 /***/ }),

--- a/packages/webpack/test/__snapshots__/webpack.test.js.snap
+++ b/packages/webpack/test/__snapshots__/webpack.test.js.snap
@@ -1,5 +1,213 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`/webpack.js should generate correct builds when files change 1`] = `
+"/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+/******/
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = \\"\\";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+\\"use strict\\";
+/* unused harmony export one */
+var one = \\"one\\";
+/* harmony default export */ __webpack_exports__[\\"a\\"] = {
+    \\"one\\": \\"one\\"
+};
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+\\"use strict\\";
+Object.defineProperty(__webpack_exports__, \\"__esModule\\", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__output_changed_css__ = __webpack_require__(0);
+
+
+console.log(__WEBPACK_IMPORTED_MODULE_0__output_changed_css__[\\"a\\" /* default */]);
+
+
+/***/ })
+/******/ ]);"
+`;
+
+exports[`/webpack.js should generate correct builds when files change 2`] = `
+"/* packages/webpack/test/output/changed.css */
+.one {
+    color: red
+}"
+`;
+
+exports[`/webpack.js should generate correct builds when files change 3`] = `
+"/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+/******/
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = \\"\\";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+\\"use strict\\";
+/* unused harmony export two */
+var two = \\"two\\";
+/* harmony default export */ __webpack_exports__[\\"a\\"] = {
+    \\"two\\": \\"two\\"
+};
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+\\"use strict\\";
+Object.defineProperty(__webpack_exports__, \\"__esModule\\", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__output_changed_css__ = __webpack_require__(0);
+
+
+console.log(__WEBPACK_IMPORTED_MODULE_0__output_changed_css__[\\"a\\" /* default */]);
+
+
+/***/ })
+/******/ ]);"
+`;
+
+exports[`/webpack.js should generate correct builds when files change 4`] = `
+"/* packages/webpack/test/output/changed.css */
+.two {
+    color: blue
+}"
+`;
+
 exports[`/webpack.js should handle dependencies 1`] = `
 "/******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache

--- a/packages/webpack/test/specimens/change.js
+++ b/packages/webpack/test/specimens/change.js
@@ -1,0 +1,3 @@
+import css from "../output/changed.css";
+
+console.log(css);

--- a/packages/webpack/test/specimens/watch.js
+++ b/packages/webpack/test/specimens/watch.js
@@ -1,0 +1,3 @@
+import css from "../output/watched.css";
+
+console.log(css);

--- a/packages/webpack/test/webpack.test.js
+++ b/packages/webpack/test/webpack.test.js
@@ -303,4 +303,62 @@ describe("/webpack.js", function() {
             ".two { color: blue; }"
         ), 100);
     });
+
+    it("should generate correct builds when files change", function(done) {
+        var compiler;
+        
+        // Create v1 of the file
+        fs.writeFileSync(
+            "./packages/webpack/test/output/changed.css",
+            ".one { color: red; }"
+        );
+
+        compiler = webpack({
+            entry  : "./packages/webpack/test/specimens/change.js",
+            output : {
+                path     : output,
+                filename : "./changing.js"
+            },
+            module : {
+                rules : [
+                    {
+                        test,
+                        use
+                    }
+                ]
+            },
+            plugins : [
+                new Plugin({
+                    namer,
+                    css : "./changing.css"
+                })
+            ]
+        });
+        
+        // Run webpack the first time
+        compiler.run((err, stats) => {
+            expect(err).toBeFalsy();
+            expect(stats.hasErrors()).toBeFalsy();
+
+            expect(read("changing.js")).toMatchSnapshot();
+            expect(read("changing.css")).toMatchSnapshot();
+            
+            // v2 of the file
+            fs.writeFileSync(
+                "./packages/webpack/test/output/changed.css",
+                ".two { color: blue; }"
+            );
+
+            // Run webpack again!
+            compiler.run((err2, stats2) => {
+                expect(err2).toBeFalsy();
+                expect(stats2.hasErrors()).toBeFalsy();
+
+                expect(read("changing.js")).toMatchSnapshot();
+                expect(read("changing.css")).toMatchSnapshot();
+
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
This is a copy of the very brute-force approach the rollup plugin takes, it simply throws away the entire Processor instance after each run. There may be a better way to handle this within webpack (`watchify` fires very useful file change events we can use to precisely purge the cache, for instance) but for now this will remove a lot of badness at the cost of some speed.

cc @TrySound 

Fixes #290 