### PR TITLE
Reject calls to .output() if file processing isn't complete

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,11 @@
-# API
+# `Processor` API
 
-## Processor
+- [Usage](#usage)
+- [Options](#options)
+- [Properties](#properties)
+- [API](#api)
+
+## Usage
 
 Instantiate a new `Processor` instance, call it's `.file(<path>)` or `.string(<name>, <contents>)` methods, and then use the returned Promise to get access to the results/output.
 
@@ -33,9 +38,9 @@ Promise.all([
 });
 ```
 
-### Processor Options
+## Options
 
-#### `before`
+### `before`
 
 Specify an array of PostCSS plugins to be run against each file before it is processed.
 
@@ -45,7 +50,7 @@ new Processor({
 });
 ```
 
-#### `after`
+### `after`
 
 Specify an array of PostCSS plugins to be run after files are processed, but before they are combined. Plugin will be passed a `to` and `from` option.
 
@@ -57,7 +62,7 @@ new Processor({
 });
 ```
 
-#### `done`
+### `done`
 
 Specify an array of PostCSS plugins to be run against the complete combined CSS.
 
@@ -67,7 +72,7 @@ new Processor({
 });
 ```
 
-#### `map`
+### `map`
 
 Enable source map generation. Can also be passed to `.output()`.
 
@@ -87,7 +92,7 @@ new Processor({
 });
 ```
 
-#### `cwd`
+### `cwd`
 
 Specify the current working directory for this Processor instance, used when resolving `composes`/`@value` rules that reference other files.
 
@@ -99,7 +104,7 @@ new Processor({
 })
 ```
 
-#### `namer`
+### `namer`
 
 Specify a function (that takes `filename` & `selector` as arguments) to produce scoped selectors.
 
@@ -121,7 +126,7 @@ new Processor({
 });
 ```
 
-#### `resolvers`
+### `resolvers`
 
 If you want to provide your own file resolution logic you can pass an array of resolver functions. Each resolver function receives three arguments:
 
@@ -144,7 +149,7 @@ new Processor({
 })
 ```
 
-#### `exportGlobals`
+### `exportGlobals`
 
 By default identifiers wrapped in `:global(...)` are exported for ease of referencing via JS. By setting `exportGlobals` to `false` that behavior can be disabled. Mostly useful to avoid warnings when global CSS properties are not valid JS identifiers.
 
@@ -176,3 +181,38 @@ new Processor({
 }
 */
 ```
+
+## Properties
+
+### `.files`
+
+Returns an object keyed by absolute file paths of all known files in the `Processor` instance.
+
+### `.options`
+
+Returns the options object passed to the `Processor` augmented with the defaults.
+
+## APIs
+
+### `.string(file, css)`
+
+Returns a promise. Add `file` to the `Processor` instance with `css` contents.
+
+### `.file(file)`
+
+Returns a promise. Add `file` to the `Processor` instance, reads contents from disk using `fs`.
+
+### `.output([files])`
+
+Returns a promise. Finalize processing of all added CSS and create combined CSS output file. Optionally allows for combining a subset of the loaded files by passing a single file or array of files.
+
+**WARNING**: Calling `.output()` before any preceeding `.file(...)`/`.string(...)` calls have resolved their returned promises will return a rejected promise. See [usage](#usage) for an example of correct usage.
+
+### `.remove([files])`
+
+Remove files from the `Processor` instance. Accepts a single file or array of files.
+
+### `.dependencies([file])`
+
+Returns an array of file paths. Accepts a single file argument to get the dependencies for, will return entire dependency graph in order if argument is omitted.
+

--- a/packages/core/test/__snapshots__/api.test.js.snap
+++ b/packages/core/test/__snapshots__/api.test.js.snap
@@ -170,6 +170,8 @@ exports[`/processor.js API .output() should order output by dependencies, then a
 }"
 `;
 
+exports[`/processor.js API .output() should reject if called before input has been processed 1`] = `[Error: File processing not complete]`;
+
 exports[`/processor.js API .output() should return a postcss result 1`] = `
 "/* packages/core/test/specimens/folder/folder.css */
 .folder {

--- a/packages/core/test/api.test.js
+++ b/packages/core/test/api.test.js
@@ -210,6 +210,12 @@ describe("/processor.js", () => {
                 }))
                 .then((result) => expect(result.css).toMatchSnapshot())
             );
+
+            it("should reject if called before input has been processed", () => {
+                processor.file(require.resolve("./specimens/start.css"));
+
+                return expect(processor.output()).rejects.toMatchSnapshot();
+            });
         });
 
         describe("._resolve()", () => {


### PR DESCRIPTION
See #324 for an example of how this can bite you currently. Also adds documentation on `Processor` methods/properties so that this gotcha can be called out in the docs that now exist.