### PR TITLE
Add 2 (failing) tests using cssnano@4.0.0-rc.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,8 @@
   ],
   "devDependencies": {
     "pegjs": "^0.10.0",
-    "test-utils": "^5.1.5"
+    "test-utils": "^5.1.5",
+    "cssnano": "^4.0.0-rc.1"
   },
   "dependencies": {
     "dependency-graph": "^0.5.0",

--- a/packages/core/test/options.test.js
+++ b/packages/core/test/options.test.js
@@ -244,6 +244,36 @@ describe("/processor.js", function() {
                     .then(() => processor.output())
                     .then((result) => expect(result.css).toMatchSnapshot());
                 });
+
+                it("should work with cssnano (no preset)", () => {
+                    var processor = new Processor({
+                        namer,
+                        done : [ require("cssnano") ]
+                    });
+
+                    return processor.file(
+                        "./packages/core/test/specimens/local.css"
+                    )
+                    .then(() => processor.output({ to : "./packages/core/test/output/local.css" }))
+                    .then((result) => expect(result.css).toMatchSnapshot());
+                });
+
+                it("should work with cssnano (default preset)", () => {
+                    var processor = new Processor({
+                        namer,
+                        done : [ 
+                            require("cssnano")({
+                                 preset : "default"
+                            })
+                        ]
+                    });
+
+                    return processor.file(
+                        "./packages/core/test/specimens/local.css"
+                    )
+                    .then(() => processor.output({ to : "./packages/core/test/output/local.css" }))
+                    .then((result) => expect(result.css).toMatchSnapshot());
+                });
             });
         });
     });


### PR DESCRIPTION
This adds 2 failing tests using `cssnano@4.0.0-rc.1` as done lifecycle option:

1. **should work with cssnano (no preset)**  
When not passing a preset to cssnano it tries to find a config file using `root.source`. This is not set when creating the Root node with `postcss.root()`. In my opinion this is a cssnano bug (Created a PR for it here: ben-eb/cssnano#382).
2. **should work with cssnano (default preset)**
[`postcss-discard-duplicates`](https://github.com/ben-eb/cssnano/tree/master/packages/postcss-discard-duplicates) can't handle nested `Root` nodes, it only expects `Rule`, `AtRule`, `Declaration` or `Comment` ([src/index.js:107-112](https://github.com/ben-eb/cssnano/blob/master/packages/postcss-discard-duplicates/src/index.js#L107-L112)). Maybe this could be fixed in cssnano, but other tools might not like nested `Root` nodes too, thats why I tried to fix it here in #346.

<details><summary>Travis output (Click to expand)</summary><p>

```
  ● /processor.js › options › lifecycle options › done › should work with cssnano (no preset)
    TypeError: Cannot read property 'input' of undefined
      
      at fromFile (packages/core/node_modules/cssnano/dist/index.js:51:30)
      at resolveConfig (packages/core/node_modules/cssnano/dist/index.js:113:26)
      at packages/core/node_modules/cssnano/dist/index.js:125:16
      at LazyResult.run (packages/core/node_modules/postcss/lib/lazy-result.js:270:20)
      at LazyResult.asyncTick (packages/core/node_modules/postcss/lib/lazy-result.js:185:32)
      at processing.Promise.then._this2.processed (packages/core/node_modules/postcss/lib/lazy-result.js:224:20)
      at LazyResult.async (packages/core/node_modules/postcss/lib/lazy-result.js:221:27)
      at LazyResult.then (packages/core/node_modules/postcss/lib/lazy-result.js:127:21)
  ● /processor.js › options › lifecycle options › done › should work with cssnano (default preset)
    TypeError: handlers[last.type] is not a function
      
      at dedupe (packages/core/node_modules/postcss-discard-duplicates/dist/index.js:134:28)
      at initializePlugin (packages/core/node_modules/cssnano/dist/index.js:41:51)
```
</p></details>