### PR TITLE
feat: dev mode for rollup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1033,9 +1033,17 @@
       "version": "file:packages/rollup",
       "requires": {
         "@modular-css/processor": "file:packages/processor",
+        "dedent": "0.7.0",
         "esutils": "^2.0.2",
         "mkdirp": "^0.5.1",
-        "rollup-pluginutils": "^2.0.1"
+        "rollup-pluginutils": "^2.0.1",
+        "slash": "^2.0.0"
+      },
+      "dependencies": {
+        "slash": {
+          "version": "2.0.0",
+          "bundled": true
+        }
       }
     },
     "@modular-css/shortnames": {
@@ -5172,8 +5180,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5194,14 +5201,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5216,20 +5221,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5346,8 +5348,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5359,7 +5360,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5374,7 +5374,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5382,14 +5381,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5408,7 +5405,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5489,8 +5485,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5502,7 +5497,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5588,8 +5582,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5625,7 +5618,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5645,7 +5637,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5689,14 +5680,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/packages/rollup/README.md
+++ b/packages/rollup/README.md
@@ -60,6 +60,10 @@ export default {
 
 File name to use in case there are any CSS dependencies that appear in multiple bundles. Defaults to "common.css".
 
+### `dev`
+
+Enable dev mode. In dev mode the default export of a CSS file will be a `Proxy` instead of a bare object. Attempts to access non-existant properties on the proxy will throw a `ReferenceError` to assist in catching invalid usage.
+
 ### `include`/`exclude`
 
 A minimatch pattern, or an array of minimatch patterns, relative to `process.cwd()`. `include` defaults to `**/*.css`.

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -22,6 +22,7 @@
   ],
   "dependencies": {
     "@modular-css/processor": "file:../processor",
+    "dedent": "0.7.0",
     "esutils": "^2.0.2",
     "mkdirp": "^0.5.1",
     "rollup-pluginutils": "^2.0.1"

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -25,9 +25,10 @@
     "dedent": "0.7.0",
     "esutils": "^2.0.2",
     "mkdirp": "^0.5.1",
+    "slash": "^2.0.0",
     "rollup-pluginutils": "^2.0.1"
   },
   "peerDependencies": {
-    "rollup": "^0.65.0"
+    "rollup": ">0.65.0"
   }
 }

--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -5,6 +5,7 @@ const path = require("path");
 
 const { keyword } = require("esutils");
 const utils = require("rollup-pluginutils");
+const dedent = require("dedent");
 
 const Processor = require("@modular-css/processor");
 const output    = require("@modular-css/processor/lib/output.js");
