### PR TITLE
fix: modular-css-svelte handles empty CSS files

### DIFF
--- a/packages/svelte/test/__snapshots__/svelte.test.js.snap
+++ b/packages/svelte/test/__snapshots__/svelte.test.js.snap
@@ -205,15 +205,61 @@ exports[`/svelte.js should extract CSS from a <style> tag 2`] = `
 "
 `;
 
-exports[`/svelte.js should handle invalid references in "<script>" (inline: false, strict: false) 1`] = `
+exports[`/svelte.js should handle errors: "empty css file - <link>" 1`] = `"modular-css-svelte: Unable to find .nope, .alsonope in \\"./empty.css\\""`;
+
+exports[`/svelte.js should handle errors: "empty css file - <link>" 2`] = `
 Array [
   Array [
-    "modular-css-svelte: Unable to find \\"css.nuhuh\\" in ./invalid.css",
+    "modular-css-svelte: Unable to find .nope in \\"./empty.css\\"",
+  ],
+  Array [
+    "modular-css-svelte: Unable to find .alsonope in \\"./empty.css\\"",
   ],
 ]
 `;
 
-exports[`/svelte.js should handle invalid references in "<script>" (inline: false, strict: false) 2`] = `
+exports[`/svelte.js should handle errors: "empty css file - <link>" 3`] = `
+"
+
+<div class=\\"{css.nope}\\">NOPE</div>
+<div class=\\"{css.alsonope}\\">STILL NOPE</div>
+<script>
+    import css from \\"./empty.css\\";
+</script>"
+`;
+
+exports[`/svelte.js should handle errors: "empty css file - <style>" 1`] = `"modular-css-svelte: Unable to find .nope, .alsonope in \\"<style>\\""`;
+
+exports[`/svelte.js should handle errors: "empty css file - <style>" 2`] = `
+Array [
+  Array [
+    "modular-css-svelte: Unable to find .nope in \\"<style>\\"",
+  ],
+  Array [
+    "modular-css-svelte: Unable to find .alsonope in \\"<style>\\"",
+  ],
+]
+`;
+
+exports[`/svelte.js should handle errors: "empty css file - <style>" 3`] = `
+"<div class=\\"{css.nope}\\">NOPE</div>
+<div class=\\"{css.alsonope}\\">STILL NOPE</div>
+
+<style>/* replaced by modular-css */</style>
+"
+`;
+
+exports[`/svelte.js should handle errors: "invalid reference <script> - <link>" 1`] = `"modular-css-svelte: Unable to find .nuhuh in \\"./invalid.css\\""`;
+
+exports[`/svelte.js should handle errors: "invalid reference <script> - <link>" 2`] = `
+Array [
+  Array [
+    "modular-css-svelte: Unable to find .nuhuh in \\"./invalid.css\\"",
+  ],
+]
+`;
+
+exports[`/svelte.js should handle errors: "invalid reference <script> - <link>" 3`] = `
 "
 
 <h2 class=\\"yup\\">Yup</h2>
@@ -224,17 +270,17 @@ console.log(css.nuhuh);</script>
 "
 `;
 
-exports[`/svelte.js should handle invalid references in "<script>" (inline: false, strict: true) 1`] = `"modular-css-svelte: Unable to find \\"css.nuhuh\\" in ./invalid.css"`;
+exports[`/svelte.js should handle errors: "invalid reference <script> - <style>" 1`] = `"modular-css-svelte: Unable to find .nuhuh in \\"<style>\\""`;
 
