### PR TITLE
Add support for <link> elements in svelte components

### DIFF
--- a/docs/svelte.md
+++ b/docs/svelte.md
@@ -1,0 +1,78 @@
+# Svelte
+
+`modular-css-svelte` provides a [svelte preprocessor](https://svelte.technology/guide#preprocessing) that can convert inline `<style>` or external `<link>` tags using `modular-css` and will also staticly replace any css references it can find for maximum speed.
+
+### Options
+
+All options are passed to the underlying `Processor` instance, see [Options](api.md#options).
+
+## Usage
+
+### `svelte.preprocess()`
+
+```js
+const filename = "./Component.html";
+
+const { processor, preprocess } = require("modular-css-svelte")({
+    css : "./dist/bundle.css"
+});
+
+const processed = await svelte.preprocess(
+    fs.readFileSync(filename, "utf8"),
+    Object.assign({}, preprocess, { filename })
+);
+
+const result = processor.output();
+
+fs.writeFileSync("./dist/bundle.css", result.css);
+```
+
+### `rollup-plugin-svelte`
+
+#### API
+
+```js
+const rollup = require("rollup").rollup;
+
+const { preprocess, plugin } = require("modular-css-svelte/rollup")({
+    css : "./dist/bundle.css"
+});
+
+const bundle = await rollup({
+    input   : "./Component.html",
+    plugins : [
+        require("rollup-plugin-svelte")({
+            preprocess
+        }),
+        plugin
+    ]
+});
+
+// bundle.write will also write out the CSS to the path specified in the `css` arg
+bundle.write({
+    format : "es",
+    file   : "./dist/bundle.js"
+});
+```
+
+#### `rollup.config.js`
+
+```js
+const { preprocess, plugin } = require("modular-css-svelte/rollup")({
+    css : "./dist/bundle.css"
+});
+
+module.exports = {
+    input   : "./Component.html",
+    output  : {
+        format : "es",
+        file   : "./dist/bundle.js"
+    },
+    plugins : [
+        require("rollup-plugin-svelte")({
+            preprocess
+        }),
+        plugin
+    ]
+};
+```

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -5,15 +5,15 @@ modular-css-svelte  [![NPM Version](https://img.shields.io/npm/v/modular-css-sve
     <a href="https://gitter.im/modular-css/modular-css"><img src="https://img.shields.io/gitter/room/modular-css/modular-css.svg" alt="Gitter" /></a>
 </p>
 
-Svelte preprocessor support for [`modular-css`](https://github.com/tivac/modular-css). Process inline `<style>`s inside your Svelte components using the full power of `modular-css` while also providing compile-time optimizations for smaller bundles and even faster runtime performance!
+Svelte preprocessor support for [`modular-css`](https://github.com/tivac/modular-css). Process inline `<style>`s or `<link>` references inside your Svelte components using the full power of `modular-css` while also providing compile-time optimizations for smaller bundles and even faster runtime performance!
 
 ## Example
 
 Turns this
 
 ```html
-<div class="{{css.main}}">
-    <h1 class="{{css.title}}">Title</h1>
+<div class="{css.main}">
+    <h1 class="{css.title}">Title</h1>
 </div>
 
 <style>
@@ -36,6 +36,8 @@ into what is effectively this
 ```
 
 while allowing you to use all of the usual `modular-css` goodies.
+
+Alternatively you can use `<link>` tags to reference CSS external to the component.
 
 ## Install
 
@@ -115,4 +117,3 @@ module.exports = {
 ## Options
 
 All options are passed to the underlying `Processor` instance, see [Options](https://github.com/tivac/modular-css/blob/master/docs/api.md#options).
-

--- a/packages/svelte/methods.js
+++ b/packages/svelte/methods.js
@@ -1,39 +1,62 @@
 "use strict";
 
+const path = require("path");
+
+const resolve = require("resolve-from");
+
+const styleRegex = /<style[\S\s]*?>([\S\s]*?)<\/style>/igm;
+const linkRegex = /<link\b[^<>]*?\bhref=\s*(?:"([^"]+)"|'([^']+)'|([^>\s]+))[^>]*>/igm;
+
 exports.markup = (processor) => ({ content, filename }) => {
-        const search = /<style[\S\s]*?>([\S\s]*?)<\/style>/igm;
-        const matches = search.exec(content);
+    const link = linkRegex.exec(content);
+    const style = styleRegex.exec(content);
 
-        if(!matches) {
-            return {
-                code : content
-            };
-        }
+    if(!link && !style) {
+        return {
+            code : content
+        };
+    }
 
-        const style = matches[1];
+    if(link && style) {
+        throw new Error("modular-css-svelte supports <style> OR <link>, but not both");
+    }
 
-        return processor.string(
+    let css;
+
+    if(style) {
+        css = processor.string(
             filename,
-            style
-        )
-        .then((result) => {
-            const exported = result.files[result.file].exports;
+            style[1]
+        );
+    }
 
-            return {
-                code : content
-                    // Replace simple {css.<key>} values first
-                    .replace(
-                        new RegExp(`{css.(${Object.keys(exported).join("|")})}`, "gm"),
-                        (match, key) => exported[key].join(" ")
-                    )
-                    // Then any remaining bare css.<key> values
-                    .replace(
-                        new RegExp(`(\\b)css.(${Object.keys(exported).join("|")})(\\b)`, "gm"),
-                        (match, prefix, key, suffix) => `${prefix}"${exported[key].join(" ")}"${suffix}`
-                    )
-            };
-        });
-    };
+    if(link) {
+        // Remove the <link> element from the component to avoid double-loading
+        content = content.replace(link[0], "");
+
+        let external = resolve(path.dirname(filename), link[1] || link[2] || link[3]);
+
+        css = processor.file(external);
+    }
+
+    return css.then((result) => {
+        const exported = result.files[result.file].exports;
+
+        return {
+            code : content
+                // Replace simple {css.<key>} values first
+                .replace(
+                    new RegExp(`{css.(${Object.keys(exported).join("|")})}`, "gm"),
+                    (match, key) => exported[key].join(" ")
+                )
+                // Then any remaining bare css.<key> values
+                .replace(
+                    new RegExp(`(\\b)css.(${Object.keys(exported).join("|")})(\\b)`, "gm"),
+                    (match, prefix, key, suffix) => `${prefix}"${exported[key].join(" ")}"${suffix}`
+                )
+        };
+    });
+};
 
 exports.style = () => ({
     code : "/* replaced by modular-css */"

--- a/packages/svelte/package-lock.json
+++ b/packages/svelte/package-lock.json
@@ -1,1038 +1,313 @@
 {
-	"name": "modular-css-svelte",
-	"version": "9.0.0",
-	"lockfileVersion": 1,
-	"requires": true,
-	"dependencies": {
-		"minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-		},
-		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"requires": {
-				"minimist": "0.0.8"
-			}
-		},
-		"modular-css-core": {
-			"version": "file:../core",
-			"requires": {
-				"dependency-graph": "0.6.0",
-				"escape-string-regexp": "1.0.5",
-				"lodash.findlast": "4.6.0",
-				"lodash.foreach": "4.5.0",
-				"lodash.get": "4.4.2",
-				"lodash.invert": "4.3.0",
-				"lodash.mapvalues": "4.6.0",
-				"lodash.uniq": "4.5.0",
-				"p-each-series": "1.0.0",
-				"postcss": "6.0.19",
-				"postcss-selector-parser": "3.1.1",
-				"postcss-url": "7.3.1",
-				"postcss-value-parser": "3.3.0",
-				"resolve-from": "4.0.0",
-				"true-case-path": "1.0.2",
-				"unique-slug": "2.0.0"
-			},
-			"dependencies": {
-				"alphanum-sort": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"bundled": true,
-					"requires": {
-						"color-convert": "1.9.1"
-					}
-				},
-				"argh": {
-					"version": "0.1.4",
-					"bundled": true
-				},
-				"argparse": {
-					"version": "1.0.10",
-					"bundled": true,
-					"requires": {
-						"sprintf-js": "1.0.3"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"bundled": true,
-					"requires": {
-						"balanced-match": "1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"browserslist": {
-					"version": "2.11.3",
-					"bundled": true,
-					"requires": {
-						"caniuse-lite": "1.0.30000811",
-						"electron-to-chromium": "1.3.34"
-					}
-				},
-				"caniuse-api": {
-					"version": "2.0.0",
-					"bundled": true,
-					"requires": {
-						"browserslist": "2.11.3",
-						"caniuse-lite": "1.0.30000811",
-						"lodash.memoize": "4.1.2",
-						"lodash.uniq": "4.5.0"
-					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30000811",
-					"bundled": true
-				},
-				"chalk": {
-					"version": "2.3.2",
-					"bundled": true,
-					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
-					}
-				},
-				"clap": {
-					"version": "1.2.3",
-					"bundled": true,
-					"requires": {
-						"chalk": "1.1.3"
-					},
-					"dependencies": {
-						"ansi-styles": {
-							"version": "2.2.1",
-							"bundled": true
-						},
-						"chalk": {
-							"version": "1.1.3",
-							"bundled": true,
-							"requires": {
-								"ansi-styles": "2.2.1",
-								"escape-string-regexp": "1.0.5",
-								"has-ansi": "2.0.0",
-								"strip-ansi": "3.0.1",
-								"supports-color": "2.0.0"
-							}
-						},
-						"supports-color": {
-							"version": "2.0.0",
-							"bundled": true
-						}
-					}
-				},
-				"coa": {
-					"version": "1.0.4",
-					"bundled": true,
-					"requires": {
-						"q": "1.5.1"
-					}
-				},
-				"color": {
-					"version": "1.0.3",
-					"bundled": true,
-					"requires": {
-						"color-convert": "1.9.1",
-						"color-string": "1.5.2"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.1",
-					"bundled": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"bundled": true
-				},
-				"color-string": {
-					"version": "1.5.2",
-					"bundled": true,
-					"requires": {
-						"color-name": "1.1.3",
-						"simple-swizzle": "0.2.2"
-					}
-				},
-				"colors": {
-					"version": "1.1.2",
-					"bundled": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true
-				},
-				"cosmiconfig": {
-					"version": "2.2.2",
-					"bundled": true,
-					"requires": {
-						"is-directory": "0.3.1",
-						"js-yaml": "3.10.0",
-						"minimist": "1.2.0",
-						"object-assign": "4.1.1",
-						"os-homedir": "1.0.2",
-						"parse-json": "2.2.0",
-						"require-from-string": "1.2.1"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"bundled": true
-						}
-					}
-				},
-				"css-color-names": {
-					"version": "0.0.4",
-					"bundled": true
-				},
-				"css-declaration-sorter": {
-					"version": "2.1.0",
-					"bundled": true,
-					"requires": {
-						"argh": "0.1.4",
-						"postcss": "6.0.19",
-						"read-file-stdin": "0.2.1",
-						"timsort": "0.3.0",
-						"write-file-stdout": "0.0.2"
-					}
-				},
-				"css-unit-converter": {
-					"version": "1.1.1",
-					"bundled": true
-				},
-				"cssnano": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"cosmiconfig": "2.2.2",
-						"cssnano-preset-default": "4.0.0-rc.2",
-						"is-resolvable": "1.1.0",
-						"postcss": "6.0.19"
-					}
-				},
-				"cssnano-preset-default": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"css-declaration-sorter": "2.1.0",
-						"cssnano-util-raw-cache": "4.0.0-rc.2",
-						"postcss": "6.0.19",
-						"postcss-calc": "6.0.1",
-						"postcss-colormin": "4.0.0-rc.2",
-						"postcss-convert-values": "4.0.0-rc.2",
-						"postcss-discard-comments": "4.0.0-rc.2",
-						"postcss-discard-duplicates": "4.0.0-rc.2",
-						"postcss-discard-empty": "4.0.0-rc.2",
-						"postcss-discard-overridden": "4.0.0-rc.2",
-						"postcss-merge-longhand": "4.0.0-rc.2",
-						"postcss-merge-rules": "4.0.0-rc.2",
-						"postcss-minify-font-values": "4.0.0-rc.2",
-						"postcss-minify-gradients": "4.0.0-rc.2",
-						"postcss-minify-params": "4.0.0-rc.2",
-						"postcss-minify-selectors": "4.0.0-rc.2",
-						"postcss-normalize-charset": "4.0.0-rc.2",
-						"postcss-normalize-display-values": "4.0.0-rc.2",
-						"postcss-normalize-positions": "4.0.0-rc.2",
-						"postcss-normalize-repeat-style": "4.0.0-rc.2",
-						"postcss-normalize-string": "4.0.0-rc.2",
-						"postcss-normalize-timing-functions": "4.0.0-rc.2",
-						"postcss-normalize-unicode": "4.0.0-rc.2",
-						"postcss-normalize-url": "4.0.0-rc.2",
-						"postcss-normalize-whitespace": "4.0.0-rc.2",
-						"postcss-ordered-values": "4.0.0-rc.2",
-						"postcss-reduce-initial": "4.0.0-rc.2",
-						"postcss-reduce-transforms": "4.0.0-rc.2",
-						"postcss-svgo": "4.0.0-rc.2",
-						"postcss-unique-selectors": "4.0.0-rc.2"
-					}
-				},
-				"cssnano-util-get-arguments": {
-					"version": "4.0.0-rc.2",
-					"bundled": true
-				},
-				"cssnano-util-get-match": {
-					"version": "4.0.0-rc.2",
-					"bundled": true
-				},
-				"cssnano-util-raw-cache": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"postcss": "6.0.19"
-					}
-				},
-				"cssnano-util-same-parent": {
-					"version": "4.0.0-rc.2",
-					"bundled": true
-				},
-				"csso": {
-					"version": "2.3.2",
-					"bundled": true,
-					"requires": {
-						"clap": "1.2.3",
-						"source-map": "0.5.7"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.5.7",
-							"bundled": true
-						}
-					}
-				},
-				"cuint": {
-					"version": "0.2.2",
-					"bundled": true
-				},
-				"dependency-graph": {
-					"version": "0.6.0",
-					"bundled": true
-				},
-				"dot-prop": {
-					"version": "4.2.0",
-					"bundled": true,
-					"requires": {
-						"is-obj": "1.0.1"
-					}
-				},
-				"electron-to-chromium": {
-					"version": "1.3.34",
-					"bundled": true
-				},
-				"error-ex": {
-					"version": "1.3.1",
-					"bundled": true,
-					"requires": {
-						"is-arrayish": "0.2.1"
-					}
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"bundled": true
-				},
-				"esprima": {
-					"version": "4.0.0",
-					"bundled": true
-				},
-				"flatten": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"function-bind": {
-					"version": "1.1.1",
-					"bundled": true
-				},
-				"gather-stream": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"glob": {
-					"version": "6.0.4",
-					"bundled": true,
-					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
-				"has": {
-					"version": "1.0.1",
-					"bundled": true,
-					"requires": {
-						"function-bind": "1.1.1"
-					}
-				},
-				"has-ansi": {
-					"version": "2.0.0",
-					"bundled": true,
-					"requires": {
-						"ansi-regex": "2.1.1"
-					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"bundled": true
-				},
-				"hex-color-regex": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"hsl-regex": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"hsla-regex": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"html-comment-regex": {
-					"version": "1.1.1",
-					"bundled": true
-				},
-				"imurmurhash": {
-					"version": "0.1.4",
-					"bundled": true
-				},
-				"indexes-of": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"bundled": true,
-					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"bundled": true
-				},
-				"is-absolute-url": {
-					"version": "2.1.0",
-					"bundled": true
-				},
-				"is-arrayish": {
-					"version": "0.2.1",
-					"bundled": true
-				},
-				"is-color-stop": {
-					"version": "1.1.0",
-					"bundled": true,
-					"requires": {
-						"css-color-names": "0.0.4",
-						"hex-color-regex": "1.1.0",
-						"hsl-regex": "1.0.0",
-						"hsla-regex": "1.0.0",
-						"rgb-regex": "1.0.1",
-						"rgba-regex": "1.0.0"
-					}
-				},
-				"is-directory": {
-					"version": "0.3.1",
-					"bundled": true
-				},
-				"is-obj": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"is-plain-obj": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"is-resolvable": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"is-svg": {
-					"version": "2.1.0",
-					"bundled": true,
-					"requires": {
-						"html-comment-regex": "1.1.1"
-					}
-				},
-				"js-yaml": {
-					"version": "3.10.0",
-					"bundled": true,
-					"requires": {
-						"argparse": "1.0.10",
-						"esprima": "4.0.0"
-					}
-				},
-				"lodash.findlast": {
-					"version": "4.6.0",
-					"bundled": true
-				},
-				"lodash.foreach": {
-					"version": "4.5.0",
-					"bundled": true
-				},
-				"lodash.get": {
-					"version": "4.4.2",
-					"bundled": true
-				},
-				"lodash.invert": {
-					"version": "4.3.0",
-					"bundled": true
-				},
-				"lodash.mapvalues": {
-					"version": "4.6.0",
-					"bundled": true
-				},
-				"lodash.memoize": {
-					"version": "4.1.2",
-					"bundled": true
-				},
-				"lodash.uniq": {
-					"version": "4.5.0",
-					"bundled": true
-				},
-				"mime": {
-					"version": "1.6.0",
-					"bundled": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"bundled": true,
-					"requires": {
-						"brace-expansion": "1.1.11"
-					}
-				},
-				"minimist": {
-					"version": "0.0.8",
-					"bundled": true
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"normalize-url": {
-					"version": "1.9.1",
-					"bundled": true,
-					"requires": {
-						"object-assign": "4.1.1",
-						"prepend-http": "1.0.4",
-						"query-string": "4.3.4",
-						"sort-keys": "1.1.2"
-					}
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"requires": {
-						"wrappy": "1.0.2"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"p-each-series": {
-					"version": "1.0.0",
-					"bundled": true,
-					"requires": {
-						"p-reduce": "1.0.0"
-					}
-				},
-				"p-reduce": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"parse-json": {
-					"version": "2.2.0",
-					"bundled": true,
-					"requires": {
-						"error-ex": "1.3.1"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"pegjs": {
-					"version": "0.10.0",
-					"bundled": true
-				},
-				"postcss": {
-					"version": "6.0.19",
-					"bundled": true,
-					"requires": {
-						"chalk": "2.3.2",
-						"source-map": "0.6.1",
-						"supports-color": "5.3.0"
-					}
-				},
-				"postcss-calc": {
-					"version": "6.0.1",
-					"bundled": true,
-					"requires": {
-						"css-unit-converter": "1.1.1",
-						"postcss": "6.0.19",
-						"postcss-selector-parser": "2.2.3",
-						"reduce-css-calc": "2.1.4"
-					},
-					"dependencies": {
-						"postcss-selector-parser": {
-							"version": "2.2.3",
-							"bundled": true,
-							"requires": {
-								"flatten": "1.0.2",
-								"indexes-of": "1.0.1",
-								"uniq": "1.0.1"
-							}
-						}
-					}
-				},
-				"postcss-colormin": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"browserslist": "2.11.3",
-						"color": "1.0.3",
-						"has": "1.0.1",
-						"postcss": "6.0.19",
-						"postcss-value-parser": "3.3.0"
-					}
-				},
-				"postcss-convert-values": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"postcss": "6.0.19",
-						"postcss-value-parser": "3.3.0"
-					}
-				},
-				"postcss-discard-comments": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"postcss": "6.0.19"
-					}
-				},
-				"postcss-discard-duplicates": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"postcss": "6.0.19"
-					}
-				},
-				"postcss-discard-empty": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"postcss": "6.0.19"
-					}
-				},
-				"postcss-discard-overridden": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"postcss": "6.0.19"
-					}
-				},
-				"postcss-merge-longhand": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"postcss": "6.0.19",
-						"postcss-value-parser": "3.3.0",
-						"stylehacks": "4.0.0-rc.2"
-					}
-				},
-				"postcss-merge-rules": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"browserslist": "2.11.3",
-						"caniuse-api": "2.0.0",
-						"cssnano-util-same-parent": "4.0.0-rc.2",
-						"postcss": "6.0.19",
-						"postcss-selector-parser": "3.1.1",
-						"vendors": "1.0.1"
-					}
-				},
-				"postcss-minify-font-values": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"postcss": "6.0.19",
-						"postcss-value-parser": "3.3.0"
-					}
-				},
-				"postcss-minify-gradients": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"cssnano-util-get-arguments": "4.0.0-rc.2",
-						"is-color-stop": "1.1.0",
-						"postcss": "6.0.19",
-						"postcss-value-parser": "3.3.0"
-					}
-				},
-				"postcss-minify-params": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"alphanum-sort": "1.0.2",
-						"cssnano-util-get-arguments": "4.0.0-rc.2",
-						"postcss": "6.0.19",
-						"postcss-value-parser": "3.3.0",
-						"uniqs": "2.0.0"
-					}
-				},
-				"postcss-minify-selectors": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"alphanum-sort": "1.0.2",
-						"has": "1.0.1",
-						"postcss": "6.0.19",
-						"postcss-selector-parser": "3.1.1"
-					}
-				},
-				"postcss-normalize-charset": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"postcss": "6.0.19"
-					}
-				},
-				"postcss-normalize-display-values": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"cssnano-util-get-match": "4.0.0-rc.2",
-						"postcss": "6.0.19",
-						"postcss-value-parser": "3.3.0"
-					}
-				},
-				"postcss-normalize-positions": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"cssnano-util-get-arguments": "4.0.0-rc.2",
-						"has": "1.0.1",
-						"postcss": "6.0.19",
-						"postcss-value-parser": "3.3.0"
-					}
-				},
-				"postcss-normalize-repeat-style": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"cssnano-util-get-arguments": "4.0.0-rc.2",
-						"cssnano-util-get-match": "4.0.0-rc.2",
-						"postcss": "6.0.19",
-						"postcss-value-parser": "3.3.0"
-					}
-				},
-				"postcss-normalize-string": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"has": "1.0.1",
-						"postcss": "6.0.19",
-						"postcss-value-parser": "3.3.0"
-					}
-				},
-				"postcss-normalize-timing-functions": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"cssnano-util-get-match": "4.0.0-rc.2",
-						"postcss": "6.0.19",
-						"postcss-value-parser": "3.3.0"
-					}
-				},
-				"postcss-normalize-unicode": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"postcss": "6.0.19",
-						"postcss-value-parser": "3.3.0"
-					}
-				},
-				"postcss-normalize-url": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"is-absolute-url": "2.1.0",
-						"normalize-url": "1.9.1",
-						"postcss": "6.0.19",
-						"postcss-value-parser": "3.3.0"
-					}
-				},
-				"postcss-normalize-whitespace": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"postcss": "6.0.19",
-						"postcss-value-parser": "3.3.0"
-					}
-				},
-				"postcss-ordered-values": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"cssnano-util-get-arguments": "4.0.0-rc.2",
-						"postcss": "6.0.19",
-						"postcss-value-parser": "3.3.0"
-					}
-				},
-				"postcss-reduce-initial": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"browserslist": "2.11.3",
-						"caniuse-api": "2.0.0",
-						"has": "1.0.1",
-						"postcss": "6.0.19"
-					}
-				},
-				"postcss-reduce-transforms": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"cssnano-util-get-match": "4.0.0-rc.2",
-						"has": "1.0.1",
-						"postcss": "6.0.19",
-						"postcss-value-parser": "3.3.0"
-					}
-				},
-				"postcss-selector-parser": {
-					"version": "3.1.1",
-					"bundled": true,
-					"requires": {
-						"dot-prop": "4.2.0",
-						"indexes-of": "1.0.1",
-						"uniq": "1.0.1"
-					}
-				},
-				"postcss-svgo": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"is-svg": "2.1.0",
-						"postcss": "6.0.19",
-						"postcss-value-parser": "3.3.0",
-						"svgo": "0.7.2"
-					}
-				},
-				"postcss-unique-selectors": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"alphanum-sort": "1.0.2",
-						"postcss": "6.0.19",
-						"uniqs": "2.0.0"
-					}
-				},
-				"postcss-url": {
-					"version": "7.3.1",
-					"bundled": true,
-					"requires": {
-						"mime": "1.6.0",
-						"minimatch": "3.0.4",
-						"mkdirp": "0.5.1",
-						"postcss": "6.0.19",
-						"xxhashjs": "0.2.2"
-					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.0",
-					"bundled": true
-				},
-				"prepend-http": {
-					"version": "1.0.4",
-					"bundled": true
-				},
-				"q": {
-					"version": "1.5.1",
-					"bundled": true
-				},
-				"query-string": {
-					"version": "4.3.4",
-					"bundled": true,
-					"requires": {
-						"object-assign": "4.1.1",
-						"strict-uri-encode": "1.1.0"
-					}
-				},
-				"read-file-stdin": {
-					"version": "0.2.1",
-					"bundled": true,
-					"requires": {
-						"gather-stream": "1.0.0"
-					}
-				},
-				"reduce-css-calc": {
-					"version": "2.1.4",
-					"bundled": true,
-					"requires": {
-						"css-unit-converter": "1.1.1",
-						"postcss-value-parser": "3.3.0"
-					}
-				},
-				"require-from-string": {
-					"version": "1.2.1",
-					"bundled": true
-				},
-				"resolve-from": {
-					"version": "4.0.0",
-					"bundled": true
-				},
-				"rgb-regex": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"rgba-regex": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"sax": {
-					"version": "1.2.4",
-					"bundled": true
-				},
-				"simple-swizzle": {
-					"version": "0.2.2",
-					"bundled": true,
-					"requires": {
-						"is-arrayish": "0.3.1"
-					},
-					"dependencies": {
-						"is-arrayish": {
-							"version": "0.3.1",
-							"bundled": true
-						}
-					}
-				},
-				"sort-keys": {
-					"version": "1.1.2",
-					"bundled": true,
-					"requires": {
-						"is-plain-obj": "1.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"bundled": true
-				},
-				"sprintf-js": {
-					"version": "1.0.3",
-					"bundled": true
-				},
-				"strict-uri-encode": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"requires": {
-						"ansi-regex": "2.1.1"
-					}
-				},
-				"stylehacks": {
-					"version": "4.0.0-rc.2",
-					"bundled": true,
-					"requires": {
-						"browserslist": "2.11.3",
-						"postcss": "6.0.19",
-						"postcss-selector-parser": "3.1.1"
-					}
-				},
-				"supports-color": {
-					"version": "5.3.0",
-					"bundled": true,
-					"requires": {
-						"has-flag": "3.0.0"
-					}
-				},
-				"svgo": {
-					"version": "0.7.2",
-					"bundled": true,
-					"requires": {
-						"coa": "1.0.4",
-						"colors": "1.1.2",
-						"csso": "2.3.2",
-						"js-yaml": "3.7.0",
-						"mkdirp": "0.5.1",
-						"sax": "1.2.4",
-						"whet.extend": "0.9.9"
-					},
-					"dependencies": {
-						"esprima": {
-							"version": "2.7.3",
-							"bundled": true
-						},
-						"js-yaml": {
-							"version": "3.7.0",
-							"bundled": true,
-							"requires": {
-								"argparse": "1.0.10",
-								"esprima": "2.7.3"
-							}
-						}
-					}
-				},
-				"test-utils": {
-					"version": "8.0.0",
-					"bundled": true
-				},
-				"timsort": {
-					"version": "0.3.0",
-					"bundled": true
-				},
-				"true-case-path": {
-					"version": "1.0.2",
-					"bundled": true,
-					"requires": {
-						"glob": "6.0.4"
-					}
-				},
-				"uniq": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"uniqs": {
-					"version": "2.0.0",
-					"bundled": true
-				},
-				"unique-slug": {
-					"version": "2.0.0",
-					"bundled": true,
-					"requires": {
-						"imurmurhash": "0.1.4"
-					}
-				},
-				"vendors": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"whet.extend": {
-					"version": "0.9.9",
-					"bundled": true
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"write-file-stdout": {
-					"version": "0.0.2",
-					"bundled": true
-				},
-				"xxhashjs": {
-					"version": "0.2.2",
-					"bundled": true,
-					"requires": {
-						"cuint": "0.2.2"
-					}
-				}
-			}
-		}
-	}
+  "name": "modular-css-svelte",
+  "version": "10.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "modular-css-core": {
+      "version": "file:../core",
+      "requires": {
+        "dependency-graph": "^0.6.0",
+        "escape-string-regexp": "^1.0.5",
+        "lodash.findlast": "^4.6.0",
+        "lodash.foreach": "^4.5.0",
+        "lodash.get": "^4.4.2",
+        "lodash.invert": "^4.3.0",
+        "lodash.mapvalues": "^4.6.0",
+        "lodash.uniq": "^4.5.0",
+        "p-each-series": "^1.0.0",
+        "postcss": "^6.0.11",
+        "postcss-selector-parser": "^3.0.0",
+        "postcss-url": "^7.3.0",
+        "postcss-value-parser": "^3.3.0",
+        "resolve-from": "^4.0.0",
+        "true-case-path": "^1.0.2",
+        "unique-slug": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "bundled": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "clap": {
+          "bundled": true
+        },
+        "color-convert": {
+          "version": "1.9.1",
+          "bundled": true,
+          "requires": {
+            "color-name": "^1.1.1"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "cosmiconfig": {
+          "bundled": true
+        },
+        "csso": {
+          "bundled": true
+        },
+        "cuint": {
+          "version": "0.2.2",
+          "bundled": true
+        },
+        "dependency-graph": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "dot-prop": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "glob": {
+          "version": "6.0.4",
+          "bundled": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "indexes-of": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "is-obj": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "lodash.findlast": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "lodash.foreach": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.get": {
+          "version": "4.4.2",
+          "bundled": true
+        },
+        "lodash.invert": {
+          "version": "4.3.0",
+          "bundled": true
+        },
+        "lodash.mapvalues": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "lodash.uniq": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "mime": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "p-each-series": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "p-reduce": "^1.0.0"
+          }
+        },
+        "p-reduce": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "postcss": {
+          "version": "6.0.19",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.3.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.2.0"
+          }
+        },
+        "postcss-calc": {
+          "bundled": true
+        },
+        "postcss-selector-parser": {
+          "version": "3.1.1",
+          "bundled": true,
+          "requires": {
+            "dot-prop": "^4.1.1",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        },
+        "postcss-url": {
+          "version": "7.3.1",
+          "bundled": true,
+          "requires": {
+            "mime": "^1.4.1",
+            "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.0",
+            "postcss": "^6.0.1",
+            "xxhashjs": "^0.2.1"
+          }
+        },
+        "postcss-value-parser": {
+          "version": "3.3.0",
+          "bundled": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "simple-swizzle": {
+          "bundled": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "bundled": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "svgo": {
+          "bundled": true
+        },
+        "true-case-path": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "glob": "^6.0.4"
+          }
+        },
+        "uniq": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "unique-slug": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "imurmurhash": "^0.1.4"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "xxhashjs": {
+          "version": "0.2.2",
+          "bundled": true,
+          "requires": {
+            "cuint": "^0.2.2"
+          }
+        }
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+    }
+  }
 }

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -22,6 +22,7 @@
   ],
   "dependencies": {
     "mkdirp": "^0.5.1",
-    "modular-css-core": "file:../core"
+    "modular-css-core": "file:../core",
+    "resolve-from": "^4.0.0"
   }
 }

