### PR TITLE
feat: add support for Rollup 60

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ language: node_js
 node_js:
 - node
 - '8'
-- '6'
 
 # https://docs.travis-ci.com/user/customizing-the-build/#Fast-Finishing
 matrix:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10719,9 +10719,9 @@
       }
     },
     "rollup": {
-      "version": "0.59.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.59.4.tgz",
-      "integrity": "sha512-ISiMqq/aJa+57QxX2MRcvLESHdJ7wSavmr6U1euMr+6UgFe6KM+3QANrYy8LQofwhTC1I7BcAdlLnDiaODs1BA==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.60.0.tgz",
+      "integrity": "sha512-uZrBe2uFy9E0FO3fb1T5ZEkUeZrF2rQIGWYmEoJ39NQegaJGQriPgJIGyKW3RkPwEIFH5X0C3HfqAgDdjE4CdQ==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1343,7 +1343,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -1929,8 +1928,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -2046,7 +2044,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2488,7 +2485,6 @@
       "requires": {
         "anymatch": "^1.3.0",
         "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
         "glob-parent": "^2.0.0",
         "inherits": "^2.0.1",
         "is-binary-path": "^1.0.0",
@@ -2758,7 +2754,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "dev": true,
       "requires": {
         "color-name": "^1.1.1"
       }
@@ -2766,8 +2761,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.5.2",
@@ -2853,8 +2847,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -3429,8 +3422,7 @@
     },
     "cuint": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
-      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
+      "bundled": true,
       "dev": true
     },
     "currently-unhandled": {
@@ -3682,8 +3674,7 @@
     },
     "dependency-graph": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.6.0.tgz",
-      "integrity": "sha512-xcKNDlPjiz7oV3RUnI45Ys/G/fiPgmQEzOYAXCC13RTBgneacHmCaaYwJC+KD6N7kIdqn4RRB7rZSKMwD7TJzQ==",
+      "bundled": true,
       "dev": true
     },
     "deps-sort": {
@@ -4957,535 +4948,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.21",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": "^2.1.0"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "minipass": {
-          "version": "2.2.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.10.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.1.10",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
-    },
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
@@ -6043,8 +5505,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -6263,7 +5724,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -6272,8 +5732,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
@@ -7919,26 +7378,22 @@
     },
     "lodash.findlast": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.findlast/-/lodash.findlast-4.6.0.tgz",
-      "integrity": "sha1-6ou3jPLn54BPyK630ZU+B/4x+8g=",
+      "bundled": true,
       "dev": true
     },
     "lodash.foreach": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
+      "bundled": true,
       "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "bundled": true,
       "dev": true
     },
     "lodash.invert": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.invert/-/lodash.invert-4.3.0.tgz",
-      "integrity": "sha1-j/4g1LYW9WvqjxqgxuvYDc90Ku4=",
+      "bundled": true,
       "dev": true
     },
     "lodash.kebabcase": {
@@ -7949,8 +7404,7 @@
     },
     "lodash.mapvalues": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
+      "bundled": true,
       "dev": true
     },
     "lodash.memoize": {
@@ -8343,8 +7797,7 @@
     },
     "mime": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bundled": true,
       "dev": true
     },
     "mime-db": {
@@ -8384,7 +7837,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -8489,64 +7941,14 @@
         "unique-slug": "^2.0.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "bundled": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
         "chalk": {
-          "version": "2.3.2",
+          "version": "2.4.1",
           "bundled": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
-        },
-        "clap": {
-          "version": "",
-          "bundled": true
-        },
-        "color-convert": {
-          "version": "1.9.1",
-          "bundled": true,
-          "requires": {
-            "color-name": "^1.1.1"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "cosmiconfig": {
-          "version": "",
-          "bundled": true
-        },
-        "csso": {
-          "version": "",
-          "bundled": true
-        },
-        "cuint": {
-          "version": "0.2.2",
-          "bundled": true
         },
         "dot-prop": {
           "version": "4.2.0",
@@ -8567,75 +7969,8 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true
-        },
-        "indexes-of": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "is-obj": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "mime": {
-          "version": "1.6.0",
-          "bundled": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "p-reduce": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "postcss-calc": {
-          "version": "",
           "bundled": true
         },
         "postcss-selector-parser": {
@@ -8648,40 +7983,9 @@
             "uniq": "^1.0.1"
           }
         },
-        "simple-swizzle": {
-          "version": "",
-          "bundled": true
-        },
         "source-map": {
           "version": "0.6.1",
           "bundled": true
-        },
-        "supports-color": {
-          "version": "5.3.0",
-          "bundled": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "svgo": {
-          "version": "",
-          "bundled": true
-        },
-        "uniq": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "xxhashjs": {
-          "version": "0.2.2",
-          "bundled": true,
-          "requires": {
-            "cuint": "^0.2.2"
-          }
         }
       }
     },
@@ -8751,13 +8055,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
-    },
-    "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-      "dev": true,
-      "optional": true
     },
     "nanomatch": {
       "version": "1.2.9",
@@ -9134,7 +8431,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -9300,8 +8596,7 @@
     },
     "p-each-series": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
