### PR TITLE
feat: revert #266 to be more like #158

### DIFF
--- a/packages/browserify/test/browserify.test.js
+++ b/packages/browserify/test/browserify.test.js
@@ -12,7 +12,7 @@ var browserify = require("browserify"),
     plugin = require("../browserify.js");
 
 // Because these tests keep failing CI...
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
 
 describe("/browserify.js", function() {
     afterAll(() => shell.rm("-rf", "./packages/browserify/test/output/browserify"));

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -94,10 +94,20 @@ console.log(css);
 
 exports[`/rollup.js watch should generate correct builds in watch mode when files change 1`] = `
 "/* packages/rollup/test/output/watched.css */
-.mc580619a9_one { color: red; }"
+.mc580619a9_one { color: red; }
+/* packages/rollup/test/specimens/simple.css */
+.mc12d71625_fooga {
+    color: red;
+}
+"
 `;
 
 exports[`/rollup.js watch should generate correct builds in watch mode when files change 2`] = `
 "/* packages/rollup/test/output/watched.css */
-.mc580619a9_two { color: blue; }"
+.mc580619a9_two { color: blue; }
+/* packages/rollup/test/specimens/simple.css */
+.mc12d71625_fooga {
+    color: red;
+}
+"
 `;

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -285,7 +285,7 @@ describe("/rollup.js", () => {
 
             // Start watching (re-requiring rollup because it needs root obj reference)
             watcher = watch(require("rollup"), {
-                entry   : require.resolve("./specimens/rollup/watch.js"),
+                entry   : require.resolve("./specimens/watch.js"),
                 dest    : "./packages/rollup/test/output/watch.js",
                 format  : "es",
                 plugins : [

--- a/packages/rollup/test/specimens/rollup/watch.js
+++ b/packages/rollup/test/specimens/rollup/watch.js
@@ -1,3 +1,0 @@
-import css from "../../output/watched.css";
-
-console.log(css);

--- a/packages/rollup/test/specimens/watch.js
+++ b/packages/rollup/test/specimens/watch.js
@@ -1,0 +1,4 @@
+import css from "../output/watched.css";
+import css2 from "./simple.css";
+
+console.log(css, css2);


### PR DESCRIPTION
Fixes #345

Turns out that `rollup-watch` only calls `transform` for files that changed (were purged from the `cache` object), so only changes files exist in the second pass on a bundle. That's... bad.

Instead go back to remove dependencies and re-processing if they're "new", but only after the first run. Still feels kludgey but seems to work ok after cleaning up the watch test to be a bit more interesting.