### PR TITLE
Add a hint to the example Rollup config to avoid Unexpected Token error

### DIFF
--- a/docs/rollup.md
+++ b/docs/rollup.md
@@ -34,6 +34,7 @@ All other options are passed to the underlying `Processor` instance, see [Option
 rollup({
     entry   : "./index.js",
     plugins : [
+        // Make sure it's the first entry in your plugin list to avoid syntax errors
         require("modular-css-rollup")({
             css : "./gen/index.css"
         })


### PR DESCRIPTION
Not sure if you want this to be added to the docs but it took me way too long to figure out why I was getting `Unexpected token (1:0)` errors when running Rollup.

Even if you don't accept it, I hope it might help some future user searching for a solution to stumble upon this PR.