-      "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+      "bundled": true,
       "dev": true,
       "requires": {
         "p-reduce": "^1.0.0"
@@ -9479,8 +8774,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -9983,8 +9277,7 @@
     },
     "postcss-url": {
       "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/postcss-url/-/postcss-url-7.3.2.tgz",
-      "integrity": "sha512-QMV5mA+pCYZQcUEPQkmor9vcPQ2MT+Ipuu8qdi1gVxbNiIiErEGft+eny1ak19qALoBkccS5AHaCaCDzh7b9MA==",
+      "bundled": true,
       "dev": true,
       "requires": {
         "mime": "^1.4.1",
@@ -10828,7 +10121,6 @@
         "capture-exit": "^1.2.0",
         "exec-sh": "^0.2.0",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^1.2.3",
         "micromatch": "^3.1.4",
         "minimist": "^1.1.1",
         "walker": "~1.0.5",
@@ -11624,7 +10916,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -12034,27 +11325,8 @@
     },
     "true-case-path": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
-      "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
-      "dev": true,
-      "requires": {
-        "glob": "^6.0.4"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "dev": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
+      "bundled": true,
+      "dev": true
     },
     "tslib": {
       "version": "1.9.2",
@@ -12545,7 +11817,6 @@
             "anymatch": "^2.0.0",
             "async-each": "^1.0.0",
             "braces": "^2.3.0",
-            "fsevents": "^1.1.2",
             "glob-parent": "^3.1.0",
             "inherits": "^2.0.1",
             "is-binary-path": "^1.0.0",
@@ -12849,8 +12120,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",
@@ -12954,8 +12224,7 @@
     },
     "xxhashjs": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.2.tgz",
-      "integrity": "sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==",
+      "bundled": true,
       "dev": true,
       "requires": {
         "cuint": "^0.2.2"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lint-staged": "^7.0.4",
     "modular-css-core": "file:./packages/core",
     "pegjs": "^0.10.0",
-    "rollup": "^0.59.4",
+    "rollup": "^0.60.0",
     "rollup-plugin-svelte": "^4.1.0",
     "shelljs": "^0.8.1",
     "svelte": "^2.1.1",

--- a/packages/rollup/README.md
+++ b/packages/rollup/README.md
@@ -1,5 +1,4 @@
-modular-css-rollup  [![NPM Version](https://img.shields.io/npm/v/modular-css-rollup.svg)](https://www.npmjs.com/package/modular-css-rollup) [![NPM License](https://img.shields.io/npm/l/modular-css-rollup.svg)](https://www.npmjs.com/package/modular-css-rollup) [![NPM Downloads](https://img.shields.io/npm/dm/modular-css-rollup.svg)](https://www.npmjs.com/package/modular-css-rollup)
-===========
+# modular-css-rollup  [![NPM Version](https://img.shields.io/npm/v/modular-css-rollup.svg)](https://www.npmjs.com/package/modular-css-rollup) [![NPM License](https://img.shields.io/npm/l/modular-css-rollup.svg)](https://www.npmjs.com/package/modular-css-rollup) [![NPM Downloads](https://img.shields.io/npm/dm/modular-css-rollup.svg)](https://www.npmjs.com/package/modular-css-rollup)
 
 <p align="center">
     <a href="https://gitter.im/modular-css/modular-css"><img src="https://img.shields.io/gitter/room/modular-css/modular-css.svg" alt="Gitter" /></a>
@@ -13,18 +12,16 @@ Rollup support for [`modular-css`](https://github.com/tivac/modular-css).
 
 ## Usage
 
+⚠️ As of `modular-css-rollup@11` this plugin will only work with `rollup@0.60.0` or higher due to plugin API changes ⚠️
+
 ### API
 
 ```js
-rollup({
+const bundle = await rollup({
     input   : "./index.js",
     plugins : [
-        require("modular-css-rollup")({
-            css : "./gen/index.css"
-        })
+        require("modular-css-rollup")()
     ]
-}).then(function(bundle) {
-    ...
 });
 ```
 
@@ -40,36 +37,35 @@ export default {
         format  : "umd"
     },
     plugins : [
-        css({
-            css : "./gen/index.css"
-        })
+        css()
     ]
 };
 ```
 
 ## Options
 
-### `ext`
-
-Extension to match on. Defaults to `.css`. Can be used in place of `include`/`exclude`.
-
 ### `include`/`exclude`
 
-A minimatch pattern, or an array of minimatch patterns, relative to `process.cwd()`. Can be used in place of `ext`.
+A minimatch pattern, or an array of minimatch patterns, relative to `process.cwd()`. `include` defaults to `**/*.css`.
 
 ### `css`
 
-Location to write the generated CSS file to.
+Boolean to determine if CSS files should be output at the end of compilation. Defaults to `true`.
 
 ### `json`
 
-Location to write out the JSON mapping file for use in server rendering.
+Boolean to determine if JSON files should be output at the end of compilation. Defaults to `false`.
 
 ### `namedExports`
 
 By default this plugin will create both a default export and named `export`s for each class in a CSS file. You can disable this by setting `namedExports` to `false`.
 
+### `map`
+
+Boolean to determine if inline source maps should be included. Defaults to `true`.
+
+To force the creation of external source maps set the value to `{ inline : false }`.
+
 ### Shared Options
 
 All other options are passed to the underlying `Processor` instance, see [Options](https://github.com/tivac/modular-css/blob/master/docs/api.md#options).
-

--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -118,7 +118,8 @@ module.exports = function(opts) {
                         from : source,
                         to   : css,
 
-                        files : bundle[entry]
+                        // Only export for files within this bundle
+                        files : Object.keys(bundle[entry].modules).filter(filter)
                     });
                     
                     this.setAssetSource(css, result.css);

--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -1,11 +1,9 @@
 "use strict";
 
-const fs   = require("fs");
 const path = require("path");
 
 const keyword = require("esutils").keyword;
 const utils   = require("rollup-pluginutils");
-const mkdirp  = require("mkdirp");
 
 const Processor = require("modular-css-core");
 const output    = require("modular-css-core/lib/output.js");
@@ -107,7 +105,7 @@ module.exports = function(opts) {
             runs++;
         },
 
-        generateBundle : async function(output, bundle, isWrite) {
+        generateBundle : async function(outputOptions, bundle) {
             await Promise.all(
                 Object.keys(bundle).map(async (entry) => {
                     const base = path.basename(entry, path.extname(entry));
@@ -135,37 +133,5 @@ module.exports = function(opts) {
                 })
             );
         },
-
-        // TODO: move into generateBundle
-        // onwrite : function(bundle, result) {
-        //     return result.css.then((data) => {
-        //         if(options.css) {
-        //             mkdirp.sync(path.dirname(options.css));
-                    
-        //             fs.writeFileSync(
-        //                 options.css,
-        //                 data.css
-        //             );
-        //         }
-
-        //         if(options.css && data.map) {
-        //             mkdirp.sync(path.dirname(options.css));
-
-        //             fs.writeFileSync(
-        //                 `${options.css}.map`,
-        //                 data.map.toString()
-        //             );
-        //         }
-                
-        //         if(options.json) {
-        //             mkdirp.sync(path.dirname(options.json));
-                    
-        //             fs.writeFileSync(
-        //                 options.json,
-        //                 JSON.stringify(data.compositions, null, 4)
-        //             );
-        //         }
-        //     });
-        // }
     };
 };

--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -30,10 +30,6 @@ module.exports = function(opts) {
     let processor = new Processor(options);
     let source;
         
-    if(!options.onwarn) {
-        options.onwarn = console.warn.bind(console); // eslint-disable-line
-    }
-
     return {
         name : "modular-css",
 
@@ -109,6 +105,12 @@ module.exports = function(opts) {
             await Promise.all(
                 Object.keys(bundle).map(async (entry) => {
                     const base = path.basename(entry, path.extname(entry));
+                    const files = Object.keys(bundle[entry].modules).filter(filter);
+
+                    // No point continuing if nothing to output!
+                    if(!files.length) {
+                        return;
+                    }
 
                     // TODO: docs say that empty string arg to .emitAsset() shouldn't be required
                     // https://github.com/rollup/rollup/wiki/Plugins#plugin-context

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`/rollup.js code splitting should support manual chunks 1`] = `
+"/* packages/rollup/test/specimens/manual-chunks/a.css */
+.a {
+
+    color: red;
+}
+"
+`;
+
+exports[`/rollup.js code splitting should support manual chunks 2`] = `
+"/* packages/rollup/test/specimens/manual-chunks/b.css */
+.b {
+
+    color: blue;
+}
+"
+`;
+
+exports[`/rollup.js code splitting should support manual chunks 3`] = `
+"/* packages/rollup/test/specimens/manual-chunks/c.css */
+.c { color: green; }
+"
+`;
+
 exports[`/rollup.js code splitting should support splitting up CSS files 1`] = `
 "/* packages/rollup/test/specimens/simple.css */
 .fooga {
@@ -147,9 +171,7 @@ console.log(css);
 }
 `;
 
-exports[`/rollup.js watch should correctly add new css files in watch mode when files change 1`] = `""`;
-
-exports[`/rollup.js watch should correctly add new css files in watch mode when files change 2`] = `
+exports[`/rollup.js watch should correctly add new css files in watch mode when files change 1`] = `
 "/* packages/rollup/test/output/one.css */
 .mc19ef5610_one {
     color: red;

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`/rollup.js code splitting should support splitting up CSS files 1`] = `
+"/* packages/rollup/test/specimens/simple.css */
+.fooga {
+    color: red;
+}
+"
+`;
+
+exports[`/rollup.js code splitting should support splitting up CSS files 2`] = `
+"/* packages/rollup/test/specimens/named.css */
+.a {
+    color: red;
+}
+"
+`;
+
 exports[`/rollup.js should allow disabling of named exports 1`] = `
 "var css = {
     \\"str\\": \\"\\\\\\"string\\\\\\"\\",

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -22,8 +22,7 @@ exports[`/rollup.js should generate CSS 1`] = `
 .fooga {
     color: red;
 }
-
-/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uL3NwZWNpbWVucy9zaW1wbGUuY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLCtDQUFDO0FBRUQ7SUFDSSxXQUFXO0NBQ2QiLCJmaWxlIjoic2ltcGxlLmNzcyIsInNvdXJjZXNDb250ZW50IjpbIkB2YWx1ZSBzdHI6IFwic3RyaW5nXCI7XG5cbi5mb29nYSB7XG4gICAgY29sb3I6IHJlZDtcbn1cbiJdfQ== */"
+"
 `;
 
 exports[`/rollup.js should generate JSON 1`] = `
@@ -45,7 +44,25 @@ console.log(css);
 "
 `;
 
-exports[`/rollup.js should generate external source maps 1`] = `"{\\"version\\":3,\\"sources\\":[\\"../specimens/simple.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,+CAAC;AAED;IACI,WAAW;CACd\\",\\"file\\":\\"simple.css\\",\\"sourcesContent\\":[\\"@value str: \\\\\\"string\\\\\\";\\\\n\\\\n.fooga {\\\\n    color: red;\\\\n}\\\\n\\"]}"`;
+exports[`/rollup.js should generate external source maps 1`] = `
+Object {
+  "file": Any<String>,
+  "mappings": "AAAA,+CAAC;AAED;IACI,WAAW;CACd",
+  "names": Array [],
+  "sources": Array [
+    "packages/rollup/test/specimens/simple.css",
+  ],
+  "sourcesContent": Array [
+    "@value str: \\"string\\";
+
+.fooga {
+    color: red;
+}
+",
+  ],
+  "version": 3,
+}
+`;
 
 exports[`/rollup.js should not output sourcemaps when they are disabled 1`] = `
 "/* packages/rollup/test/specimens/simple.css */
@@ -76,6 +93,16 @@ console.log(css);
 `;
 
 exports[`/rollup.js should warn & not export individual keys when they are not valid identifiers 1`] = `
+Object {
+  "code": "PLUGIN_WARNING",
+  "id": Any<String>,
+  "message": "Invalid JS identifier \\"fooga-wooga\\", unable to export",
+  "plugin": "modular-css",
+  "toString": [Function],
+}
+`;
+
+exports[`/rollup.js should warn & not export individual keys when they are not valid identifiers 2`] = `
 "var css = {
     \\"fooga\\": \\"fooga\\",
     \\"fooga-wooga\\": \\"fooga-wooga\\"
@@ -91,6 +118,9 @@ SourceMap {
   "file": "simple.js",
   "mappings": ";;;;;AAEA,OAAO,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC",
   "names": Array [],
+  "sources": Array [
+    "packages/rollup/test/specimens/simple.js",
+  ],
   "sourcesContent": Array [
     "import css from \\"./simple.css\\";
 

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -42,7 +42,7 @@ const format = "es";
 describe("/rollup.js", () => {
     /* eslint max-statements: "off" */
     
-    afterEach(() => shell.rm("-rf", "./packages/rollup/test/output/*"));
+    // afterEach(() => shell.rm("-rf", "./packages/rollup/test/output/*"));
     
     it("should be a function", () =>
         expect(typeof plugin).toBe("function")
@@ -469,6 +469,36 @@ describe("/rollup.js", () => {
 
                 return done();
             }));
+        });
+    });
+
+    describe("code splitting", () => {
+        it("should support splitting up CSS files", async () => {
+            const bundle = await rollup({
+                experimentalCodeSplitting : true,
+                
+                input : [
+                    require.resolve("./specimens/simple.js"),
+                    require.resolve("./specimens/named.js"),
+                ],
+
+                plugins : [
+                    plugin({
+                        namer,
+                        map : false
+                    })
+                ]
+            });
+    
+            await bundle.write({
+                format,
+                assetFileNames,
+                
+                dir : "./packages/rollup/test/output/"
+            });
+
+            expect(read("assets/simple.css")).toMatchSnapshot();
+            expect(read("assets/named.css")).toMatchSnapshot();
         });
     });
 });

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -42,7 +42,7 @@ const format = "es";
 describe("/rollup.js", () => {
     /* eslint max-statements: "off" */
     
-    // afterEach(() => shell.rm("-rf", "./packages/rollup/test/output/*"));
+    afterEach(() => shell.rm("-rf", "./packages/rollup/test/output/*"));
     
     it("should be a function", () =>
         expect(typeof plugin).toBe("function")

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -36,10 +36,13 @@ function watching(cb) {
 
 error.postcssPlugin = "error-plugin";
 
+const assetFileNames = "assets/[name][extname]";
+const format = "es";
+
 describe("/rollup.js", () => {
     /* eslint max-statements: "off" */
     
-    afterEach(() => shell.rm("-rf", "./packages/rollup/test/output/*"));
+    // afterEach(() => shell.rm("-rf", "./packages/rollup/test/output/*"));
     
     it("should be a function", () =>
         expect(typeof plugin).toBe("function")
@@ -54,7 +57,7 @@ describe("/rollup.js", () => {
                 })
             ]
         })
-        .then((bundle) => bundle.generate({ format : "es" }))
+        .then((bundle) => bundle.generate({ format }))
         .then((result) => expect(result.code).toMatchSnapshot())
     );
     
@@ -67,42 +70,29 @@ describe("/rollup.js", () => {
                 })
             ]
         })
-        .then((bundle) => bundle.generate({ format : "es" }))
+        .then((bundle) => bundle.generate({ format }))
         .then((result) => expect(result.code).toMatchSnapshot())
     );
 
-    it("should attach a promise to the bundle.generate response", () =>
-        rollup({
+    it("should generate CSS", async () => {
+        const bundle = await rollup({
             input   : require.resolve("./specimens/simple.js"),
             plugins : [
                 plugin({
                     namer,
-                    css : "./packages/rollup/test/output/simple.css"
+                    map : false
                 })
             ]
-        })
-        .then((bundle) => bundle.generate({ format : "es" }))
-        .then((result) => expect(typeof result.css.then).toBe("function"))
-    );
-    
-    it("should generate CSS", () =>
-        rollup({
-            input   : require.resolve("./specimens/simple.js"),
-            plugins : [
-                plugin({
-                    namer,
-                    css : "./packages/rollup/test/output/simple.css"
-                })
-            ]
-        })
-        .then((bundle) => bundle.write({
-            format : "es",
-            file   : "./packages/rollup/test/output/simple.js"
-        }))
-        .then(() =>
-            expect(read("simple.css")).toMatchSnapshot()
-        )
-    );
+        });
+
+        await bundle.write({
+            format,
+            assetFileNames,
+            file : "./packages/rollup/test/output/simple.js",
+        });
+
+        expect(read("assets/simple.css")).toMatchSnapshot();
+    });
     
     it("should generate JSON", () =>
         rollup({
@@ -110,69 +100,82 @@ describe("/rollup.js", () => {
             plugins : [
                 plugin({
                     namer,
-                    json : "./packages/rollup/test/output/simple.json"
+                    json : true
                 })
             ]
         })
         .then((bundle) => bundle.write({
-            format : "es",
-            file   : "./packages/rollup/test/output/simple.js"
+            format,
+            assetFileNames,
+            file : "./packages/rollup/test/output/simple.js",
         }))
         .then(() =>
-            expect(read("simple.json")).toMatchSnapshot()
+            expect(read("assets/simple.json")).toMatchSnapshot()
         )
     );
 
-    it("should provide named exports", () =>
-        rollup({
+    it("should provide named exports", async () => {
+        const bundle = await rollup({
             input   : require.resolve("./specimens/named.js"),
             plugins : [
                 plugin({
                     namer
                 })
             ]
-        })
-        .then((bundle) => bundle.generate({ format : "es" }))
-        .then((result) => expect(result.code).toMatchSnapshot())
-    );
+        });
 
-    it("should generate external source maps", () =>
-        rollup({
+        const result = await bundle.generate({ format });
+
+        expect(result.code).toMatchSnapshot();
+    });
+
+    it("should generate external source maps", async () => {
+        const bundle = await rollup({
             input   : require.resolve("./specimens/simple.js"),
             plugins : [
                 plugin({
                     namer,
-                    css : "./packages/rollup/test/output/simple.css",
                     map : {
                         inline : false
                     }
                 })
             ]
-        })
-        .then((bundle) => bundle.write({
-            format : "es",
-            file   : "./packages/rollup/test/output/simple.js"
-        }))
-        .then(() => expect(read("simple.css.map")).toMatchSnapshot())
-    );
+        });
+
+        await bundle.write({
+            format,
+            assetFileNames,
+            file : "./packages/rollup/test/output/simple.js",
+        });
+
+        // Have to parse it into JSON so the propertyMatcher can exclude the file property
+        // since it is a hash value and changes constantly
+        expect(JSON.parse(read("assets/simple.css.map"))).toMatchSnapshot({
+            file : expect.any(String)
+        });
+    });
     
-    it("should warn & not export individual keys when they are not valid identifiers", () =>
-        rollup({
+    it("should warn & not export individual keys when they are not valid identifiers", async () => {
+        const bundle = await rollup({
             input   : require.resolve("./specimens/invalid-name.js"),
+            onwarn  : (msg) => expect(msg).toMatchSnapshot({ id : expect.any(String) }),
             plugins : [
                 plugin({
                     namer,
-                    onwarn : (msg) =>
-                        expect(msg).toBe("Invalid JS identifier \"fooga-wooga\", unable to export")
                 })
             ]
-        })
-        .then((bundle) => bundle.generate({ format : "es" }))
-        .then((result) => expect(result.code).toMatchSnapshot())
-    );
+        });
 
-    it("should allow disabling of named exports", () =>
-        rollup({
+        const result = await bundle.generate({
+            format,
+            assetFileNames
+        });
+
+        expect(result.code).toMatchSnapshot();
+    });
+
+    it("should allow disabling of named exports", async () => {
+        const bundle = await rollup({
             input   : require.resolve("./specimens/simple.js"),
             plugins : [
                 plugin({
@@ -180,13 +183,18 @@ describe("/rollup.js", () => {
                     namedExports : false
                 })
             ]
-        })
-        .then((bundle) => bundle.generate({ format : "es" }))
-        .then((result) => expect(result.code).toMatchSnapshot())
-    );
+        });
+
+        const result = await bundle.generate({
+            format,
+            assetFileNames
+        });
+
+        expect(result.code).toMatchSnapshot();
+    });
     
-    it("shouldn't disable sourcemap generation", () =>
-        rollup({
+    it("shouldn't disable sourcemap generation", async () => {
+        const bundle = await rollup({
             input   : require.resolve("./specimens/simple.js"),
             plugins : [
                 plugin({
@@ -194,52 +202,47 @@ describe("/rollup.js", () => {
                     sourcemap : true
                 })
             ]
-        })
-        .then((bundle) => bundle.generate({
-            format    : "es",
-            sourcemap : true
-        }))
-        .then((result) => {
-            var map = result.map;
+        });
 
-            // Sources are absolute file paths, so prevent snapshot testing
-            delete map.sources;
-            
-            expect(map).toMatchSnapshot();
-        })
-    );
+        const result = await bundle.generate({
+            format,
+            assetFileNames,
+
+            sourcemap : true
+        });
+
+        expect(result.map).toMatchSnapshot();
+    });
     
-    it("should not output sourcemaps when they are disabled", () =>
-        rollup({
+    it("should not output sourcemaps when they are disabled", async () => {
+        const bundle = await rollup({
             input   : require.resolve("./specimens/simple.js"),
             plugins : [
                 plugin({
                     namer,
                     map : false,
-                    css : "./packages/rollup/test/output/no-maps.css"
                 })
             ]
-        })
-        .then((bundle) => Promise.all([
-            bundle,
-            bundle.generate({
-                format    : "es",
-                sourcemap : false
-            })
-        ]))
-        .then((results) => {
-            expect(results[1].map).toBe(null);
+        });
 
-            return results[0].write({
-                format    : "es",
-                file      : "./packages/rollup/test/output/no-maps.js",
-                sourcemap : false
-            });
-        })
-        .then(() =>
-            expect(read("no-maps.css")).toMatchSnapshot()
-        )
-    );
+        const source = await bundle.generate({
+            format,
+            assetFileNames,
+            sourcemap : false
+        });
+
+        expect(source.map).toBe(null);
+
+        await bundle.write({
+            format,
+            assetFileNames,
+
+            file      : "./packages/rollup/test/output/no-maps.js",
+            sourcemap : false,
+        });
+        
+        expect(read("assets/no-maps.css")).toMatchSnapshot();
+    });
 
     it("should respect the CSS dependency tree", () =>
         rollup({
@@ -250,7 +253,7 @@ describe("/rollup.js", () => {
                 })
             ]
         })
-        .then((bundle) => bundle.generate({ format : "es" }))
+        .then((bundle) => bundle.generate({ format }))
         .then((result) => expect(result.code).toMatchSnapshot())
     );
 
@@ -300,8 +303,8 @@ describe("/rollup.js", () => {
                 ]
             })
             .then((bundle) => bundle.write({
-                format : "es",
-                file   : "./packages/rollup/test/output/done-error.js"
+                format,
+                file : "./packages/rollup/test/output/done-error.js"
             }))
         );
     });
@@ -319,16 +322,16 @@ describe("/rollup.js", () => {
                 ".one { color: red; }"
             );
 
-            // Start watching (re-requiring rollup because it needs root obj reference)
+            // Start watching
             watcher = watch({
                 input  : require.resolve("./specimens/watch.js"),
                 output : {
-                    file   : "./packages/rollup/test/output/watch.js",
-                    format : "es"
+                    file : "./packages/rollup/test/output/watch-output.js",
+                    format,
+                    assetFileNames,
                 },
                 plugins : [
                     plugin({
-                        css : "./packages/rollup/test/output/watch-output.css",
                         map : false
                     })
                 ]
@@ -342,13 +345,13 @@ describe("/rollup.js", () => {
             
             watcher.on("event", watching((builds) => {
                 if(builds === 1) {
-                    expect(read("watch-output.css")).toMatchSnapshot();
+                    expect(read("assets/watch-output.css")).toMatchSnapshot();
 
                     // continue watching
                     return;
                 }
 
-                expect(read("watch-output.css")).toMatchSnapshot();
+                expect(read("assets/watch-output.css")).toMatchSnapshot();
 
                 return done();
             }));
@@ -356,68 +359,56 @@ describe("/rollup.js", () => {
 
         it("should correctly update files within the dependency graph in watch mode when files change", (done) => {
             // Create v1 of the files
-            fs.writeFileSync(
-                "./packages/rollup/test/output/one.css",
-                dedent(`
-                    .one {
-                        color: red;
-                    }
-                `)
-            );
+            fs.writeFileSync("./packages/rollup/test/output/one.css", dedent(`
+                .one {
+                    color: red;
+                }
+            `));
 
-            fs.writeFileSync(
-                "./packages/rollup/test/output/two.css",
-                dedent(`
-                    .two {
-                        composes: one from "./one.css";
-                        
-                        color: blue;
-                    }
-                `)
-            );
+            fs.writeFileSync("./packages/rollup/test/output/two.css", dedent(`
+                .two {
+                    composes: one from "./one.css";
+                    
+                    color: blue;
+                }
+            `));
             
-            fs.writeFileSync(
-                "./packages/rollup/test/output/watch.js",
-                dedent(`
-                    import css from "./two.css";
-                    console.log(css);
-                `)
-            );
+            fs.writeFileSync("./packages/rollup/test/output/watch.js", dedent(`
+                import css from "./two.css";
+                console.log(css);
+            `));
 
-            // Start watching (re-requiring rollup because it needs root obj reference)
+            // Start watching
             watcher = watch({
                 input  : require.resolve("./output/watch.js"),
                 output : {
-                    file   : "./packages/rollup/test/output/watch-output.js",
-                    format : "es"
+                    file : "./packages/rollup/test/output/watch-output.js",
+                    format,
+                    assetFileNames,
                 },
                 plugins : [
                     plugin({
-                        css : "./packages/rollup/test/output/watch-output.css",
                         map : false
                     })
                 ]
             });
 
             // Create v2 of the file after a bit
-            setTimeout(() => fs.writeFileSync(
-                "./packages/rollup/test/output/one.css",
-                dedent(`
-                    .one {
-                        color: green;
-                    }
-                `)
-            ), 200);
+            setTimeout(() => fs.writeFileSync("./packages/rollup/test/output/one.css", dedent(`
+                .one {
+                    color: green;
+                }
+            `)), 200);
             
             watcher.on("event", watching((builds) => {
                 if(builds === 1) {
-                    expect(read("watch-output.css")).toMatchSnapshot();
+                    expect(read("assets/watch-output.css")).toMatchSnapshot();
 
                     // continue watching
                     return;
                 }
 
-                expect(read("watch-output.css")).toMatchSnapshot();
+                expect(read("assets/watch-output.css")).toMatchSnapshot();
 
                 return done();
             }));
@@ -441,16 +432,16 @@ describe("/rollup.js", () => {
                 `)
             );
 
-            // Start watching (re-requiring rollup because it needs root obj reference)
+            // Start watching
             watcher = watch({
                 input  : require.resolve("./output/watch.js"),
                 output : {
-                    file   : "./packages/rollup/test/output/watch-output.js",
-                    format : "es"
+                    file : "./packages/rollup/test/output/watch-output.js",
+                    format,
+                    assetFileNames,
                 },
                 plugins : [
                     plugin({
-                        css : "./packages/rollup/test/output/watch-output.css",
                         map : false
                     })
                 ]
@@ -468,13 +459,13 @@ describe("/rollup.js", () => {
             
             watcher.on("event", watching((builds) => {
                 if(builds === 1) {
-                    expect(read("watch-output.css")).toMatchSnapshot();
+                    expect(read("assets/watch-output.css")).toMatchSnapshot();
 
                     // continue watching
                     return;
                 }
 
-                expect(read("watch-output.css")).toMatchSnapshot();
+                expect(read("assets/watch-output.css")).toMatchSnapshot();
 
                 return done();
             }));

--- a/packages/rollup/test/specimens/manual-chunks/a.css
+++ b/packages/rollup/test/specimens/manual-chunks/a.css
@@ -1,0 +1,5 @@
+.a {
+    composes: c from "./c.css";
+
+    color: red;
+}

--- a/packages/rollup/test/specimens/manual-chunks/a.js
+++ b/packages/rollup/test/specimens/manual-chunks/a.js
@@ -1,0 +1,6 @@
+import css from "./a.css";
+import c from "./c.js";
+
+console.log(c);
+
+export default css;

--- a/packages/rollup/test/specimens/manual-chunks/b.css
+++ b/packages/rollup/test/specimens/manual-chunks/b.css
@@ -1,0 +1,5 @@
+.b {
+    composes: c from "./c.css";
+
+    color: blue;
+}

--- a/packages/rollup/test/specimens/manual-chunks/b.js
+++ b/packages/rollup/test/specimens/manual-chunks/b.js
@@ -1,0 +1,6 @@
+import css from "./b.css";
+import c from "./c.js";
+
+console.log(c);
+
+export default css;

--- a/packages/rollup/test/specimens/manual-chunks/c.css
+++ b/packages/rollup/test/specimens/manual-chunks/c.css
@@ -1,0 +1,1 @@
+.c { color: green; }

--- a/packages/rollup/test/specimens/manual-chunks/c.js
+++ b/packages/rollup/test/specimens/manual-chunks/c.js
@@ -1,0 +1,3 @@
+import css from "./c.css";
+
+export default css;

--- a/packages/rollup/test/specimens/no-css.js
+++ b/packages/rollup/test/specimens/no-css.js
@@ -1,0 +1,1 @@
+console.log("hello");

--- a/packages/test-utils/exists.js
+++ b/packages/test-utils/exists.js
@@ -1,0 +1,8 @@
+"use strict";
+
+const path = require("path");
+
+const shell = require("shelljs");
+
+module.exports = (cwd) =>
+    (name) => shell.test("-f", path.join(cwd, "./output", name));


### PR DESCRIPTION
This takes advantage of the new plugins APIs introduced in https://github.com/rollup/rollup/pull/2208

`modular-css-rollup` will now support automatic chunks via multiple `inputs` and manual chunking of vendor files via `manualChunks`. It might also support dynamic `import` but I haven't written tests for that yet.

This is a :warning: **BREAKING CHANGE** :warning:, it will only be compatible with `rollup@0.60` and higher.