### PR TITLE
feat: Named json output

### DIFF
--- a/docs/rollup.md
+++ b/docs/rollup.md
@@ -14,7 +14,7 @@ A minimatch pattern, or an array of minimatch patterns, relative to `process.cwd
 
 ### `json`
 
-Boolean to determine if JSON files should be output at the end of compilation. Defaults to `false`.
+Boolean/String to determine if JSON files containing all exported classes & values should be output. If set to `true` will write out to a file named `exports.json`. If a `String` will write out to that file name. Defaults to `false`.
 
 ### `map`
 

--- a/packages/rollup/README.md
+++ b/packages/rollup/README.md
@@ -54,7 +54,7 @@ A minimatch pattern, or an array of minimatch patterns, relative to `process.cwd
 
 ### `json`
 
-Boolean to determine if JSON files should be output at the end of compilation. Defaults to `false`.
+Boolean/String to determine if JSON files containing all exported classes & values should be output. If set to `true` will write out to a file named `exports.json`. If a `String` will write out to that file name. Defaults to `false`.
 
 ### `map`
 

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -54,6 +54,15 @@ exports[`/rollup.js should generate JSON 1`] = `
 }"
 `;
 
+exports[`/rollup.js should generate JSON with a custom name 1`] = `
+"{
+    \\"packages/rollup/test/specimens/simple.css\\": {
+        \\"str\\": \\"\\\\\\"string\\\\\\"\\",
+        \\"fooga\\": \\"fooga\\"
+    }
+}"
+`;
+
 exports[`/rollup.js should generate exports 1`] = `
 "var css = {
     \\"str\\": \\"\\\\\\"string\\\\\\"\\",

--- a/packages/rollup/test/__snapshots__/splitting.test.js.snap
+++ b/packages/rollup/test/__snapshots__/splitting.test.js.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`/rollup.js code splitting should ouput only 1 JSON file 1`] = `
+Array [
+  Object {
+    "file": "common.css",
+    "text": "/* packages/rollup/test/specimens/simple.css */
+.fooga {
+    color: red;
+}
+",
+  },
+  Object {
+    "file": "dependencies.css",
+    "text": "/* packages/rollup/test/specimens/dependencies.css */
+.wooga {
+
+    background: blue;
+}
+",
+  },
+  Object {
+    "file": "exports.json",
+    "text": "{
+    \\"packages/rollup/test/specimens/dependencies.css\\": {
+        \\"wooga\\": \\"fooga wooga\\"
+    },
+    \\"packages/rollup/test/specimens/simple.css\\": {
+        \\"str\\": \\"\\\\\\"string\\\\\\"\\",
+        \\"fooga\\": \\"fooga\\"
+    }
+}",
+  },
+]
+`;
+
 exports[`/rollup.js code splitting should support dynamic imports 1`] = `
 Array [
   Object {

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -160,7 +160,27 @@ describe("/rollup.js", () => {
             file : prefix(`./output/rollup/json/simple.js`),
         });
         
-        expect(read("./rollup/json/assets/simple.json")).toMatchSnapshot();
+        expect(read("./rollup/json/assets/exports.json")).toMatchSnapshot();
+    });
+    
+    it("should generate JSON with a custom name", async () => {
+        const bundle = await rollup({
+            input   : require.resolve("./specimens/simple.js"),
+            plugins : [
+                plugin({
+                    namer,
+                    json : "custom.json",
+                }),
+            ],
+        });
+        
+        await bundle.write({
+            format,
+            assetFileNames,
+            file : prefix(`./output/rollup/json-named/simple.js`),
+        });
+        
+        expect(read("./rollup/json-named/assets/custom.json")).toMatchSnapshot();
     });
 
     it("should provide named exports", async () => {

--- a/packages/rollup/test/splitting.test.js
+++ b/packages/rollup/test/splitting.test.js
@@ -20,6 +20,8 @@ error.postcssPlugin = "error-plugin";
 const assetFileNames = "assets/[name][extname]";
 const format = "es";
 const map = false;
+const sourcemap = false;
+const json = true;
 
 describe("/rollup.js", () => {
     beforeAll(() => shell.rm("-rf", prefix("./output/rollup/*")));
@@ -179,6 +181,37 @@ describe("/rollup.js", () => {
             });
 
             expect(dir("./rollup/dynamic-imports/assets/")).toMatchSnapshot();
+        });
+
+        it("should ouput only 1 JSON file", async () => {
+            const bundle = await rollup({
+                experimentalCodeSplitting,
+
+                input : [
+                    require.resolve("./specimens/simple.js"),
+                    require.resolve("./specimens/dependencies.js"),
+                ],
+
+                plugins : [
+                    plugin({
+                        namer,
+                        map,
+                        json,
+                    }),
+                ],
+            });
+
+            await bundle.write({
+                format,
+                sourcemap,
+
+                assetFileNames,
+                chunkFileNames,
+
+                dir : prefix(`./output/rollup/json-splitting`),
+            });
+
+            expect(dir("./rollup/json-splitting/assets")).toMatchSnapshot();
         });
     });
 });

--- a/packages/rollup/test/splitting.test.js
+++ b/packages/rollup/test/splitting.test.js
@@ -49,6 +49,7 @@ describe("/rollup.js", () => {
     
             await bundle.write({
                 format,
+                sourcemap,
 
                 assetFileNames,
                 chunkFileNames,
@@ -78,6 +79,7 @@ describe("/rollup.js", () => {
 
             await bundle.write({
                 format,
+                sourcemap,
 
                 assetFileNames,
                 chunkFileNames,
@@ -107,6 +109,7 @@ describe("/rollup.js", () => {
 
             await bundle.write({
                 format,
+                sourcemap,
 
                 assetFileNames,
                 chunkFileNames,
@@ -142,6 +145,7 @@ describe("/rollup.js", () => {
 
             await bundle.write({
                 format,
+                sourcemap,
 
                 assetFileNames,
                 chunkFileNames,
@@ -173,6 +177,7 @@ describe("/rollup.js", () => {
 
             await bundle.write({
                 format,
+                sourcemap,
 
                 assetFileNames,
                 chunkFileNames,


### PR DESCRIPTION
Also fixes #485 by limiting output to a single file containing ALL compositions.

**BREAKING CHANGE**: The default file name when `json : true` has changed from whatever the CSS file was called to `exports.json`.