### PR TITLE
Fix bad browserify options references

### DIFF
--- a/packages/browserify/browserify.js
+++ b/packages/browserify/browserify.js
@@ -27,7 +27,7 @@ module.exports = function(browserify, opts) {
             cache : true
         }, opts),
         
-        processor = opts.cache && new Processor(options),
+        processor = options.cache && new Processor(options),
         
         bundler, bundles, handled;
     
@@ -50,7 +50,7 @@ module.exports = function(browserify, opts) {
         if(path.extname(file) !== options.ext) {
             return through();
         }
-        
+
         return sink.str(function(buffer, done) {
             var push = this.push.bind(this),
                 real = fs.realpathSync(file);
@@ -144,7 +144,7 @@ module.exports = function(browserify, opts) {
         handled = {};
         
         // cache set to false means we need to create a new Processor each run-through
-        if(!opts.cache) {
+        if(!options.cache) {
             processor = new Processor(options);
         }
 
@@ -154,7 +154,7 @@ module.exports = function(browserify, opts) {
         bundler.on("end", function() {
             var bundling = Object.keys(bundles).length > 0,
                 common;
-            
+
             if(options.json) {
                 mkdirp.sync(path.dirname(options.json));
                 
@@ -212,7 +212,7 @@ module.exports = function(browserify, opts) {
                 files : bundling && common,
                 to    : options.css
             })
-            .then((result) => fs.writeFileSync(options.css, result.css))
+            .then((result) => fs.writeFileSync(options.css, result.css, "utf8"))
             .catch((error) => bundler.emit("error", error));
         });
     });

--- a/packages/browserify/test/__snapshots__/issue-313.test.js.snap
+++ b/packages/browserify/test/__snapshots__/issue-313.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`/browserify.js /issues /313 should include all dependencies after watchify update 1`] = `
+"/* packages/browserify/test/specimens/issues/313/1.css */
+.mcd2dffd93_wooga {
+    color: red
+}
+/* packages/browserify/test/specimens/issues/313/2.css */
+.mc4882c370_fooga {
+    color: blue
+}"
+`;

--- a/packages/browserify/test/issue-313.test.js
+++ b/packages/browserify/test/issue-313.test.js
@@ -1,0 +1,58 @@
+"use strict";
+
+var fs = require("fs"),
+    
+    browserify = require("browserify"),
+    from       = require("from2-string"),
+    
+    read = require("test-utils/read.js")(__dirname),
+
+    bundle = require("./lib/bundle.js"),
+    plugin = require("../browserify.js");
+
+describe("/browserify.js", function() {
+    describe("/issues", function() {
+        describe("/313", function() {
+            it("should include all dependencies after watchify update", function(done) {
+                var src = from("require('./packages/browserify/test/specimens/issues/313/1.css');require('./packages/browserify/test/specimens/issues/313/2.css');"),
+                    opts = { cache: {}, packageCache: {} },
+                    
+                    build = browserify(src, opts);
+
+                build.plugin("watchify");
+                build.plugin(plugin, {
+                    css : "./packages/browserify/test/output/issues/313.css"
+                });
+
+                var expectedOutput;
+
+                // File changed
+                build.on("update", function() {
+                    bundle(build)
+                        .then(() => {
+                            // expect(read("./issues/313.css")).toMatchSnapshot();
+
+                            // compare the output of the updated file with the initial bundle
+                            expect(read("./issues/313.css")).toEqual(expectedOutput);
+
+                            build.close();
+                            
+                            done();
+                        });
+                });
+
+                // Run first bundle, start watching
+                bundle(build)
+                    .then(() => {
+                        // save the output of the first build
+                        expectedOutput = read("./issues/313.css");
+
+                        expect(expectedOutput).toMatchSnapshot();
+                        
+                        // Trigger a rebuild
+                        fs.utimesSync("./packages/browserify/test/specimens/issues/313/2.css", new Date(), new Date());
+                    });
+            });
+        });
+    });
+});

--- a/packages/browserify/test/specimens/issues/313/1.css
+++ b/packages/browserify/test/specimens/issues/313/1.css
@@ -1,0 +1,1 @@
+.wooga { color: red; }

--- a/packages/browserify/test/specimens/issues/313/2.css
+++ b/packages/browserify/test/specimens/issues/313/2.css
@@ -1,0 +1,1 @@
+.fooga { color: blue; }


### PR DESCRIPTION
This is a slight reworking of #314 to make it the default watchify test for caching since clearly the previous version wasn't working.

Also includes some other cleanup in the watchify tests, as well as some saner places for files to live in order to keep things clean-ish.

Fixes #314 
Fixes #313

Hey @darthmaim would you take a look to verify that I didn't do anything stupid here?