### PR TITLE
feat: processor.remove returns removed files

### DIFF
--- a/packages/core/processor.js
+++ b/packages/core/processor.js
@@ -147,7 +147,7 @@ Processor.prototype = {
     // Remove a file from the dependency graph
     remove : function(input) {
         var order = this._graph.overallOrder(),
-            files;
+            files, removed;
         
         // Only want files actually in the array
         files = (Array.isArray(input) ? input : [ input ])
@@ -160,21 +160,23 @@ Processor.prototype = {
 
         // Remove everything that depends on files to be removed as well
         // since it will also have to be recalculated
-        files = files
-            .reduce(
-                (prev, curr) => prev.concat(
-                    this._graph.dependantsOf(curr)
-                        .concat(curr)
-                ),
-                []
-            )
-            .sort((a, b) => order.indexOf(a) - order.indexOf(b));
-
-        unique(files).forEach((file) => {
+        files = files.reduce((prev, curr) =>
+            prev.concat(
+                this._graph.dependantsOf(curr).concat(curr)
+            ),
+            []
+        )
+        .sort((a, b) => order.indexOf(a) - order.indexOf(b));
+        
+        removed = unique(files);
+        
+        removed.forEach((file) => {
             delete this._files[file];
 
             this._graph.removeNode(file);
         });
+
+        return removed;
     },
     
     // Get the dependency order for a file or the entire tree

--- a/packages/core/test/__snapshots__/api.test.js.snap
+++ b/packages/core/test/__snapshots__/api.test.js.snap
@@ -178,6 +178,13 @@ Array [
 ]
 `;
 
+exports[`/processor.js API .remove() should return an array of removed files 1`] = `
+Array [
+  "a.css",
+  "b.css",
+]
+`;
+
 exports[`/processor.js API .string() should process a string 1`] = `
 Object {
   "wooga": Array [

--- a/packages/core/test/api.test.js
+++ b/packages/core/test/api.test.js
@@ -114,6 +114,24 @@ describe("/processor.js", () => {
                     expect(processor.dependencies()).toEqual([]);
                 })
             );
+            
+            it("should return an array of removed files", () =>
+                Promise.all([
+                    processor.string("./a.css", ".a { }"),
+                    processor.string("./b.css", ".b { }"),
+                    processor.string("./c.css", ".c { }")
+                ])
+                .then(() => {
+                    expect(
+                        relative(
+                            processor.remove([
+                                "./a.css",
+                                "./b.css"
+                            ])
+                        )
+                    ).toMatchSnapshot();
+                })
+            );
         });
         
         describe(".dependencies()", () => {


### PR DESCRIPTION
This will enable fixing of #353 once the changes to `modular-css-rollup` lands.