### PR TITLE
Aliases resolver

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,9 +4,12 @@
     "packages/*"
   ],
   "version": "independent",
-  "commands": {
+  "command": {
     "publish": {
       "message": "v%s"
+    },
+    "bootstrap": {
+      "hoist": true
     }
   }
 }

--- a/packages/aliases/.npmignore
+++ b/packages/aliases/.npmignore
@@ -1,0 +1,4 @@
+coverage/
+profiling/
+test/
+.*

--- a/packages/aliases/LICENSE
+++ b/packages/aliases/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Pat Cavit
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/aliases/README.md
+++ b/packages/aliases/README.md
@@ -7,7 +7,7 @@ modular-css-aliases [![NPM Version](https://img.shields.io/npm/v/modular-css-ali
 
 A resolver for [`modular-css`](https://github.com/tivac/modular-css) that will let you resolve file references against named aliases. Useful to avoid code like
 
-```css
+```
 @value foo from "../../../../../../../../some/other/directory/file.css";
 ```
 

--- a/packages/aliases/README.md
+++ b/packages/aliases/README.md
@@ -1,0 +1,54 @@
+modular-css-aliases [![NPM Version](https://img.shields.io/npm/v/modular-css-aliases.svg)](https://www.npmjs.com/package/modular-css-aliases) [![NPM License](https://img.shields.io/npm/l/modular-css-aliases.svg)](https://www.npmjs.com/package/modular-css-aliases) [![NPM Downloads](https://img.shields.io/npm/dm/modular-css-aliases.svg)](https://www.npmjs.com/package/modular-css-aliases)
+===========
+
+<p align="center">
+    <a href="https://gitter.im/modular-css/modular-css"><img src="https://img.shields.io/gitter/room/modular-css/modular-css.svg" alt="Gitter" /></a>
+</p>
+
+A resolver for [`modular-css`](https://github.com/tivac/modular-css) that will let you resolve file references against named aliases. Useful to avoid code like
+
+```css
+@value foo from "../../../../../../../../some/other/directory/file.css";
+```
+
+which is annoying to write, annoying to read, and also super-brittle.
+
+## Install
+
+`$ npm i modular-css-aliases`
+
+## Usage
+
+Pass as part of the `resolvers` array in the `modular-css` options (via JS API/Rollup/Browserify/WebPack/etc). When `modular-css` is trying to resolve `@value` or `composes` file references it'll replace the alias keys with their path value for file lookups.
+
+```js
+var Processor = require("modular-css-core"),
+    aliases   = require("modular-css-aliases")
+
+    processor = new Processor({
+        resolvers : [
+            aliases({
+                aliases : {
+                    one  : "./path/one",
+                    path : "../../some/other/path"
+                }
+            })
+        ]
+    });
+```
+
+which allows you to write CSS like this.
+
+```css
+@value one from "one/one.css";
+
+.a {
+    composes: path from "path/path.css";
+}
+```
+
+### Options
+
+#### `aliases`
+
+A `object` consisting of key/value pairs of alias names to file paths. Paths can be relative to the `cwd` of the `Processor` instance or absolute paths.

--- a/packages/aliases/aliases.js
+++ b/packages/aliases/aliases.js
@@ -1,0 +1,31 @@
+"use strict";
+
+var from = require("resolve-from");
+
+module.exports = function(args) {
+    var options = Object.assign(
+            Object.create(null),
+            { aliases : {} },
+            args
+        ),
+        aliases = Object.keys(options.aliases)
+            .map((alias) => ({
+                name   : alias,
+                search : new RegExp(`^${alias}\\b`)
+            }));
+    
+    return (src, file) => {
+        var match;
+
+        match = aliases.find((alias) => file.search(alias.search) > -1);
+
+        if(!match) {
+            return false;
+        }
+
+        return from.silent(
+            options.aliases[match.name],
+            file.replace(match.search, ".")
+        );
+    };
+};

--- a/packages/aliases/package.json
+++ b/packages/aliases/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "modular-css-aliases",
+  "version": "5.1.5",
+  "description": "Custom file resolver supporting directory aliases for modular-css",
+  "main": "./aliases.js",
+  "repository": "tivac/modular-css",
+  "bugs": {
+    "url": "https://github.com/tivac/modular-css/issues"
+  },
+  "author": "Pat Cavit <npm@patcavit.com>",
+  "license": "MIT",
+  "keywords": [
+    "css",
+    "css-modules",
+    "modular-css",
+    "paths",
+    "aliases"
+  ],
+  "devDependencies": {
+    "dentist": "^1.0.3",
+    "modular-css-core": "^5.1.5",
+    "test-utils": "^5.1.5"
+  }
+}

--- a/packages/aliases/test/__snapshots__/aliases.test.js.snap
+++ b/packages/aliases/test/__snapshots__/aliases.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`modular-css-aliases should be usable as a modular-css resolver 1`] = `
+Object {
+  "packages/aliases/test/specimens/one/sub/sub.css": Object {
+    "sub": "sub",
+  },
+  "packages/aliases/test/specimens/two/two.css": Object {
+    "two": "two",
+  },
+  "packages/paths/test/specimens/one/start.css": Object {
+    "rule": "two rule",
+  },
+}
+`;
+
+exports[`modular-css-aliases should fall through to the default resolver 1`] = `
+Object {
+  "packages/aliases/test/specimens/two/two.css": Object {
+    "two": "two",
+  },
+  "packages/paths/test/specimens/one/start.css": Object {
+    "rule": "two rule",
+  },
+  "packages/paths/test/specimens/one/sub/sub.css": Object {
+    "sub": "sub",
+  },
+}
+`;

--- a/packages/aliases/test/aliases.test.js
+++ b/packages/aliases/test/aliases.test.js
@@ -1,0 +1,100 @@
+"use strict";
+
+var dedent = require("dentist").dedent,
+    
+    Processor = require("modular-css-core"),
+    namer     = require("test-utils/namer.js"),
+
+    aliases = require("../aliases.js");
+
+describe("modular-css-aliases", function() {
+    it("should return a falsey value if a file isn't found", function() {
+        var fn = aliases({
+            aliases : {
+                specimens : "./packages/aliases/test/specimens"
+            }
+        });
+
+        expect(fn(".", "specimens/fooga.css")).toBeFalsy();
+    });
+
+    it("should return the absolute path if a file is found", function() {
+        var fn = aliases({
+            aliases : {
+                one : "./packages/aliases/test/specimens/one"
+            }
+        });
+
+        expect(fn(".", "one/one.css")).toBe(require.resolve("./specimens/one/one.css"));
+    });
+
+    it("should check multiple aliases for files & return the first match", function() {
+        var fn = aliases({
+            aliases : {
+                one : "./packages/aliases/test/specimens/one",
+                two : "./packages/aliases/test/specimens/two",
+                sub : "./packages/aliases/test/specimens/one/sub"
+            }
+        });
+
+        expect(fn(".", "one/one.css")).toBe(require.resolve("./specimens/one/one.css"));
+        expect(fn(".", "sub/sub.css")).toBe(require.resolve("./specimens/one/sub/sub.css"));
+    });
+
+    it("should be usable as a modular-css resolver", function() {
+        var processor = new Processor({
+                namer,
+                resolvers : [
+                    aliases({
+                        aliases : {
+                            sub : "./packages/aliases/test/specimens/one/sub",
+                            two : "./packages/aliases/test/specimens/two"
+                        }
+                    })
+                ]
+            });
+        
+        return processor.string(
+            "./packages/paths/test/specimens/one/start.css",
+            dedent(`
+                @value sub from "sub/sub.css";
+                
+                .rule {
+                    composes: two from "two/two.css";
+                }
+            `)
+        )
+        .then(() => processor.output())
+        .then((result) =>
+            expect(result.compositions).toMatchSnapshot()
+        );
+    });
+
+    it("should fall through to the default resolver", function() {
+        var processor = new Processor({
+                namer,
+                resolvers : [
+                    aliases({
+                        aliases : {
+                            two : "./packages/aliases/test/specimens/two"
+                        }
+                    })
+                ]
+            });
+        
+        return processor.string(
+            "./packages/paths/test/specimens/one/start.css",
+            dedent(`
+                @value sub from "./sub/sub.css";
+                
+                .rule {
+                    composes: two from "two/two.css";
+                }
+            `)
+        )
+        .then(() => processor.output())
+        .then((result) =>
+            expect(result.compositions).toMatchSnapshot()
+        );
+    });
+});

--- a/packages/aliases/test/specimens/one/one.css
+++ b/packages/aliases/test/specimens/one/one.css
@@ -1,0 +1,3 @@
+@value one: "one";
+
+.one { color: red; }

--- a/packages/aliases/test/specimens/one/sub/sub.css
+++ b/packages/aliases/test/specimens/one/sub/sub.css
@@ -1,0 +1,3 @@
+@value sub: "sub";
+
+.sub { color: blue; }

--- a/packages/aliases/test/specimens/two/two.css
+++ b/packages/aliases/test/specimens/two/two.css
@@ -1,0 +1,3 @@
+@value two: "two";
+
+.two { color: blue; }

--- a/packages/paths/README.md
+++ b/packages/paths/README.md
@@ -7,7 +7,7 @@ modular-css-paths [![NPM Version](https://img.shields.io/npm/v/modular-css-paths
 
 A resolver for [`modular-css`](https://github.com/tivac/modular-css) that will let you resolve file references against arbitrary paths. Useful to avoid code like
 
-```css
+```
 @value foo from "../../../../../../../../some/other/directory/file.css";
 ```
 

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -21,6 +21,6 @@
     "test-utils": "^5.1.5"
   },
   "dependencies": {
-    "resolve-from": "^2.0.0"
+    "resolve-from": "^3.0.0"
   }
 }

--- a/packages/paths/paths.js
+++ b/packages/paths/paths.js
@@ -11,15 +11,13 @@ module.exports = function(args) {
             args
         );
     
-    options.paths = options.paths.map((dir) => from.bind(null, dir));
-
     return (src, file) => {
         var result;
 
-        options.paths.some((fn) =>
-            (result = fn(file))
+        options.paths.some((dir) =>
+            (result = from.silent(dir, file))
         );
-        
+
         return result;
     };
 };


### PR DESCRIPTION
README lays out the case for this, but basically it's a way to make simple named aliases to complex/long/ugly filepaths.

Instead of 

```
@value foo from "../../../../../../../../some/other/directory/file.css";
```

You can alias `directory` to that path, and do this

```
@value foo from "directory/file.css";
```