--- a/packages/svelte/test/__snapshots__/rollup.test.js.snap
+++ b/packages/svelte/test/__snapshots__/rollup.test.js.snap
@@ -197,3 +197,201 @@ exports[`/rollup.js should generate exports 2`] = `
     }
 "
 `;
+
+exports[`/rollup.js should support external css via <link> 1`] = `
+"function noop() {}
+
+function assign(tar, src) {
+	for (var k in src) tar[k] = src[k];
+	return tar;
+}
+
+function insertNode(node, target, anchor) {
+	target.insertBefore(node, anchor);
+}
+
+function detachNode(node) {
+	node.parentNode.removeChild(node);
+}
+
+function createElement(name) {
+	return document.createElement(name);
+}
+
+function blankObject() {
+	return Object.create(null);
+}
+
+function destroy(detach) {
+	this.destroy = noop;
+	this.fire('destroy');
+	this.set = noop;
+
+	this._fragment.d(detach !== false);
+	this._fragment = null;
+	this._state = {};
+}
+
+function _differs(a, b) {
+	return a != a ? b == b : a !== b || ((a && typeof a === 'object') || typeof a === 'function');
+}
+
+function fire(eventName, data) {
+	var handlers =
+		eventName in this._handlers && this._handlers[eventName].slice();
+	if (!handlers) return;
+
+	for (var i = 0; i < handlers.length; i += 1) {
+		var handler = handlers[i];
+
+		if (!handler.__calling) {
+			handler.__calling = true;
+			handler.call(this, data);
+			handler.__calling = false;
+		}
+	}
+}
+
+function get() {
+	return this._state;
+}
+
+function init(component, options) {
+	component._handlers = blankObject();
+	component._bind = options._bind;
+
+	component.options = options;
+	component.root = options.root || component;
+	component.store = component.root.store || options.store;
+}
+
+function on(eventName, handler) {
+	var handlers = this._handlers[eventName] || (this._handlers[eventName] = []);
+	handlers.push(handler);
+
+	return {
+		cancel: function() {
+			var index = handlers.indexOf(handler);
+			if (~index) handlers.splice(index, 1);
+		}
+	};
+}
+
+function set(newState) {
+	this._set(assign({}, newState));
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
+}
+
+function _set(newState) {
+	var oldState = this._state,
+		changed = {},
+		dirty = false;
+
+	for (var key in newState) {
+		if (this._differs(newState[key], oldState[key])) changed[key] = dirty = true;
+	}
+	if (!dirty) return;
+
+	this._state = assign(assign({}, oldState), newState);
+	this._recompute(changed, this._state);
+	if (this._bind) this._bind(changed, this._state);
+
+	if (this._fragment) {
+		this.fire(\\"state\\", { changed: changed, current: this._state, previous: oldState });
+		this._fragment.p(changed, this._state);
+		this.fire(\\"update\\", { changed: changed, current: this._state, previous: oldState });
+	}
+}
+
+function callAll(fns) {
+	while (fns && fns.length) fns.shift()();
+}
+
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+}
+
+var proto = {
+	destroy,
+	get,
+	fire,
+	on,
+	set,
+	_recompute: noop,
+	_set,
+	_mount,
+	_differs
+};
+
+
+
+function create_main_fragment(component, ctx) {
+	var div;
+
+	return {
+		c() {
+			div = createElement(\\"div\\");
+			div.innerHTML = \\"<h1 class=\\\\\\"flex fooga hd\\\\\\">Head</h1>\\\\r\\\\n    <div class=\\\\\\"fooga wooga bd\\\\\\"><p class=undefined>Text</p></div>\\";
+			div.className = \\"flex wrapper\\";
+		},
+
+		m(target, anchor) {
+			insertNode(div, target, anchor);
+		},
+
+		p: noop,
+
+		d(detach) {
+			if (detach) {
+				detachNode(div);
+			}
+		}
+	};
+}
+
+function Svelte_external(options) {
+	init(this, options);
+	this._state = assign({}, options.data);
+	this._intro = true;
+
+	this._fragment = create_main_fragment(this, this._state);
+
+	if (options.target) {
+		this._fragment.c();
+		this._mount(options.target, options.anchor);
+	}
+}
+
+assign(Svelte_external.prototype, proto);
+
+export default Svelte_external;
+"
+`;
+
+exports[`/rollup.js should support external css via <link> 2`] = `
+"/* packages/svelte/test/specimens/simple.css */
+.fooga {
+    color: red;
+}
+/* packages/svelte/test/specimens/dependencies.css */
+.wooga {
+
+    background: blue;
+}
+/* packages/svelte/test/specimens/external.css */
+.flex {
+    display: flex;
+}
+.text {
+    color: #000;
+}
+.active {
+    color: #F00;
+}
+"
+`;

