### PR TITLE
Don't nest Root nodes

### DIFF
--- a/packages/browserify/test/__snapshots__/issue-58.test.js.snap
+++ b/packages/browserify/test/__snapshots__/issue-58.test.js.snap
@@ -40,7 +40,6 @@ exports[`/browserify.js /issues /58 should update when CSS dependencies change 3
 .mc46e4a65d_issue1 {
     color: teal;
 }
-
 .mc46e4a65d_issue2 {
     color: aqua;
 }

--- a/packages/core/processor.js
+++ b/packages/core/processor.js
@@ -251,7 +251,13 @@ Processor.prototype = {
                 root.append(result.root.nodes);
 
                 idx = root.index(comment);
-                
+
+                if(idx > 0) {
+                    comment.raws.before = "\n\n";
+                }
+
+                root.raws.after = result.root.raws.after;
+
                 // Need to manually insert a newline after the comment, but can only
                 // do that via whatever comes after it for some reason?
                 // I'm not clear why comment nodes lack a `.raws.after` property
@@ -261,7 +267,7 @@ Processor.prototype = {
                     root.nodes[idx + 1].raws.before = "\n";
                 }
             });
-            
+
             return this._done.process(
                 root,
                 params(this, args)

--- a/packages/core/processor.js
+++ b/packages/core/processor.js
@@ -247,10 +247,8 @@ Processor.prototype = {
                     }),
                     idx;
                 
-                root.append([
-                    comment,
-                    result.root
-                ]);
+                root.append(comment);
+                root.append(result.root.nodes);
 
                 idx = root.index(comment);
                 

--- a/packages/core/test/__snapshots__/api.test.js.snap
+++ b/packages/core/test/__snapshots__/api.test.js.snap
@@ -137,7 +137,6 @@ exports[`/processor.js API .output() should order output by dependencies, then a
 
 /* packages/core/test/specimens/composes.css */
 
-
 /* packages/core/test/specimens/deep.css */
 .deep {
     

--- a/packages/core/test/__snapshots__/externals.test.js.snap
+++ b/packages/core/test/__snapshots__/externals.test.js.snap
@@ -14,7 +14,6 @@ exports[`/processor.js externals should support overriding external values 1`] =
 .a .wooga {
     color: green;
 }
-
 .b:hover .booga {
     background: blue;
 }

--- a/packages/core/test/__snapshots__/options.test.js.snap
+++ b/packages/core/test/__snapshots__/options.test.js.snap
@@ -49,13 +49,11 @@ a {}"
 
 exports[`/processor.js options lifecycle options done should run async postcss plugins done processing 1`] = `
 "/* packages/core/test/specimens/async-done.css */
-
 a {}"
 `;
 
 exports[`/processor.js options lifecycle options done should run sync postcss plugins done processing 1`] = `
 "/* packages/core/test/specimens/sync-done.css */
-
 a {}"
 `;
 

--- a/packages/core/test/__snapshots__/values.test.js.snap
+++ b/packages/core/test/__snapshots__/values.test.js.snap
@@ -16,7 +16,6 @@ exports[`/processor.js values should support simple values 1`] = `
 exports[`/processor.js values should support value composition 1`] = `
 "/* packages/core/test/specimens/values.css */
 
-
 /* packages/core/test/specimens/value-composition.css */
 .red {
     color: red;
@@ -27,12 +26,10 @@ exports[`/processor.js values should support value composition 1`] = `
 exports[`/processor.js values should support value namespaces 1`] = `
 "/* packages/core/test/specimens/values.css */
 
-
 /* packages/core/test/specimens/value-namespace.css */
 .red {
     color: red;
 }
-
 .blue {
     color: blue;
 }
@@ -53,7 +50,6 @@ exports[`/processor.js values should support value replacement in :external(...)
 .a .wooga {
     color: green;
 }
-
 .b:hover .booga {
     background: blue;
 }

--- a/packages/core/test/issues/__snapshots__/issue-191.test.js.snap
+++ b/packages/core/test/issues/__snapshots__/issue-191.test.js.snap
@@ -7,6 +7,5 @@ exports[`/issues /191 should ignore case differences in file paths 1`] = `
 }
 
 /* packages/core/test/issues/specimens/191/start.css */
-
 "
 `;


### PR DESCRIPTION
cssnano@4 (more specific postcss-discard-duplicates) doesn't like this and I couldn't find any other module doing this.

Instead of appending the single root node this will append all child nodes of the individual files. This shouldn't change anything…