### PR TITLE
fix "Cannot read propoerty 'search' of undefined"

### DIFF
--- a/packages/core/plugins/values-export.js
+++ b/packages/core/plugins/values-export.js
@@ -6,7 +6,7 @@ var search = /values-local|values-composed/;
 module.exports = (css, result) => {
     var file   = result.opts.files[result.opts.from],
         values = result.messages
-            .filter((msg) => msg.plugin.search(search) > -1)
+            .filter((msg) => msg.plugin && msg.plugin.search(search) > -1)
             .reduce((prev, curr) => Object.assign(prev, curr.values), Object.create(null));
     
     file.values = Object.assign(file.values || Object.create(null), values);


### PR DESCRIPTION
Messages with field `plugin` unfortunately are not standard so relying on this field can lead to problems like `Cannot read property 'search' of undefined`
E.g https://github.com/postcss/postcss-import#dependency-message-support