--- a/packages/svelte/test/__snapshots__/rollup.test.js.snap
+++ b/packages/svelte/test/__snapshots__/rollup.test.js.snap
@@ -336,7 +336,7 @@ function create_main_fragment(component, ctx) {
 	return {
 		c() {
 			div = createElement(\\"div\\");
-			div.innerHTML = \\"<h1 class=\\\\\\"flex fooga hd\\\\\\">Head</h1>\\\\r\\\\n    <div class=\\\\\\"fooga wooga bd\\\\\\"><p class=undefined>Text</p></div>\\";
+			div.innerHTML = \\"<h1 class=\\\\\\"flex fooga hd\\\\\\">Head</h1>\\\\n    <div class=\\\\\\"fooga wooga bd\\\\\\"><p class=undefined>Text</p></div>\\";
 			div.className = \\"flex wrapper\\";
 		},
 

--- a/packages/svelte/test/__snapshots__/svelte.test.js.snap
+++ b/packages/svelte/test/__snapshots__/svelte.test.js.snap
@@ -47,3 +47,38 @@ exports[`/svelte.js should ignore invalid {css.<key>} 1`] = `
 <h2 class=\\"yup\\">World</h2>
 <style>/* replaced by modular-css */</style>"
 `;
+
+exports[`/svelte.js should support external css via <link> 1`] = `
+"<div class=\\"flex wrapper\\">
+    <h1 class=\\"flex fooga hd\\">Head</h1>
+    <div class=\\"fooga wooga bd\\">
+        <p class=\\"{true ? \\"text\\" : \\"active\\" }\\">Text</p>
+    </div>
+</div>
+
+
+"
+`;
+
+exports[`/svelte.js should support external css via <link> 2`] = `
+"/* packages/svelte/test/specimens/simple.css */
+.fooga {
+    color: red;
+}
+/* packages/svelte/test/specimens/dependencies.css */
+.wooga {
+
+    background: blue;
+}
+/* packages/svelte/test/specimens/external.css */
+.flex {
+    display: flex;
+}
+.text {
+    color: #000;
+}
+.active {
+    color: #F00;
+}
+"
+`;

--- a/packages/svelte/test/rollup.test.js
+++ b/packages/svelte/test/rollup.test.js
@@ -61,4 +61,29 @@ describe("/rollup.js", () => {
             expect(() => read("svelte.css")).toThrow();
         });
     });
