### PR TITLE
fix: Multiple :externals() should work

### DIFF
--- a/packages/core/plugins/externals.js
+++ b/packages/core/plugins/externals.js
@@ -46,16 +46,21 @@ module.exports = (css, result) => {
     }
     
     css.walkRules(/:external/, (rule) => {
-        var externals = selector((selectors) =>
+        var externals = selector((selectors) => {
+                var found = [];
+                
                 selectors.walkPseudos((pseudo) => {
                     // Need to ensure we only process :external pseudos, see #261
                     if(pseudo.value !== ":external") {
                         return;
                     }
                     
-                    process(rule, pseudo);
-                })
-            );
+                    // Can't replace here, see postcss/postcss-selector-parser#105
+                    found.push(pseudo);
+                });
+
+                found.forEach((pseudo) => process(rule, pseudo));
+            });
         
         rule.selector = externals.process(rule.selector).result;
     });

--- a/packages/core/test/__snapshots__/externals.test.js.snap
+++ b/packages/core/test/__snapshots__/externals.test.js.snap
@@ -14,7 +14,6 @@ exports[`/processor.js externals should support overriding external values 1`] =
 .b:hover .booga {
     background: blue;
 }
-
 .wooga .booga {
     color: red;
 }

--- a/packages/core/test/__snapshots__/externals.test.js.snap
+++ b/packages/core/test/__snapshots__/externals.test.js.snap
@@ -14,5 +14,9 @@ exports[`/processor.js externals should support overriding external values 1`] =
 .b:hover .booga {
     background: blue;
 }
+
+.wooga .booga {
+    color: red;
+}
 "
 `;

--- a/packages/core/test/__snapshots__/values.test.js.snap
+++ b/packages/core/test/__snapshots__/values.test.js.snap
@@ -49,5 +49,9 @@ exports[`/processor.js values should support value replacement in :external(...)
 .b:hover .booga {
     background: blue;
 }
+
+.wooga .booga {
+    color: red;
+}
 "
 `;

--- a/packages/core/test/__snapshots__/values.test.js.snap
+++ b/packages/core/test/__snapshots__/values.test.js.snap
@@ -49,7 +49,6 @@ exports[`/processor.js values should support value replacement in :external(...)
 .b:hover .booga {
     background: blue;
 }
-
 .wooga .booga {
     color: red;
 }

--- a/packages/core/test/specimens/externals.css
+++ b/packages/core/test/specimens/externals.css
@@ -6,6 +6,7 @@
 
 .b:hover :external(booga from localCss) {
     background: blue;
+}
 
 :external(wooga from "./simple.css") :external(booga from localCss) {
     color: red;

--- a/packages/core/test/specimens/externals.css
+++ b/packages/core/test/specimens/externals.css
@@ -6,4 +6,7 @@
 
 .b:hover :external(booga from localCss) {
     background: blue;
+
+:external(wooga from "./simple.css") :external(booga from localCss) {
+    color: red;
 }


### PR DESCRIPTION
Same issue as in #277, https://github.com/postcss/postcss-selector-parser/pull/105 should fix it hopefully. Not out yet and want to Fix #342 so using the same workaround for now.