### PR TITLE
Rollup docs: plugin name has been renamed

### DIFF
--- a/docs/rollup.md
+++ b/docs/rollup.md
@@ -1,6 +1,6 @@
 # Rollup
 
-`modular-css/rollup` provides a rollup build plugin you can use to transform imported `.css` files into lookup objects.
+`modular-css-rollup` provides a rollup build plugin you can use to transform imported `.css` files into lookup objects.
 
 ## Options
 


### PR DESCRIPTION
Small tweak for the Rollup docs: the plugin for Rollup now has it's own package `modular-css-rollup`.