### PR TITLE
fix: tighten up rollup bundles

### DIFF
--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -134,9 +134,9 @@ module.exports = function(opts) {
             Object.keys(bundles).forEach((entry) => {
                 const file = {
                     entry,
-                    base : extensionless(entry),
 
-                    css : [ ],
+                    base : extensionless(entry),
+                    css  : [],
                 };
 
                 // Get CSS files being used by each entry point
@@ -153,7 +153,7 @@ module.exports = function(opts) {
                         start,
                     ];
 
-                    file.css = file.css.concat(used);
+                    file.css.push(...used);
 
                     used.forEach((dep) => {
                         usage.set(dep, usage.has(dep) ? usage.get(dep) + 1 : 1);
@@ -163,35 +163,41 @@ module.exports = function(opts) {
                 files.push(file);
             });
 
-            // Second pass removes any dependencies appearing in multiple bundles
-            files.forEach((file) => {
-                const { css } = file;
+            // Special case where we don't need to do any ref-counting
+            if(files.length === 1) {
+                files[0].css = processor.dependencies();
+            } else {
+                // Only have to do this work if there's multiple bundles
+                // Second pass removes any dependencies appearing in multiple bundles
+                files.forEach((file) => {
+                    const { css } = file;
 
-                file.css = css.filter((dep) => {
-                    if(usage.get(dep) > 1) {
-                        common.set(dep, true);
+                    file.css = css.filter((dep) => {
+                        if(usage.get(dep) > 1) {
+                            common.set(dep, true);
 
-                        return false;
+                            return false;
+                        }
+
+                        return true;
+                    });
+                });
+
+                // Add any other files that weren't part of a bundle to the common chunk
+                Object.keys(processor.files).forEach((file) => {
+                    if(!usage.has(file)) {
+                        common.set(file, true);
                     }
-
-                    return true;
                 });
-            });
 
-            // Add any other files that weren't part of a bundle to the common chunk
-            Object.keys(processor.files).forEach((file) => {
-                if(!usage.has(file)) {
-                    common.set(file, true);
+                // Common chunk only emitted if necessary
+                if(common.size) {
+                    files.push({
+                        entry : options.common,
+                        base  : extensionless(options.common),
+                        css   : [ ...common.keys() ],
+                    });
                 }
-            });
-
-            // Common chunk only emitted if necessary
-            if(common.size) {
-                files.push({
-                    entry : options.common,
-                    base  : extensionless(options.common),
-                    css   : [ ...common.keys() ],
-                });
             }
 
             await Promise.all(

--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -156,18 +156,18 @@ module.exports = function(opts) {
                     file.css.push(...used);
 
                     used.forEach((dep) => {
-                        usage.set(dep, usage.has(dep) ? usage.get(dep) + 1 : 1);
+                        usage.set(dep, (usage.get(dep) || 0) + 1);
                     });
                 });
 
                 files.push(file);
             });
 
-            // Special case where we don't need to do any ref-counting
             if(files.length === 1) {
+                // Only one entry file means we only need one bundle.
                 files[0].css = processor.dependencies();
             } else {
-                // Only have to do this work if there's multiple bundles
+                // Multiple bundles means ref-counting to find the shared deps
                 // Second pass removes any dependencies appearing in multiple bundles
                 files.forEach((file) => {
                     const { css } = file;

--- a/packages/rollup/test/__snapshots__/rollup-watch.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup-watch.test.js.snap
@@ -89,7 +89,11 @@ exports[`/rollup.js watch mode should update when a dependency changes 2`] = `
 `;
 
 exports[`/rollup.js watch mode should update when a shared dependency changes 1`] = `
-"/* packages/rollup/test/output/watch/shared-deps/one.css */
+"/* packages/rollup/test/output/watch/shared-deps/two.css */
+.mc5067d789_two {
+    color: green;
+}
+/* packages/rollup/test/output/watch/shared-deps/one.css */
 .mca79168b9_one {
     color: red;
 }
@@ -102,25 +106,15 @@ exports[`/rollup.js watch mode should update when a shared dependency changes 1`
 exports[`/rollup.js watch mode should update when a shared dependency changes 2`] = `
 "/* packages/rollup/test/output/watch/shared-deps/two.css */
 .mc5067d789_two {
-    color: green;
-}"
-`;
-
-exports[`/rollup.js watch mode should update when a shared dependency changes 3`] = `
-"/* packages/rollup/test/output/watch/shared-deps/one.css */
+    color: yellow;
+}
+/* packages/rollup/test/output/watch/shared-deps/one.css */
 .mca79168b9_one {
-    color: blue;
+    color: red;
 }
 /* packages/rollup/test/output/watch/shared-deps/three.css */
 .mc4ec9318b_three {
     color: teal;
-}"
-`;
-
-exports[`/rollup.js watch mode should update when a shared dependency changes 4`] = `
-"/* packages/rollup/test/output/watch/shared-deps/two.css */
-.mc5067d789_two {
-    color: green;
 }"
 `;
 

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -80,17 +80,13 @@ exports[`/rollup.js code splitting should support splitting up CSS files 2`] = `
 `;
 
 exports[`/rollup.js should accept an existing processor instance 1`] = `
-"/* packages/rollup/test/specimens/simple.css */
-.fooga {
-    color: red;
-}
-"
-`;
-
-exports[`/rollup.js should accept an existing processor instance 2`] = `
 "/* packages/rollup/test/specimens/fake.css */
 .fake {
     color: yellow;
+}
+/* packages/rollup/test/specimens/simple.css */
+.fooga {
+    color: red;
 }"
 `;
 
@@ -269,20 +265,6 @@ console.log(css, css$1);
 `;
 
 exports[`/rollup.js shouldn't over-remove files from an existing processor instance 2`] = `
-"/* packages/rollup/test/specimens/repeated-references/a.css */
-.a {
-
-    color: red;
-}
-/* packages/rollup/test/specimens/repeated-references/b.css */
-.b {
-    
-    color: blue;
-}
-"
-`;
-
-exports[`/rollup.js shouldn't over-remove files from an existing processor instance 3`] = `
 "/* packages/rollup/test/specimens/repeated-references/d.css */
 .d {
     color: darkblue;
@@ -290,6 +272,16 @@ exports[`/rollup.js shouldn't over-remove files from an existing processor insta
 /* packages/rollup/test/specimens/repeated-references/c.css */
 .c {
     color: cadetblue;
+}
+/* packages/rollup/test/specimens/repeated-references/b.css */
+.b {
+    
+    color: blue;
+}
+/* packages/rollup/test/specimens/repeated-references/a.css */
+.a {
+
+    color: red;
 }
 "
 `;

--- a/packages/rollup/test/rollup-watch.test.js
+++ b/packages/rollup/test/rollup-watch.test.js
@@ -298,24 +298,21 @@ describe("/rollup.js", () => {
             });
 
             // Create v2 of the file after a bit
-            setTimeout(() => write(`./watch/shared-deps/one.css`, dedent(`
-                .one {
-                    composes: two from "./two.css";
-                    color: blue;
+            setTimeout(() => write(`./watch/shared-deps/two.css`, dedent(`
+                .two {
+                    color: yellow;
                 }
             `)), 200);
 
             watcher.on("event", watching((builds) => {
                 if(builds === 1) {
                     expect(read("./watch/shared-deps/assets/watch-output.css")).toMatchSnapshot();
-                    expect(read("./watch/shared-deps/assets/common.css")).toMatchSnapshot();
                     
                     // continue watching
                     return;
                 }
                 
                 expect(read("./watch/shared-deps/assets/watch-output.css")).toMatchSnapshot();
-                expect(read("./watch/shared-deps/assets/common.css")).toMatchSnapshot();
 
                 return done();
             }));

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -346,7 +346,6 @@ describe("/rollup.js", () => {
         });
 
         expect(read("./rollup/existing-processor/assets/existing-processor.css")).toMatchSnapshot();
-        expect(read("./rollup/existing-processor/assets/common.css")).toMatchSnapshot();
     });
 
     it("shouldn't over-remove files from an existing processor instance", async () => {
@@ -376,7 +375,6 @@ describe("/rollup.js", () => {
 
         expect(read("./rollup/repeated-references/repeated-references.js")).toMatchSnapshot();
         expect(read("./rollup/repeated-references/assets/repeated-references.css")).toMatchSnapshot();
-        expect(read("./rollup/repeated-references/assets/common.css")).toMatchSnapshot();
     });
 
     describe("errors", () => {


### PR DESCRIPTION
When working on #449 I got annoyed at how many times I was having to check `common.css` in cases where it wasn't actually necessary.

So now I've done something about it. `modular-css-rollup` will only create a `common.css` if there's more than one CSS bundle being generated which is how it should've been all along.