### PR TITLE
Bundle specific ref-counting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9165,6 +9165,12 @@
         "graceful-fs": "^4.1.2"
       }
     },
+    "read-dir-deep": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/read-dir-deep/-/read-dir-deep-1.0.4.tgz",
+      "integrity": "sha512-hxNRefbc81F1SkkIH9KAQv4WkfIzx7dNeYt1/whQM9pgbaQ8KTL+TXLdHnlMKty8YAMCq7PRakrfbkwyt6RrqA==",
+      "dev": true
+    },
     "read-only-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "lerna": "^3.0.0-rc.0",
     "modular-css-core": "file:./packages/core",
     "pegjs": "^0.10.0",
+    "read-dir-deep": "^1.0.4",
     "rollup": "^0.63.5",
     "rollup-plugin-svelte": "^4.2.1",
     "shelljs": "^0.8.1",

--- a/packages/rollup/test/__snapshots__/splitting.test.js.snap
+++ b/packages/rollup/test/__snapshots__/splitting.test.js.snap
@@ -1,115 +1,135 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`/rollup.js code splitting should support dynamic imports 1`] = `
-"/* packages/rollup/test/specimens/dynamic-imports/a.css */
+Array [
+  Object {
+    "file": "a.css",
+    "text": "/* packages/rollup/test/specimens/dynamic-imports/a.css */
 .a {
 
     color: aqua;
 }
-"
-`;
-
-exports[`/rollup.js code splitting should support dynamic imports 2`] = `
-"/* packages/rollup/test/specimens/dynamic-imports/b.css */
+",
+  },
+  Object {
+    "file": "b.css",
+    "text": "/* packages/rollup/test/specimens/dynamic-imports/b.css */
 .b {
     color: blue;
 }
-"
-`;
-
-exports[`/rollup.js code splitting should support dynamic imports 3`] = `
-"/* packages/rollup/test/specimens/dynamic-imports/c.css */
+",
+  },
+  Object {
+    "file": "c.css",
+    "text": "/* packages/rollup/test/specimens/dynamic-imports/c.css */
 .c {
     
     color: cyan;
 }
-"
-`;
-
-exports[`/rollup.js code splitting should support dynamic imports 4`] = `
-"/* packages/rollup/test/specimens/dynamic-imports/d.css */
+",
+  },
+  Object {
+    "file": "common.css",
+    "text": "/* packages/rollup/test/specimens/dynamic-imports/d.css */
 .d {
     color: darkred;
 }
-"
+",
+  },
+]
 `;
 
 exports[`/rollup.js code splitting should support manual chunks 1`] = `
-"/* packages/rollup/test/specimens/manual-chunks/a.css */
+Array [
+  Object {
+    "file": "a.css",
+    "text": "/* packages/rollup/test/specimens/manual-chunks/a.css */
 .a {
 
     color: red;
 }
-"
-`;
-
-exports[`/rollup.js code splitting should support manual chunks 2`] = `
-"/* packages/rollup/test/specimens/manual-chunks/b.css */
+",
+  },
+  Object {
+    "file": "b.css",
+    "text": "/* packages/rollup/test/specimens/manual-chunks/b.css */
 .b {
 
     color: blue;
 }
-"
-`;
-
-exports[`/rollup.js code splitting should support manual chunks 3`] = `
-"/* packages/rollup/test/specimens/manual-chunks/d.css */
+",
+  },
+  Object {
+    "file": "common.css",
+    "text": "/* packages/rollup/test/specimens/manual-chunks/d.css */
 /* packages/rollup/test/specimens/manual-chunks/c.css */
 .c {
     color: green;
     background: darkred;
 }
-"
+",
+  },
+]
 `;
 
 exports[`/rollup.js code splitting should support splitting up CSS files 1`] = `
-"/* packages/rollup/test/specimens/simple.css */
+Array [
+  Object {
+    "file": "common.css",
+    "text": "/* packages/rollup/test/specimens/simple.css */
 .fooga {
     color: red;
 }
-"
-`;
-
-exports[`/rollup.js code splitting should support splitting up CSS files 2`] = `
-"/* packages/rollup/test/specimens/dependencies.css */
+",
+  },
+  Object {
+    "file": "dependencies.css",
+    "text": "/* packages/rollup/test/specimens/dependencies.css */
 .wooga {
 
     background: blue;
 }
-"
+",
+  },
+]
 `;
 
 exports[`/rollup.js code splitting should support splitting up CSS files w/ shared assets 1`] = `
-"/* packages/rollup/test/specimens/css-chunks/a.css */
+Array [
+  Object {
+    "file": "a.css",
+    "text": "/* packages/rollup/test/specimens/css-chunks/a.css */
 .a {
 
     color: aqua;
 }
-"
-`;
-
-exports[`/rollup.js code splitting should support splitting up CSS files w/ shared assets 2`] = `
-"/* packages/rollup/test/specimens/css-chunks/b.css */
+",
+  },
+  Object {
+    "file": "b.css",
+    "text": "/* packages/rollup/test/specimens/css-chunks/b.css */
 .b {
     
     color: blue;
 }
-"
-`;
-
-exports[`/rollup.js code splitting should support splitting up CSS files w/ shared assets 3`] = `
-"/* packages/rollup/test/specimens/css-chunks/c.css */
+",
+  },
+  Object {
+    "file": "chunk.css",
+    "text": "/* packages/rollup/test/specimens/css-chunks/c.css */
 .c {
 
     color: cyan;
 }
-"
-`;
-
-exports[`/rollup.js code splitting should support splitting up CSS files w/ shared assets 4`] = `
-"/* packages/rollup/test/specimens/css-chunks/shared.css */
+",
+  },
+  Object {
+    "file": "common.css",
+    "text": "/* packages/rollup/test/specimens/css-chunks/shared.css */
 .shared {
     color: snow;
 }
-"
+",
+  },
+]
 `;

