### PR TITLE
fix: adding new files w/ rollup shouldn't error

### DIFF
--- a/packages/core/processor.js
+++ b/packages/core/processor.js
@@ -169,7 +169,7 @@ Processor.prototype = {
             .filter((file) => this._graph.hasNode(file));
         
         if(!files.length) {
-            return;
+            return [];
         }
 
         // Remove everything that depends on files to be removed as well

--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -44,7 +44,7 @@ module.exports = function(opts) {
         },
 
         transform : function(code, id) {
-            let removed;
+            let removed = [];
 
             if(!filter(id) || id.slice(slice) !== options.ext) {
                 return null;
@@ -54,8 +54,6 @@ module.exports = function(opts) {
             // avoid cache staleness issues
             if(runs) {
                 removed = processor.remove(id);
-            } else {
-                removed = [];
             }
 
             return Promise.all(

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -101,6 +101,15 @@ console.log(css);
 }
 `;
 
+exports[`/rollup.js watch should correctly add new css files in watch mode when files change 1`] = `""`;
+
+exports[`/rollup.js watch should correctly add new css files in watch mode when files change 2`] = `
+"/* packages/rollup/test/output/one.css */
+.mc19ef5610_one {
+    color: red;
+}"
+`;
+
 exports[`/rollup.js watch should correctly update files within the dependency graph in watch mode when files change 1`] = `
 "/* packages/rollup/test/output/one.css */
 .mc19ef5610_one {


### PR DESCRIPTION
Fixes #421 by making the result of `Processor.remove()` always an array instead of sometimes `null`.