+
+    it("should support external css via <link>", () => {
+        const { preprocess, plugin } = processor({
+            css : "./packages/svelte/test/output/svelte.css",
+            namer
+        });
+
+        return rollup({
+            input   : require.resolve("./specimens/svelte-external.html"),
+            plugins : [
+                require("rollup-plugin-svelte")({
+                    preprocess
+                }),
+                plugin
+            ]
+        })
+        .then((bundle) => bundle.write({
+            format : "es",
+            file   : "./packages/svelte/test/output/svelte.js"
+        }))
+        .then(() => {
+            expect(cleanup(read("svelte.js"))).toMatchSnapshot();
+            expect(read("svelte.css")).toMatchSnapshot();
+        });
+    });
 });

--- a/packages/svelte/test/specimens/external.css
+++ b/packages/svelte/test/specimens/external.css
@@ -1,0 +1,24 @@
+.flex {
+    display: flex;
+}
+
+.wrapper {
+    composes: flex;
+}
+
+.hd {
+    composes: flex;
+    composes: fooga from "./simple.css";
+}
+
+.bd {
+    composes: wooga from "./dependencies.css";
+}
+
+.text {
+    color: #000;
+}
+
+.active {
+    color: #F00;
+}

--- a/packages/svelte/test/specimens/svelte-both.html
+++ b/packages/svelte/test/specimens/svelte-both.html
@@ -1,0 +1,35 @@
+<div class="{css.wrapper}">
+    <h1 class="{css.hd}">Head</h1>
+    <div class="{css.bd}">
+        <p class="{true ? css.text : css.active }">Text</p>
+    </div>
+</div>
+
+<link rel="stylesheet" href="./external.css">
+
+<style>
+    .flex {
+        display: flex;
+    }
+
+    .wrapper {
+        composes: flex;
+    }
+
+    .hd {
+        composes: flex;
+        composes: fooga from "./simple.css";
+    }
+
+    .bd {
+        composes: wooga from "./dependencies.css";
+    }
+
+    .text {
+        color: #000;
+    }
+
+    .active {
+        color: #F00;
+    }
+</style>

