### PR TITLE
Fix webpack by breaking apart watching/non-watching modes

### DIFF
--- a/packages/webpack/loader.js
+++ b/packages/webpack/loader.js
@@ -26,9 +26,7 @@ module.exports = function(source) {
                     `export default ${JSON.stringify(classes, null, 4)};`
                 ];
 
-            processor.dependencies(this.resourcePath).forEach((dep) =>
-                this.addDependency(dep)
-            );
+            processor.dependencies(this.resourcePath).forEach(this.addDependency);
 
             // Just default object export in this case
             if(options.namedExports === false) {


### PR DESCRIPTION
The changes in #293 work great for the mode where `webpack.run()` is being called over and over again.

Unfortunately they're super broken for webpack's actual watch mode.

So now those two are split apart, following a [convention in the webpack codebase](https://github.com/webpack/webpack/blob/b2a6085d9684cb8bb3c47cbcb778413844d70d53/lib/CachePlugin.js#L30-L33). It seems kinda hacky but now in watch mode it can use fine-grained `invalid` events to remove files from the cache and in non-watching mode it can use the coarser `.fileTimestamps` property and now all the tests actually pass and oh god I'm so tired 😪 