### PR TITLE
fix: External map references

### DIFF
--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -16,13 +16,14 @@ const emptyMappings = {
     mappings : "",
 };
 
-const parts = (file) => {
-    const name = path.basename(file, path.extname(file));
+const makeFile = (details) => {
+    const { entry } = details;
+    const name = path.basename(entry, path.extname(entry));
 
-    return {
-        base : path.join(path.dirname(file), name),
+    return Object.assign(details, {
+        base : path.join(path.dirname(entry), name),
         name,
-    };
+    });
 };
 
 module.exports = function(opts) {
@@ -166,7 +167,7 @@ module.exports = function(opts) {
 
             // First pass is used to calculate JS usage of CSS dependencies
             Object.keys(bundles).forEach((entry) => {
-                const file = Object.assign(parts(entry), {
+                const file = makeFile({
                     entry,
                     css : [],
                 });
@@ -224,7 +225,7 @@ module.exports = function(opts) {
 
                 // Common chunk only emitted if necessary
                 if(common.size) {
-                    files.push(Object.assign(parts(options.common), {
+                    files.push(makeFile({
                         entry : options.common,
                         css   : [ ...common.keys() ],
                     }));

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -163,6 +163,15 @@ Object {
 }
 `;
 
+exports[`/rollup.js should generate external source maps 2`] = `
+"/* packages/rollup/test/specimens/simple.css */
+.fooga {
+    color: red;
+}
+
+/*# sourceMappingURL=simple.css.map */"
+`;
+
 exports[`/rollup.js should handle assetFileNames being undefined 1`] = `
 "/* packages/rollup/test/specimens/simple.css */
 .fooga {

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -240,6 +240,8 @@ describe("/rollup.js", () => {
         expect(JSON.parse(read("./rollup/external-source-maps/assets/simple.css.map"))).toMatchSnapshot({
             file : expect.any(String),
         });
+
+        expect(read("./rollup/external-source-maps/assets/simple.css")).toMatchSnapshot();
     });
     
     it("should warn & not export individual keys when they are not valid identifiers", async () => {


### PR DESCRIPTION
Fixes #455 

This won't handle `[hash]` but I have no idea what I could possibly do there in that instance, because rollup won't tell me the filename ahead of time (since it can't get the hash until it has the contents, an annoying 🐔 and 🥚 problem).