--- a/packages/svelte/test/specimens/svelte-external.html
+++ b/packages/svelte/test/specimens/svelte-external.html
@@ -1,0 +1,8 @@
+<div class="{css.wrapper}">
+    <h1 class="{css.hd}">Head</h1>
+    <div class="{css.bd}">
+        <p class="{true ? css.text : css.active }">Text</p>
+    </div>
+</div>
+
+<link rel="stylesheet" href="./external.css">

--- a/packages/svelte/test/svelte.test.js
+++ b/packages/svelte/test/svelte.test.js
@@ -34,6 +34,28 @@ describe("/svelte.js", () => {
         );
     });
 
+    it("should support external css via <link>", () => {
+        const { processor, preprocess } = plugin({
+            css : "./packages/svelte/test/output/svelte.css",
+            namer
+        });
+
+        const filename = require.resolve("./specimens/svelte-external.html");
+
+        return svelte.preprocess(
+            fs.readFileSync(filename, "utf8"),
+            Object.assign({}, preprocess, { filename })
+        )
+        .then((processed) => {
+            expect(processed.toString()).toMatchSnapshot();
+
+            return processor.output();
+        })
+        .then((output) =>
+            expect(output.css).toMatchSnapshot()
+        );
+    });
+
     it("should ignore files without <style> blocks", () => {
         const { processor, preprocess } = plugin();
 
@@ -69,6 +91,23 @@ describe("/svelte.js", () => {
         )
         .then((processed) =>
             expect(processed.toString()).toMatchSnapshot()
+        );
+    });
+
+    it("should throw on both <style> and <link> in one file", () => {
+        const { preprocess } = plugin({
+            css : "./packages/svelte/test/output/svelte.css",
+            namer
+        });
+
+        const filename = require.resolve("./specimens/svelte-both.html");
+
+        return svelte.preprocess(
+            fs.readFileSync(filename, "utf8"),
+            Object.assign({}, preprocess, { filename })
+        )
+        .catch((error) =>
+            expect(error.message).toMatch("modular-css-svelte supports <style> OR <link>, but not both")
         );
     });
 });


### PR DESCRIPTION
Instead of only supporting single file component `<style>`, this adds support for `<link>` tags that reference an external stylesheet. Part of the impetus behind this is making transitioning from the old-style `import css from "./styles.css";` flow easier to transition away from. Before you'd need to copy the contents of the CSS file into the svelte component. Now the process is deleting some code from inside the `<script>` block and turning the `import` into a `<link>`.

It also makes referencing classes/values from component-level CSS possible, because modular-css already knows how to process a CSS file. It doesn't know anything about a svelte HTML file though & it'd be a ton of work to add support for that.

So now there's an easy transitional path from the old-style css-as-data model to the preprocessor world where most classes can be completely static!