### PR TITLE
Correctly support named exports of  @value

### DIFF
--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -18,7 +18,7 @@
     "postcss"
   ],
   "devDependencies": {
-    "rollup": "^0.51.8",
+    "rollup": "^0.56.1",
     "test-utils": "^8.0.0"
   },
   "dependencies": {

--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -67,11 +67,10 @@ module.exports = function(opts) {
                 )
             )
             .then((results) => {
-                var result  = results[0],
-                    classes = output.join(result.exports),
-                    named   = Object.keys(classes),
-                    out     = [
-                        `export default ${JSON.stringify(classes, null, 4)};`
+                var result   = results[0],
+                    exported = output.join(result.exports),
+                    out      = [
+                        `export default ${JSON.stringify(exported, null, 4)};`
                     ];
                 
                 // Add dependencies
@@ -88,14 +87,14 @@ module.exports = function(opts) {
                     };
                 }
 
-                named.forEach((ident) => {
+                Object.keys(exported).forEach((ident) => {
                     if(keyword.isReservedWordES6(ident) || !keyword.isIdentifierNameES6(ident)) {
                         options.onwarn(`Invalid JS identifier "${ident}", unable to export`);
                         
                         return;
                     }
 
-                    out.push(`export var ${ident} = "${classes[ident]}";`);
+                    out.push(`export var ${ident} = ${JSON.stringify(exported[ident])};`);
                 });
 
                 return {

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -56,10 +56,13 @@ exports[`/rollup.js should not output sourcemaps when they are disabled 1`] = `
 `;
 
 exports[`/rollup.js should provide named exports 1`] = `
-"var val = \\"\\\\\\"value\\\\\\"\\";
+"var str = \\"\\\\\\"string\\\\\\"\\";
+var num = \\"10\\";
+var dim = \\"10px\\";
+var mix = \\"1px solid red\\";
 var a = \\"a\\";
 
-console.log(a, val);
+console.log(a, str, num, dim, mix);
 "
 `;
 

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -88,7 +88,7 @@ console.log(css, fooga);
 
 exports[`/rollup.js shouldn't disable sourcemap generation 1`] = `
 Object {
-  "file": null,
+  "file": "simple.js",
   "mappings": ";;;;;AAEA,OAAO,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC",
   "names": Array [],
   "sourcesContent": Array [

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`/rollup.js should allow disabling of named exports 1`] = `
 "var css = {
+    \\"str\\": \\"\\\\\\"string\\\\\\"\\",
     \\"fooga\\": \\"fooga\\"
 };
 
@@ -22,12 +23,13 @@ exports[`/rollup.js should generate CSS 1`] = `
     color: red;
 }
 
-/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uL3NwZWNpbWVucy9zaW1wbGUuY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLCtDQUFDO0FBQUQ7SUFDSSxXQUFXO0NBQ2QiLCJmaWxlIjoic2ltcGxlLmNzcyIsInNvdXJjZXNDb250ZW50IjpbIi5mb29nYSB7XG4gICAgY29sb3I6IHJlZDtcbn1cbiJdfQ== */"
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uL3NwZWNpbWVucy9zaW1wbGUuY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLCtDQUFDO0FBRUQ7SUFDSSxXQUFXO0NBQ2QiLCJmaWxlIjoic2ltcGxlLmNzcyIsInNvdXJjZXNDb250ZW50IjpbIkB2YWx1ZSBzdHI6IFwic3RyaW5nXCI7XG5cbi5mb29nYSB7XG4gICAgY29sb3I6IHJlZDtcbn1cbiJdfQ== */"
 `;
 
 exports[`/rollup.js should generate JSON 1`] = `
 "{
     \\"packages/rollup/test/specimens/simple.css\\": {
+        \\"str\\": \\"\\\\\\"string\\\\\\"\\",
         \\"fooga\\": \\"fooga\\"
     }
 }"
@@ -35,6 +37,7 @@ exports[`/rollup.js should generate JSON 1`] = `
 
 exports[`/rollup.js should generate exports 1`] = `
 "var css = {
+    \\"str\\": \\"\\\\\\"string\\\\\\"\\",
     \\"fooga\\": \\"fooga\\"
 };
 
@@ -42,7 +45,7 @@ console.log(css);
 "
 `;
 
-exports[`/rollup.js should generate external source maps 1`] = `"{\\"version\\":3,\\"sources\\":[\\"../specimens/simple.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,+CAAC;AAAD;IACI,WAAW;CACd\\",\\"file\\":\\"simple.css\\",\\"sourcesContent\\":[\\".fooga {\\\\n    color: red;\\\\n}\\\\n\\"]}"`;
+exports[`/rollup.js should generate external source maps 1`] = `"{\\"version\\":3,\\"sources\\":[\\"../specimens/simple.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,+CAAC;AAED;IACI,WAAW;CACd\\",\\"file\\":\\"simple.css\\",\\"sourcesContent\\":[\\"@value str: \\\\\\"string\\\\\\";\\\\n\\\\n.fooga {\\\\n    color: red;\\\\n}\\\\n\\"]}"`;
 
 exports[`/rollup.js should not output sourcemaps when they are disabled 1`] = `
 "/* packages/rollup/test/specimens/simple.css */
@@ -53,9 +56,10 @@ exports[`/rollup.js should not output sourcemaps when they are disabled 1`] = `
 `;
 
 exports[`/rollup.js should provide named exports 1`] = `
-"var a = \\"a\\";
+"var val = \\"\\\\\\"value\\\\\\"\\";
+var a = \\"a\\";
 
-console.log(a);
+console.log(a, val);
 "
 `;
 
@@ -82,7 +86,7 @@ console.log(css, fooga);
 exports[`/rollup.js shouldn't disable sourcemap generation 1`] = `
 Object {
   "file": null,
-  "mappings": ";;;;AAEA,OAAO,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC",
+  "mappings": ";;;;;AAEA,OAAO,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC",
   "names": Array [],
   "sourcesContent": Array [
     "import css from \\"./simple.css\\";

--- a/packages/rollup/test/specimens/named.css
+++ b/packages/rollup/test/specimens/named.css
@@ -1,4 +1,7 @@
-@value val: "value";
+@value str: "string";
+@value num: 10;
+@value dim: 10px;
+@value mix: 1px solid red;
 
 .a {
     color: red;

--- a/packages/rollup/test/specimens/named.css
+++ b/packages/rollup/test/specimens/named.css
@@ -1,3 +1,5 @@
+@value val: "value";
+
 .a {
     color: red;
 }

--- a/packages/rollup/test/specimens/named.js
+++ b/packages/rollup/test/specimens/named.js
@@ -1,3 +1,3 @@
-import {a} from "./named.css";
+import { a, val } from "./named.css";
 
-console.log(a);
+console.log(a, val);

--- a/packages/rollup/test/specimens/named.js
+++ b/packages/rollup/test/specimens/named.js
@@ -1,3 +1,3 @@
-import { a, val } from "./named.css";
+import { a, str, num, dim, mix } from "./named.css";
 
-console.log(a, val);
+console.log(a, str, num, dim, mix);

--- a/packages/rollup/test/specimens/simple.css
+++ b/packages/rollup/test/specimens/simple.css
@@ -1,3 +1,5 @@
+@value str: "string";
+
 .fooga {
     color: red;
 }

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -22,9 +22,9 @@
   ],
   "devDependencies": {
     "dedent": "^0.7.0",
-    "rollup": "^0.51.8",
-    "rollup-plugin-svelte": "^3.3.0",
-    "svelte": "^1.46.0"
+    "rollup": "^0.56.1",
+    "rollup-plugin-svelte": "^4.0.0",
+    "svelte": "^1.55.0"
   },
   "dependencies": {
     "mkdirp": "^0.5.1",

--- a/packages/svelte/test/__snapshots__/rollup.test.js.snap
+++ b/packages/svelte/test/__snapshots__/rollup.test.js.snap
@@ -166,7 +166,7 @@ function _set(newState) {
 }
 
 function callAll(fns) {
-	while (fns && fns.length) fns.shift()();
+	while (fns && fns.length) fns.pop()();
 }
 
 function _mount(target, anchor) {

--- a/packages/svelte/test/__snapshots__/rollup.test.js.snap
+++ b/packages/svelte/test/__snapshots__/rollup.test.js.snap
@@ -50,8 +50,8 @@ function destroy(detach) {
 	this._fragment = this._state = null;
 }
 
-function differs(a, b) {
-	return a !== b || ((a && typeof a === 'object') || typeof a === 'function');
+function _differs(a, b) {
+	return a != a ? b == b : a !== b || ((a && typeof a === 'object') || typeof a === 'function');
 }
 
 function dispatchObservers(component, group, changed, newState, oldState) {
@@ -150,7 +150,7 @@ function _set(newState) {
 		dirty = false;
 
 	for (var key in newState) {
-		if (differs(newState[key], oldState[key])) changed[key] = dirty = true;
+		if (this._differs(newState[key], oldState[key])) changed[key] = dirty = true;
 	}
 	if (!dirty) return;
 
@@ -166,7 +166,7 @@ function _set(newState) {
 }
 
 function callAll(fns) {
-	while (fns && fns.length) fns.pop()();
+	while (fns && fns.length) fns.shift()();
 }
 
 function _mount(target, anchor) {
@@ -188,8 +188,10 @@ var proto = {
 	_recompute: noop,
 	_set: _set,
 	_mount: _mount,
-	_unmount: _unmount
+	_unmount: _unmount,
+	_differs: _differs
 };
+
 
 
 function create_main_fragment(state, component) {

--- a/packages/webpack/loader.js
+++ b/packages/webpack/loader.js
@@ -20,10 +20,9 @@ module.exports = function(source) {
 
     return processor.string(this.resourcePath, source)
         .then((result) => {
-            var classes = output.join(result.exports),
-                named   = Object.keys(classes),
-                out     = [
-                    `export default ${JSON.stringify(classes, null, 4)};`
+            var exported = output.join(result.exports),
+                out      = [
+                    `export default ${JSON.stringify(exported, null, 4)};`
                 ];
 
             processor.dependencies(this.resourcePath).forEach(this.addDependency);
@@ -35,14 +34,14 @@ module.exports = function(source) {
             
             // Warn if any of the exported CSS wasn't able to be used as a valid JS identifier
             // and exclude from the output
-            named.forEach((ident) => {
+            Object.keys(exported).forEach((ident) => {
                 if(keyword.isReservedWordES6(ident) || !keyword.isIdentifierNameES6(ident)) {
                     this.emitWarning(new Error(`Invalid JS identifier "${ident}", unable to export`));
                     
                     return;
                 }
 
-                out.push(`export var ${ident} = "${classes[ident]}";`);
+                out.push(`export var ${ident} = ${JSON.stringify(exported[ident])};`);
             });
 
             return done(null, out.join("\n"));

--- a/packages/webpack/test/__snapshots__/webpack.test.js.snap
+++ b/packages/webpack/test/__snapshots__/webpack.test.js.snap
@@ -905,12 +905,15 @@ console.log(__WEBPACK_IMPORTED_MODULE_0__es2015_css__[\\"a\\" /* default */]);
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 \\"use strict\\";
+/* unused harmony export val */
 /* unused harmony export a */
 /* unused harmony export b */
 /* harmony default export */ __webpack_exports__[\\"a\\"] = ({
+    \\"val\\": \\"\\\\\\"value\\\\\\"\\",
     \\"a\\": \\"a\\",
     \\"b\\": \\"b\\"
 });
+var val = \\"\\\\\\"value\\\\\\"\\";
 var a = \\"a\\";
 var b = \\"b\\";
 
@@ -1000,7 +1003,7 @@ Object.defineProperty(__webpack_exports__, \\"__esModule\\", { value: true });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__es2015_css__ = __webpack_require__(1);
 
 
-console.log(__WEBPACK_IMPORTED_MODULE_0__es2015_css__[\\"a\\"]);
+console.log(__WEBPACK_IMPORTED_MODULE_0__es2015_css__[\\"a\\"], __WEBPACK_IMPORTED_MODULE_0__es2015_css__[\\"b\\" /* val */]);
 
 
 /***/ }),
@@ -1008,12 +1011,15 @@ console.log(__WEBPACK_IMPORTED_MODULE_0__es2015_css__[\\"a\\"]);
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 \\"use strict\\";
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \\"b\\", function() { return val; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \\"a\\", function() { return a; });
 /* unused harmony export b */
 /* unused harmony default export */ var _unused_webpack_default_export = ({
+    \\"val\\": \\"\\\\\\"value\\\\\\"\\",
     \\"a\\": \\"a\\",
     \\"b\\": \\"b\\"
 });
+var val = \\"\\\\\\"value\\\\\\"\\";
 var a = \\"a\\";
 var b = \\"b\\";
 

--- a/packages/webpack/test/specimens/es2015-named.js
+++ b/packages/webpack/test/specimens/es2015-named.js
@@ -1,3 +1,3 @@
-import { a } from "./es2015.css";
+import { a, val } from "./es2015.css";
 
-console.log(a);
+console.log(a, val);

--- a/packages/webpack/test/specimens/es2015.css
+++ b/packages/webpack/test/specimens/es2015.css
@@ -1,2 +1,4 @@
+@value val: "value";
+
 .a { color: red; }
 .b { color: blue; }


### PR DESCRIPTION
Noticed this when upgrading, the change to export `@value`s alongside classes in #398 caused a bug in my webpack/rollup code to become more obvious.

They were generating code like this:

```js
export var a = ""b"";
```
since when you write `@value a: "b"` the literal value of `a` is `"b"`, and I don't convert that to an unquoted string during the output process. Now it's using `JSON.stringify(...)` when exporting ALL values, which should be safer.

It may be worth adding support later for stripping the extraneous-seeming quotes off of `@value`s that are solely `"quoted strings"` but I'm not touching that for now.