### PR TITLE
chore: document use of processing w/styleExport

### DIFF
--- a/packages/rollup/README.md
+++ b/packages/rollup/README.md
@@ -68,7 +68,7 @@ By default this plugin will create both a default export and named `export`s for
 
 ### `styleExport`
 
-By default this plugin will extract and bundle CSS in a separate file. If you would like the styles from each imported CSS file to be exported as a string for use in JS, you can enable this by setting `styleExport` to `true`. If you are using this option the `done` hook **will not run**, you should perform any additional CSS transformations in the `after` hook instead.
+By default this plugin will extract and bundle CSS in a separate file. If you would like the styles from each imported CSS file to be exported as a string for use in JS, you can enable this by setting `styleExport` to `true`. If you are using this option the `done` hook **will not run**, you should perform any additional CSS transformations in the `processing` hook instead.
 
 ```js
 import { styles } from "./styles.css";


### PR DESCRIPTION
previously recommended use of `after`, which appears to not run early enough