--- a/packages/rollup/test/__snapshots__/splitting.test.js.snap
+++ b/packages/rollup/test/__snapshots__/splitting.test.js.snap
@@ -133,3 +133,34 @@ Array [
   },
 ]
 `;
+
+exports[`/rollup.js code splitting shouldn't put bundle-specific CSS in common.css 1`] = `
+Array [
+  Object {
+    "file": "a.css",
+    "text": "/* packages/rollup/test/specimens/common-splitting/shared.css */
+.shared {
+    color: snow;
+}
+/* packages/rollup/test/specimens/common-splitting/a.css */
+.a {
+
+    color: aqua;
+}
+/* packages/rollup/test/specimens/common-splitting/b.css */
+.b {
+
+    color: blue;
+}
+",
+  },
+  Object {
+    "file": "c.css",
+    "text": "/* packages/rollup/test/specimens/common-splitting/c.css */
+.c {
+    color: cyan;
+}
+",
+  },
+]
+`;

--- a/packages/rollup/test/specimens/common-splitting/a.css
+++ b/packages/rollup/test/specimens/common-splitting/a.css
@@ -1,0 +1,5 @@
+.a {
+    composes: shared from "./shared.css";
+
+    color: aqua;
+}

--- a/packages/rollup/test/specimens/common-splitting/a.js
+++ b/packages/rollup/test/specimens/common-splitting/a.js
@@ -1,0 +1,4 @@
+import css from "./a.css";
+import js from "./b.js";
+
+console.log(css, js);

--- a/packages/rollup/test/specimens/common-splitting/b.css
+++ b/packages/rollup/test/specimens/common-splitting/b.css
@@ -1,0 +1,5 @@
+.b {
+    composes: shared from "./shared.css";
+
+    color: blue;
+}

--- a/packages/rollup/test/specimens/common-splitting/b.js
+++ b/packages/rollup/test/specimens/common-splitting/b.js
@@ -1,0 +1,5 @@
+import css from "./b.css";
+
+console.log(css);
+
+export default "b.js";

--- a/packages/rollup/test/specimens/common-splitting/c.css
+++ b/packages/rollup/test/specimens/common-splitting/c.css
@@ -1,0 +1,3 @@
+.c {
+    color: cyan;
+}

--- a/packages/rollup/test/specimens/common-splitting/c.js
+++ b/packages/rollup/test/specimens/common-splitting/c.js
@@ -1,0 +1,3 @@
+import css from "./c.css";
+
+export default css;

--- a/packages/rollup/test/specimens/common-splitting/shared.css
+++ b/packages/rollup/test/specimens/common-splitting/shared.css
@@ -1,0 +1,3 @@
+.shared {
+    color: snow;
+}

--- a/packages/rollup/test/splitting.test.js
+++ b/packages/rollup/test/splitting.test.js
@@ -85,6 +85,35 @@ describe("/rollup.js", () => {
 
             expect(dir("./rollup/css-chunking/assets")).toMatchSnapshot();
         });
+        
+        it("shouldn't put bundle-specific CSS in common.css", async () => {
+            const bundle = await rollup({
+                experimentalCodeSplitting,
+
+                input : [
+                    require.resolve("./specimens/common-splitting/a.js"),
+                    require.resolve("./specimens/common-splitting/c.js"),
+                ],
+
+                plugins : [
+                    plugin({
+                        namer,
+                        map,
+                    }),
+                ],
+            });
+
+            await bundle.write({
+                format,
+
+                assetFileNames,
+                chunkFileNames,
+
+                dir : prefix(`./output/rollup/common-splitting`),
+            });
+
+            expect(dir("./rollup/common-splitting/assets")).toMatchSnapshot();
+        });
 
         it("should support manual chunks", async () => {
             const bundle = await rollup({

--- a/packages/rollup/test/splitting.test.js
+++ b/packages/rollup/test/splitting.test.js
@@ -5,7 +5,7 @@ const { rollup } = require("rollup");
 
 const shell = require("shelljs");
 
-const read = require("test-utils/read.js")(__dirname);
+const dir = require("test-utils/read-dir.js")(__dirname);
 const prefix = require("test-utils/prefix.js")(__dirname);
 const namer = require("test-utils/namer.js");
 
@@ -54,8 +54,7 @@ describe("/rollup.js", () => {
                 dir : prefix(`./output/rollup/splitting`),
             });
 
-            expect(read("./rollup/splitting/assets/common.css")).toMatchSnapshot();
-            expect(read("./rollup/splitting/assets/dependencies.css")).toMatchSnapshot();
+            expect(dir("./rollup/splitting/assets")).toMatchSnapshot();
         });
 
         it("should support splitting up CSS files w/ shared assets", async () => {
@@ -84,10 +83,7 @@ describe("/rollup.js", () => {
                 dir : prefix(`./output/rollup/css-chunking`),
             });
 
-            expect(read("./rollup/css-chunking/assets/a.css")).toMatchSnapshot();
-            expect(read("./rollup/css-chunking/assets/b.css")).toMatchSnapshot();
-            expect(read("./rollup/css-chunking/assets/chunk.css")).toMatchSnapshot();
-            expect(read("./rollup/css-chunking/assets/common.css")).toMatchSnapshot();
+            expect(dir("./rollup/css-chunking/assets")).toMatchSnapshot();
         });
 
         it("should support manual chunks", async () => {
@@ -122,9 +118,7 @@ describe("/rollup.js", () => {
                 dir : prefix(`./output/rollup/manual-chunks`),
             });
 
-            expect(read("./rollup/manual-chunks/assets/a.css")).toMatchSnapshot();
-            expect(read("./rollup/manual-chunks/assets/b.css")).toMatchSnapshot();
-            expect(read("./rollup/manual-chunks/assets/common.css")).toMatchSnapshot();
+            expect(dir("./rollup/manual-chunks/assets")).toMatchSnapshot();
         });
 
         it("should support dynamic imports", async () => {
@@ -155,10 +149,7 @@ describe("/rollup.js", () => {
                 dir : prefix(`./output/rollup/dynamic-imports`),
             });
 
-            expect(read("./rollup/dynamic-imports/assets/a.css")).toMatchSnapshot();
-            expect(read("./rollup/dynamic-imports/assets/b.css")).toMatchSnapshot();
-            expect(read("./rollup/dynamic-imports/assets/c.css")).toMatchSnapshot();
-            expect(read("./rollup/dynamic-imports/assets/common.css")).toMatchSnapshot();
+            expect(dir("./rollup/dynamic-imports/assets/")).toMatchSnapshot();
         });
     });
 });

--- a/packages/test-utils/read-dir.js
+++ b/packages/test-utils/read-dir.js
@@ -1,0 +1,17 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const read = require("read-dir-deep");
+
+module.exports = (cwd) =>
+    (name) => {
+        const dir = path.join(cwd, "./output", name);
+        const files = read.sync(dir);
+
+        return files.sort().map((file) => ({
+            file,
+            text : fs.readFileSync(path.join(dir, file), "utf8"),
+        }));
+    };


### PR DESCRIPTION
Previously ref-counting for CSS file usage was just an incrementing number. This could lead to issues like #466 where a CSS file is incorrectly promoted to `common.css` because it is referenced in multiple places within a single bundle.

The new logic checks the number of **bundles** the CSS file appears in, and only puts the file into `common.css` if it's in more than one bundle.