### PR TITLE
Overlapping value replacement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
-sudo: false
+# Force a VM instead of Docker, some tests that depend on the FS fail otherwise
+sudo: required
 
 language: node_js
 node_js:
 - node
-- '7'
-- '6'
+- '8'
 
 # https://docs.travis-ci.com/user/customizing-the-build/#Fast-Finishing
 matrix:

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,16 +23,6 @@
         }
       }
     },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -1163,8 +1153,8 @@
       "integrity": "sha512-8od6g684Fhi5Vpp4ABRv/RBsW1AY6wSHbJHEK6FGTv+8jvAAnlABniZu/FVmX9TcirkHepaEsa1QGkRvbg0CKw==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
         "is-text-path": "1.0.1",
+        "JSONStream": "1.3.1",
         "lodash": "4.17.4",
         "meow": "3.7.0",
         "split2": "2.2.0",
@@ -4605,6 +4595,16 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -6597,6 +6597,15 @@
       "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -6649,15 +6658,6 @@
             "ansi-regex": "3.0.0"
           }
         }
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringify-object": {

--- a/packages/browserify/test/__snapshots__/issue-58.test.js.snap
+++ b/packages/browserify/test/__snapshots__/issue-58.test.js.snap
@@ -41,6 +41,5 @@ exports[`/browserify.js /issues /58 should update when CSS dependencies change 3
 }
 .mc46e4a65d_issue2 {
     color: aqua;
-}
-"
+}"
 `;

--- a/packages/browserify/test/specimens/issues/58/1.css
+++ b/packages/browserify/test/specimens/issues/58/1.css
@@ -1,3 +1,0 @@
-.other1 { color: red; }
-.other2 { color: navy; }
-.other3 { color: blue; }

--- a/packages/browserify/test/specimens/issues/58/2.css
+++ b/packages/browserify/test/specimens/issues/58/2.css
@@ -1,3 +1,0 @@
-.other1 { color: green; }
-.other2 { color: yellow; }
-.other3 { composes: other2; background: white; }

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -13,9 +13,6 @@ function success(out) {
 }
     
 describe("/cli.js", function() {
-    // Since these tests keep failing on Travis...
-    jest.setTimeout(10000);
-    
     afterAll(() => require("shelljs").rm("-rf", "./packages/cli/test/output"));
 
     it("should show help with no args", () =>

--- a/packages/core/plugins/values-replace.js
+++ b/packages/core/plugins/values-replace.js
@@ -69,6 +69,7 @@ module.exports = (css, result) => {
 
     matchRegex = new RegExp(
         Object.keys(values)
+            .sort((a, b) => b.length - a.length)
             .map((v) => `\\b${escape(v)}\\b`)
             .join("|"),
         "g"

--- a/packages/core/test/__snapshots__/values.test.js.snap
+++ b/packages/core/test/__snapshots__/values.test.js.snap
@@ -73,6 +73,10 @@ exports[`/processor.js values should support value namespaces 1`] = `
 .blue {
     color: blue;
 }
+
+.other {
+    color: #000;
+}
 "
 `;
 

--- a/packages/core/test/specimens/value-namespace.css
+++ b/packages/core/test/specimens/value-namespace.css
@@ -7,3 +7,7 @@
 .blue {
     color: colors.b;
 }
+
+.other {
+    color: colors.base-other;
+}

--- a/packages/core/test/specimens/values.css
+++ b/packages/core/test/specimens/values.css
@@ -1,2 +1,4 @@
 @value a: red;
 @value b: blue;
+@value base: #FFF;
+@value base-other: #000;


### PR DESCRIPTION
Fixes #363 by sorting values by length so that longer replacements match first.

A little hacky-feeling, but seems ok after thinking about it for a bit.

This commit also solves the recurring travis failures I've been seeing thanks to a [tip from @darthmaim in gitter](https://gitter.im/modular-css/modular-css?at=5a08ca87505b630c05d4d848).