### PR TITLE
docs: `:global()` reset clarification

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -65,6 +65,7 @@ var css = require("./styles.css");
 Selector scoping is **only** done on simple classes/ids, any selectors containing tags or pseudo-selectors won't be exported.
 
 `:global()` is treated the same as a CSS pseudo-class and therefore cannot wrap multiple comma seperated rules. For example if you're using a CSS reset the following is required:
+
 ```css
 /* Local Scoped */
 ol, ul {
@@ -81,7 +82,8 @@ ol, ul {
     list-style: none;
 }
 ```
-Adding `:global()` to every comma seperated rule would be tedious when using something like [Eric Meyer's CSS Reset](http://meyerweb.com/eric/tools/css/reset/). Therefore it is recommended that you seperate the reset in to its own file, and make use of the [postcss-import](https://github.com/postcss/postcss-import) module with the [after](https://github.com/tivac/modular-css/blob/master/docs/api.md#after) or [done](https://github.com/tivac/modular-css/blob/master/docs/api.md#done) hooks to include the file when modular-css has finished processing. You would then just need to include `@import "reset.css";` somewhere in one of your CSS files.
+
+Adding `:global()` to every comma seperated rule would be tedious when using something like [Eric Meyer's CSS Reset](http://meyerweb.com/eric/tools/css/reset/). Therefore it is recommended that you seperate the reset in to its own file, and make use of the [postcss-import](https://github.com/postcss/postcss-import) module with the [after](https://github.com/tivac/modular-css/blob/master/docs/api.md#after) or [done](https://github.com/tivac/modular-css/blob/master/docs/api.md#done) hooks to include the file when modular-css has finished processing. You would then need to include `@import "reset.css";` somewhere in one of your CSS files.
 
 ## Composition
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -64,6 +64,25 @@ var css = require("./styles.css");
 
 Selector scoping is **only** done on simple classes/ids, any selectors containing tags or pseudo-selectors won't be exported.
 
+`:global()` is treated the same as a CSS pseudo-class and therefore cannot wrap multiple comma seperated rules. For example if you're using a CSS reset the following is required:
+```css
+/* Local Scoped */
+ol, ul {
+    list-style: none;
+}
+
+/* Global Scoped (Wrong!) */
+:global(ol, ul) {
+    list-style: none;
+}
+
+/* Global Scoped (Correct!) */
+:global(ol), :global(ul) {
+    list-style: none;
+}
+```
+Adding `:global()` to every comma seperated rule would be tedious when using something like [Eric Meyer's CSS Reset](http://meyerweb.com/eric/tools/css/reset/). Therefore it is recommended that you seperate the reset in to its own file, and make use of the [postcss-import](https://github.com/postcss/postcss-import) module with the [after](https://github.com/tivac/modular-css/blob/master/docs/api.md#after) or [done](https://github.com/tivac/modular-css/blob/master/docs/api.md#done) hooks to include the file when modular-css has finished processing. You would then just need to include `@import "reset.css";` somewhere in one of your CSS files.
+
 ## Composition
 
 Selector limitations mean that it's difficult to use complicated selectors, so to enable building anything of complexity you can compose selectors. These compositions can be within a file or even pull in classes defined in other files.


### PR DESCRIPTION
Added clarification of how `:global()` should be used with comma separated rules, and recommendation for when large amounts of comma separated rules are used e.g. in resets. As discussed in [#395](https://github.com/tivac/modular-css/issues/395)