-exports[`/svelte.js should handle invalid references in "<script>" (inline: true, strict: false) 1`] = `
+exports[`/svelte.js should handle errors: "invalid reference <script> - <style>" 2`] = `
 Array [
   Array [
-    "modular-css-svelte: Unable to find \\"css.nuhuh\\" in <style>",
+    "modular-css-svelte: Unable to find .nuhuh in \\"<style>\\"",
   ],
 ]
 `;
 
-exports[`/svelte.js should handle invalid references in "<script>" (inline: true, strict: false) 2`] = `
+exports[`/svelte.js should handle errors: "invalid reference <script> - <style>" 3`] = `
 "<h2 class=\\"yup\\">Yup</h2>
 
 <style>/* replaced by modular-css */</style>
@@ -245,17 +291,17 @@ exports[`/svelte.js should handle invalid references in "<script>" (inline: true
 "
 `;
 
-exports[`/svelte.js should handle invalid references in "<script>" (inline: true, strict: true) 1`] = `"modular-css-svelte: Unable to find \\"css.nuhuh\\" in <style>"`;
+exports[`/svelte.js should handle errors: "invalid reference template - <link>" 1`] = `"modular-css-svelte: Unable to find .nope in \\"./invalid.css\\""`;
 
-exports[`/svelte.js should handle invalid references in "template" (inline: false, strict: false) 1`] = `
+exports[`/svelte.js should handle errors: "invalid reference template - <link>" 2`] = `
 Array [
   Array [
-    "modular-css-svelte: Unable to find \\"css.nope\\" in ./invalid.css",
+    "modular-css-svelte: Unable to find .nope in \\"./invalid.css\\"",
   ],
 ]
 `;
 
-exports[`/svelte.js should handle invalid references in "template" (inline: false, strict: false) 2`] = `
+exports[`/svelte.js should handle errors: "invalid reference template - <link>" 3`] = `
 "
 
 <h1 class=\\"{css.nope}\\">Nope</h1>
@@ -265,25 +311,23 @@ exports[`/svelte.js should handle invalid references in "template" (inline: fals
 </script>"
 `;
 
-exports[`/svelte.js should handle invalid references in "template" (inline: false, strict: true) 1`] = `"modular-css-svelte: Unable to find \\"css.nope\\" in ./invalid.css"`;
+exports[`/svelte.js should handle errors: "invalid reference template - <style>" 1`] = `"modular-css-svelte: Unable to find .nope in \\"<style>\\""`;
 
-exports[`/svelte.js should handle invalid references in "template" (inline: true, strict: false) 1`] = `
+exports[`/svelte.js should handle errors: "invalid reference template - <style>" 2`] = `
 Array [
   Array [
-    "modular-css-svelte: Unable to find \\"css.nope\\" in <style>",
+    "modular-css-svelte: Unable to find .nope in \\"<style>\\"",
   ],
 ]
 `;
 
-exports[`/svelte.js should handle invalid references in "template" (inline: true, strict: false) 2`] = `
+exports[`/svelte.js should handle errors: "invalid reference template - <style>" 3`] = `
 "<h1 class=\\"{css.nope}\\">Nope</h1>
 <h2 class=\\"yup\\">Yup</h2>
 
 <style>/* replaced by modular-css */</style>
 "
 `;
-
-exports[`/svelte.js should handle invalid references in "template" (inline: true, strict: true) 1`] = `"modular-css-svelte: Unable to find \\"css.nope\\" in <style>"`;
 
 exports[`/svelte.js should ignore files without <style> blocks 1`] = `
 "<h1>Hello</h1>

--- a/packages/svelte/test/specimens/empty.html
+++ b/packages/svelte/test/specimens/empty.html
@@ -1,0 +1,3 @@
+<link rel="stylesheet" href="./empty.css" />
+
+<div class="{css.nope}">NOPE</div>

--- a/packages/svelte/test/specimens/invalid-external-empty.html
+++ b/packages/svelte/test/specimens/invalid-external-empty.html
@@ -1,3 +1,4 @@
 <link rel="stylesheet" href="./empty.css" />
 
 <div class="{css.nope}">NOPE</div>
+<div class="{css.alsonope}">STILL NOPE</div>

--- a/packages/svelte/test/specimens/invalid-inline-empty.html
+++ b/packages/svelte/test/specimens/invalid-inline-empty.html
@@ -1,0 +1,5 @@
+<div class="{css.nope}">NOPE</div>
+<div class="{css.alsonope}">STILL NOPE</div>
+
+<style>
+</style>

--- a/packages/svelte/test/svelte.test.js
+++ b/packages/svelte/test/svelte.test.js
@@ -178,4 +178,22 @@ describe("/svelte.js", () => {
 
         expect(output.css).toMatchSnapshot();
     });
+
+    it("should handle empty CSS files w/o exploding", async () => {
+        const filename = require.resolve("./specimens/empty.html");
+        const { processor, preprocess } = plugin({
+            namer,
+        });
+
+        const processed = await svelte.preprocess(
+            fs.readFileSync(filename, "utf8"),
+            Object.assign({}, preprocess, { filename })
+        );
+
+        expect(processed.toString()).toMatchSnapshot();
+
+        const output = await processor.output();
+
+        expect(output.css).toMatchSnapshot();
+    });
 });

--- a/packages/svelte/test/svelte.test.js
+++ b/packages/svelte/test/svelte.test.js
@@ -74,41 +74,41 @@ describe("/svelte.js", () => {
     });
 
     it.each`
-        title         | inline   | strict   | specimen
-        ${"<script>"} | ${true}  | ${true}  | ${"invalid-inline-script.html"}
-        ${"template"} | ${true}  | ${true}  | ${"invalid-inline-template.html"}
-        ${"<script>"} | ${true}  | ${false} | ${"invalid-inline-script.html"}
-        ${"template"} | ${true}  | ${false} | ${"invalid-inline-template.html"}
-        ${"<script>"} | ${false} | ${false} | ${"invalid-external-script.html"}
-        ${"template"} | ${false} | ${false} | ${"invalid-external-template.html"}
-        ${"<script>"} | ${false} | ${true}  | ${"invalid-external-script.html"}
-        ${"template"} | ${false} | ${true}  | ${"invalid-external-template.html"}
-    `("should handle invalid references in $title (inline: $inline, strict: $strict)", async ({ strict, specimen }) => {
+        title                                     | specimen
+        ${"invalid reference <script> - <style>"} | ${"invalid-inline-script.html"}
+        ${"invalid reference template - <style>"} | ${"invalid-inline-template.html"}
+        ${"invalid reference <script> - <link>"}  | ${"invalid-external-script.html"}
+        ${"invalid reference template - <link>"}  | ${"invalid-external-template.html"}
+        ${"empty css file - <style>"}             | ${"invalid-inline-empty.html"}
+        ${"empty css file - <link>"}              | ${"invalid-external-empty.html"}
+    `("should handle errors: $title", async ({ specimen }) => {
         const spy = jest.spyOn(global.console, "warn");
 
         spy.mockImplementation(() => { /* NO-OP */ });
         
         const filename = require.resolve(`./specimens/${specimen}`);
-
-        const { preprocess } = plugin({
+        
+        // Set up strict plugin
+        const { preprocess : strict } = plugin({
             namer,
-            strict,
+            strict : true,
         });
         
-        if(strict) {
-            await expect(
-                svelte.preprocess(
-                    fs.readFileSync(filename, "utf8"),
-                    Object.assign({}, preprocess, { filename })
-                )
-            ).rejects.toThrowErrorMatchingSnapshot();
+        await expect(
+            svelte.preprocess(
+                fs.readFileSync(filename, "utf8"),
+                Object.assign({}, strict, { filename })
+            )
+        ).rejects.toThrowErrorMatchingSnapshot();
 
-            return;
-        }
+        // Now the loose plugin
+        const { preprocess : loose } = plugin({
+            namer,
+        });
 
         const processed = await svelte.preprocess(
             fs.readFileSync(filename, "utf8"),
-            Object.assign({}, preprocess, { filename })
+            Object.assign({}, loose, { filename })
         );
         
         expect(spy).toHaveBeenCalled();
@@ -175,24 +175,6 @@ describe("/svelte.js", () => {
         expect(processed.toString()).toMatchSnapshot();
 
         output = await processor.output();
-
-        expect(output.css).toMatchSnapshot();
-    });
-
-    it("should handle empty CSS files w/o exploding", async () => {
-        const filename = require.resolve("./specimens/empty.html");
-        const { processor, preprocess } = plugin({
-            namer,
-        });
-
-        const processed = await svelte.preprocess(
-            fs.readFileSync(filename, "utf8"),
-            Object.assign({}, preprocess, { filename })
-        );
-
-        expect(processed.toString()).toMatchSnapshot();
-
-        const output = await processor.output();
 
         expect(output.css).toMatchSnapshot();
     });


### PR DESCRIPTION
Fixes #512, see the issue for the background & investigation.

This only runs the regex replacement if there's anything to replace, and also cleans up some of the error/warning output. As a bonus it also simplifies a lot of the error case test code & cuts down on the number of test cases by a bit.