@@ -83,21 +84,21 @@ module.exports = function(opts) {
             const exported = output.join(exports);
 
             const out = [
-                dev ? `
-                    const data = ${JSON.stringify(exported, null, 4)};
-                    
+                dev ? dedent(`
+                    const data = ${JSON.stringify(exported)};
+
                     export default new Proxy(data, {
                         get(tgt, key) {
                             if(key in tgt) {
                                 return tgt[key];
                             }
 
-                            throw new Error(
+                            throw new ReferenceError(
                                 key + " is not exported by " + ${JSON.stringify(path.relative(process.cwd(), id))}
                             );
                         }
                     })
-                ` :
+                `) :
                 `export default ${JSON.stringify(exported, null, 4)};`,
             ];
 

--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -6,6 +6,7 @@ const path = require("path");
 const { keyword } = require("esutils");
 const utils = require("rollup-pluginutils");
 const dedent = require("dedent");
+const slash = require("slash");
 
 const Processor = require("@modular-css/processor");
 const output    = require("@modular-css/processor/lib/output.js");
@@ -94,7 +95,9 @@ module.exports = function(opts) {
                             }
 
                             throw new ReferenceError(
-                                key + " is not exported by " + ${JSON.stringify(path.relative(process.cwd(), id))}
+                                key + " is not exported by " + ${JSON.stringify(
+                                    slash(path.relative(process.cwd(), id))
+                                )}
                             );
                         }
                     })

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -128,7 +128,7 @@ var css = new Proxy(data, {
         }
 
         throw new ReferenceError(
-            key + \\" is not exported by \\" + \\"packages\\\\\\\\rollup\\\\\\\\test\\\\\\\\specimens\\\\\\\\simple.css\\"
+            key + \\" is not exported by \\" + \\"packages/rollup/test/specimens/simple.css\\"
         );
     }
 });

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -119,22 +119,19 @@ exports[`/rollup.js should not output sourcemaps when they are disabled 1`] = `
 `;
 
 exports[`/rollup.js should output a proxy in dev mode 1`] = `
-"const data = {
-    \\"str\\": \\"\\\\\\"string\\\\\\"\\",
-    \\"fooga\\": \\"fooga\\"
-};
-                    
-                    var css = new Proxy(data, {
-                        get(tgt, key) {
-                            if(key in tgt) {
-                                return tgt[key];
-                            }
+"const data = {\\"str\\":\\"\\\\\\"string\\\\\\"\\",\\"fooga\\":\\"fooga\\"};
 
-                            throw new Error(
-                                key + \\" is not exported by \\" + \\"packages\\\\\\\\rollup\\\\\\\\test\\\\\\\\specimens\\\\\\\\simple.css\\"
-                            );
-                        }
-                    });
+var css = new Proxy(data, {
+    get(tgt, key) {
+        if(key in tgt) {
+            return tgt[key];
+        }
+
+        throw new ReferenceError(
+            key + \\" is not exported by \\" + \\"packages\\\\\\\\rollup\\\\\\\\test\\\\\\\\specimens\\\\\\\\simple.css\\"
+        );
+    }
+});
 
 console.log(css);
 "

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -118,6 +118,28 @@ exports[`/rollup.js should not output sourcemaps when they are disabled 1`] = `
 "
 `;
 
+exports[`/rollup.js should output a proxy in dev mode 1`] = `
+"const data = {
+    \\"str\\": \\"\\\\\\"string\\\\\\"\\",
+    \\"fooga\\": \\"fooga\\"
+};
+                    
+                    var css = new Proxy(data, {
+                        get(tgt, key) {
+                            if(key in tgt) {
+                                return tgt[key];
+                            }
+
+                            throw new Error(
+                                key + \\" is not exported by \\" + \\"packages\\\\\\\\rollup\\\\\\\\test\\\\\\\\specimens\\\\\\\\simple.css\\"
+                            );
+                        }
+                    });
+
+console.log(css);
+"
+`;
+
 exports[`/rollup.js should provide named exports 1`] = `
 "var str = \\"\\\\\\"string\\\\\\"\\";
 var num = \\"10\\";

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -437,6 +437,22 @@ describe("/rollup.js", () => {
         expect(read("./rollup/repeated-references/assets/repeated-references.css")).toMatchSnapshot();
     });
 
+    it("should output a proxy in dev mode", async () => {
+        const bundle = await rollup({
+            input   : require.resolve("./specimens/simple.js"),
+            plugins : [
+                plugin({
+                    namer,
+                    dev : true,
+                }),
+            ],
+        });
+
+        const result = await bundle.generate({ format });
+
+        expect(result.code).toMatchSnapshot();
+    });
+
     describe("errors", () => {
         function checkError(err) {
             expect(err.toString()).toMatch("error-plugin:");


### PR DESCRIPTION
Fixes #516 (for rollup at least, more bundlers later if folks want 'em!)

This adds a new option to `@modular-css/rollup`, `dev`. Enabling dev mode will make the default exports of each CSS file a JS Proxy that throws whenever a non-existent property is read. Should be much easier to spot the **VERY LOUD REFERENCE ERRORS** vs trying to find instances of `class="undefined"`, right?

That's the theory anyways!

This also fixes the rollup peerDependency so it stops complaining about rollup `0.66.0` and up.