### PR TITLE
Add cjs webpack loader option

### DIFF
--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -22,12 +22,10 @@ module.exports = {
         filename : "./output.js"
     },
     module : {
-        rules : [
-            {
-                test : /\.css$/,
-                use  : "modular-css-webpack/loader"
-            }
-        ]
+        rules : [{
+            test : /\.css$/,
+            use  : "modular-css-webpack/loader"
+        }]
     },
     plugins : [
         new CSSPlugin({
@@ -40,15 +38,38 @@ module.exports = {
 
 ## Options
 
-### `css`
+### Plugin Options
+
+#### `css`
 
 Location to write the generated CSS file to, relative to `output.path` just like `output.filename`
 
-### `json`
+#### `json`
 
 Location to write out the JSON mapping file to, relative to `output.path` just like `output.filename`
 
-### Shared Options
+#### Shared Options
 
 All other options are passed to the underlying `Processor` instance, see [Options](https://github.com/tivac/modular-css/blob/master/docs/api.md#processor-options).
 
+### Loader Options
+
+#### `cjs`
+
+By default this plugin will export ES2015 module `export`s. If you want to use CommonJS exports set the `cjs` option to `true`
+
+```js
+...
+    module : {
+        rules : [{
+            test : /\.css$/,
+            use  : {
+                loader  : "modular-css-webpack/loader",
+                options : {
+                    cjs : true
+                }
+            }
+        }]
+    },
+...
+```

--- a/packages/webpack/test/__snapshots__/webpack.test.js.snap
+++ b/packages/webpack/test/__snapshots__/webpack.test.js.snap
@@ -648,6 +648,95 @@ exports[`/webpack.js should output json to disk 2`] = `
 }"
 `;
 
+exports[`/webpack.js should support CommonJS exports when the option is set 1`] = `
+"/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = \\"\\";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports) {
+
+module.exports = {
+    \\"wooga\\": \\"wooga\\"
+};
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(0);
+
+
+/***/ })
+/******/ ]);"
+`;
+
 exports[`/webpack.js should support ES2015 default exports 1`] = `
 "/******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache

--- a/packages/webpack/test/webpack.test.js
+++ b/packages/webpack/test/webpack.test.js
@@ -13,6 +13,13 @@ var fs   = require("fs"),
     use  = require.resolve("../loader.js"),
     test = /\.css$/;
 
+function success(err, stats) {
+    expect(err).toBeFalsy();
+    if(stats.hasErrors()) {
+        throw stats.toJson().errors[0];
+    }
+}
+
 describe("/webpack.js", function() {
     var output = path.resolve(__dirname, "./output");
     
@@ -44,8 +51,7 @@ describe("/webpack.js", function() {
                 })
             ]
         }, (err, stats) => {
-            expect(err).toBeFalsy();
-            expect(stats.hasErrors()).toBeFalsy();
+            success(err, stats);
 
             expect(read("simple.js")).toMatchSnapshot();
             expect(read("simple.css")).toMatchSnapshot();
@@ -76,8 +82,7 @@ describe("/webpack.js", function() {
                 })
             ]
         }, (err, stats) => {
-            expect(err).toBeFalsy();
-            expect(stats.hasErrors()).toBeFalsy();
+            success(err, stats);
 
             expect(read("simple.js")).toMatchSnapshot();
             expect(read("simple.json")).toMatchSnapshot();
@@ -107,9 +112,6 @@ describe("/webpack.js", function() {
                 })
             ]
         }, (err, stats) => {
-            // Why is err not truthy?
-            expect(err).toBeFalsy();
-            
             expect(stats.hasErrors()).toBeTruthy();
 
             expect(stats.toJson().errors[0]).toMatch("Invalid composes reference");
@@ -139,9 +141,6 @@ describe("/webpack.js", function() {
                 })
             ]
         }, (err, stats) => {
-            // Why is err not truthy?
-            expect(err).toBeFalsy();
-            
             expect(stats.hasWarnings()).toBeTruthy();
 
             expect(stats.toJson().warnings[0]).toMatch("Invalid JS identifier");
@@ -173,8 +172,7 @@ describe("/webpack.js", function() {
                 })
             ]
         }, (err, stats) => {
-            expect(err).toBeFalsy();
-            expect(stats.hasErrors()).toBeFalsy();
+            success(err, stats);
 
             expect(read("start.js")).toMatchSnapshot();
             expect(read("start.css")).toMatchSnapshot();
@@ -206,8 +204,7 @@ describe("/webpack.js", function() {
                 })
             ]
         }, (err, stats) => {
-            expect(err).toBeFalsy();
-            expect(stats.hasErrors()).toBeFalsy();
+            success(err, stats);
 
             expect(read("es2015-default.js")).toMatchSnapshot();
             expect(read("es2015-default.css")).toMatchSnapshot();
@@ -238,11 +235,45 @@ describe("/webpack.js", function() {
                 })
             ]
         }, (err, stats) => {
-            expect(err).toBeFalsy();
-            expect(stats.hasErrors()).toBeFalsy();
+            success(err, stats);
 
             expect(read("es2015-named.js")).toMatchSnapshot();
             expect(read("es2015-named.css")).toMatchSnapshot();
+
+            done();
+        });
+    });
+
+    it("should support CommonJS exports when the option is set", function(done) {
+        webpack({
+            entry  : "./packages/webpack/test/specimens/simple.js",
+            output : {
+                path     : output,
+                filename : "./simple.js"
+            },
+            module : {
+                rules : [
+                    {
+                        test,
+                        use : {
+                            loader  : use,
+                            options : {
+                                cjs : true
+                            }
+                        }
+                    }
+                ]
+            },
+            plugins : [
+                new Plugin({
+                    namer,
+                    css : "./simple.css"
+                })
+            ]
+        }, (err, stats) => {
+            success(err, stats);
+
+            expect(read("simple.js")).toMatchSnapshot();
 
             done();
         });
@@ -284,8 +315,7 @@ describe("/webpack.js", function() {
             /* eslint consistent-return: off */
             changed++;
             
-            expect(err).toBeFalsy();
-            expect(stats.hasErrors()).toBeFalsy();
+            success(err, stats);
 
             expect(read("watching.js")).toMatchSnapshot(`webpack watching.js ${changed}`);
             expect(read("watching.css")).toMatchSnapshot(`webpack watching.css ${changed}`);


### PR DESCRIPTION
Fixes #294

If you're using node or need to use CommonJS for some reason and don't want to deal with `require("./file.css").default` (I don't blame you) then set `options: { cjs : true }` in your loader config and bask in the un-treeshakeable blob of data that is attached to `modular.exports`!