### PR TITLE
fix: rollup watching loses file contents

### DIFF
--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -44,9 +44,14 @@ module.exports = function(opts) {
                 return null;
             }
 
+            console.log("Rollup processing: ", id);
+            
+
             // If the file is being re-processed we need to remove it to
             // avoid cache staleness issues
             if(runs) {
+                console.log("Rollup removing: ", id);
+
                 processor.remove(id);
             }
 

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -92,6 +92,30 @@ console.log(css);
 }
 `;
 
+exports[`/rollup.js watch should correctly update files within the dependency graph in watch mode when files change 1`] = `
+"/* packages/rollup/test/output/one.css */
+.mc19ef5610_one {
+    color: red;
+}
+/* packages/rollup/test/output/two.css */
+.mc32dbcb4b_two {
+    
+    color: blue;
+}"
+`;
+
+exports[`/rollup.js watch should correctly update files within the dependency graph in watch mode when files change 2`] = `
+"/* packages/rollup/test/output/one.css */
+.mc19ef5610_one {
+    color: green;
+}
+/* packages/rollup/test/output/two.css */
+.mc32dbcb4b_two {
+    
+    color: blue;
+}"
+`;
+
 exports[`/rollup.js watch should generate correct builds in watch mode when files change 1`] = `
 "/* packages/rollup/test/output/watched.css */
 .mc580619a9_one { color: red; }

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -334,7 +334,6 @@ describe("/rollup.js", () => {
         it("should correctly update files within the dependency graph in watch mode when files change", (done) => {
             var builds = 0;
             
-            
             // Create v1 of the files
             fs.writeFileSync(
                 "./packages/rollup/test/output/one.css",

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -17,7 +17,7 @@ function error(root) {
 error.postcssPlugin = "error-plugin";
 
 describe("/rollup.js", () => {
-    // afterEach(() => require("shelljs").rm("-rf", "./packages/rollup/test/output/*"));
+    afterEach(() => require("shelljs").rm("-rf", "./packages/rollup/test/output/*"));
     
     it("should be a function", () =>
         expect(typeof plugin).toBe("function")


### PR DESCRIPTION
Fixes #353 
Depends on #376 (which was cherry-picked out of this branch, I know it's weird)

Change rollup logic to re-add all the files that were removed instead of just the one that was changed. 