### PR TITLE
fix: webpack inline maps should work

### DIFF
--- a/packages/webpack/plugin.js
+++ b/packages/webpack/plugin.js
@@ -78,8 +78,8 @@ ModularCSS.prototype.apply = function(compiler) {
                         data.css
                     );
                 
-                // TODO: This is hacky beyond belief...
-                if(this.options.map && !this.options.map.inline) {
+                // Write out external source map if it exists
+                if(data.map) {
                     compilation.assets[`${this.options.css}.map`] = new sources.RawSource(
                         data.map.toString()
                     );
@@ -94,6 +94,7 @@ ModularCSS.prototype.apply = function(compiler) {
 
             return done();
         })
+        .catch(done)
     );
 };
 

--- a/packages/webpack/test/__snapshots__/webpack.test.js.snap
+++ b/packages/webpack/test/__snapshots__/webpack.test.js.snap
@@ -725,6 +725,13 @@ exports[`/webpack.js should output css to disk 2`] = `
 
 exports[`/webpack.js should output external source maps to disk 1`] = `"{\\"version\\":3,\\"sources\\":[\\"packages/webpack/test/specimens/simple.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,gDAAC;AAAD,SAAS,WAAW,EAAE\\",\\"file\\":\\"simple.css\\",\\"sourcesContent\\":[\\".wooga { color: red; }\\\\n\\"]}"`;
 
+exports[`/webpack.js should output inline source maps 1`] = `
+"/* packages/webpack/test/specimens/simple.css */
+.wooga { color: red; }
+
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInBhY2thZ2VzL3dlYnBhY2svdGVzdC9zcGVjaW1lbnMvc2ltcGxlLmNzcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxnREFBQztBQUFELFNBQVMsV0FBVyxFQUFFIiwiZmlsZSI6InNpbXBsZS5jc3MiLCJzb3VyY2VzQ29udGVudCI6WyIud29vZ2EgeyBjb2xvcjogcmVkOyB9XG4iXX0= */"
+`;
+
 exports[`/webpack.js should output json to disk 1`] = `
 "/******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache

--- a/packages/webpack/test/webpack.test.js
+++ b/packages/webpack/test/webpack.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-statements */
 "use strict";
 
 var fs   = require("fs"),
@@ -87,6 +88,38 @@ describe("/webpack.js", () => {
 
             expect(read("simple.js")).toMatchSnapshot();
             expect(read("simple.json")).toMatchSnapshot();
+
+            done();
+        });
+    });
+
+    it("should output inline source maps", (done) => {
+        webpack({
+            entry  : "./packages/webpack/test/specimens/simple.js",
+            output : {
+                path     : output,
+                filename : "./simple.js"
+            },
+            module : {
+                rules : [
+                    {
+                        test,
+                        use
+                    }
+                ]
+            },
+            devtool : "source-map",
+            plugins : [
+                new Plugin({
+                    namer,
+                    css : "./simple.css",
+                    map : true
+                })
+            ]
+        }, (err, stats) => {
+            success(err, stats);
+
+            expect(read("simple.css")).toMatchSnapshot();
 
             done();
         });


### PR DESCRIPTION
Somehow this was never tested before?

Also make sure that errors from the plugin propagate correctly.

This fixes an error that @chiel and @getkey reported in [gitter](https://gitter.im/modular-css/modular-css?at=5a8bffc5888332ee3aa9acad).