### PR TITLE
feat: add rollup option to export styles

### DIFF
--- a/packages/rollup/README.md
+++ b/packages/rollup/README.md
@@ -66,6 +66,10 @@ To force the creation of external source maps set the value to `{ inline : false
 
 By default this plugin will create both a default export and named `export`s for each class in a CSS file. You can disable this by setting `namedExports` to `false`.
 
+### `styleExport`
+
+By default this plugin will extract and bundle CSS in a separate file. If you would like the styles from each imported CSS file to be exported as a string for use in JS, you can enable this by setting `styleExport` to `true`. If you are using this option, you should perform any additional CSS transformations in the `after` hook (instead of the `done` hook).
+
 ### Shared Options
 
 All other options are passed to the underlying `Processor` instance, see [Options](https://github.com/tivac/modular-css/blob/master/docs/api.md#options).

--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -30,6 +30,8 @@ module.exports = function(opts) {
         include : "**/*.css",
 
         namedExports : true,
+
+        styleExport : false,
     }, opts);
         
     const filter = utils.createFilter(options.include, options.exclude);
@@ -96,6 +98,10 @@ module.exports = function(opts) {
                     
                     out.push(`export var ${ident} = ${JSON.stringify(exported[ident])};`);
                 });
+            }
+
+            if(options.styleExport) {
+              out.push(`export var styles = ${JSON.stringify(result.details.result.css)};`);
             }
 
             const dependencies = processor.dependencies(id);

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -190,6 +190,13 @@ console.log(a, str, num, dim, mix);
 "
 `;
 
+exports[`/rollup.js should provide style export 1`] = `
+"var styles = \\".ooh {\\\\n    content: \\\\\\"string\\\\\\";\\\\n}\\\\n\\\\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInBhY2thZ2VzL3JvbGx1cC90ZXN0L3NwZWNpbWVucy9zdHlsZS1leHBvcnQuY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVBO0lBRkEsa0JBQXFCO0NBSXBCIiwiZmlsZSI6InBhY2thZ2VzL3JvbGx1cC90ZXN0L3NwZWNpbWVucy9zdHlsZS1leHBvcnQuY3NzIiwic291cmNlc0NvbnRlbnQiOlsiQHZhbHVlIHN0cjogXCJzdHJpbmdcIjtcblxuLm9vaCB7XG4gICAgY29udGVudDogc3RyO1xufVxuIl19 */\\";
+
+console.log(styles);
+"
+`;
+
 exports[`/rollup.js should respect the CSS dependency tree 1`] = `
 "var css = {
     \\"wooga\\": \\"fooga wooga\\"

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -178,6 +178,22 @@ describe("/rollup.js", () => {
         expect(result.code).toMatchSnapshot();
     });
 
+    it("should provide style export", async () => {
+        const bundle = await rollup({
+            input   : require.resolve("./specimens/style-export.js"),
+            plugins : [
+                plugin({
+                    namer,
+                    styleExport : true,
+                }),
+            ],
+        });
+
+        const result = await bundle.generate({ format });
+
+        expect(result.code).toMatchSnapshot();
+    });
+
     it("should generate external source maps", async () => {
         const bundle = await rollup({
             input   : require.resolve("./specimens/simple.js"),

--- a/packages/rollup/test/specimens/style-export.css
+++ b/packages/rollup/test/specimens/style-export.css
@@ -1,0 +1,5 @@
+@value str: "string";
+
+.ooh {
+    content: str;
+}

--- a/packages/rollup/test/specimens/style-export.js
+++ b/packages/rollup/test/specimens/style-export.js
@@ -1,0 +1,3 @@
+import { styles } from "./style-export.css";
+
+console.log(styles);


### PR DESCRIPTION
See https://github.com/tivac/modular-css/issues/451 for more information.

This pull request adds a `styleExport` option to `modular-css-rollup` that will add an additional ES Module `export` of each CSS Module's styles for CSS-in-JS approaches that may need the style contents instead of or in addition to class names and values. 

One specific example is gaining true style scoping by using [Shadow DOM](https://dom.spec.whatwg.org/#shadowroot) where only styles within the shadow tree will apply to the elements in the shadow tree. Making the styles available in scripts allows a developer to embed the styles in each Web Component instance.