### PR TITLE
feat: Add verbose option to rollup & svelte

### DIFF
--- a/packages/processor/test/__snapshots__/options.test.js.snap
+++ b/packages/processor/test/__snapshots__/options.test.js.snap
@@ -74,6 +74,76 @@ exports[`/processor.js options lifecycle options processing should run sync post
 a {}"
 `;
 
+exports[`/processor.js options lifecycle options verbose should output debugging messages when verbose mode is enabled 1`] = `
+Array [
+  Array [
+    "[processor]",
+    "file()",
+    "packages/processor/test/specimens/start.css",
+  ],
+  Array [
+    "[processor]",
+    "string()",
+    "packages/processor/test/specimens/start.css",
+  ],
+  Array [
+    "[processor]",
+    "processing",
+    "packages/processor/test/specimens/folder/folder.css",
+  ],
+  Array [
+    "[processor]",
+    "processed",
+    "packages/processor/test/specimens/folder/folder.css",
+  ],
+  Array [
+    "[processor]",
+    "processing",
+    "packages/processor/test/specimens/local.css",
+  ],
+  Array [
+    "[processor]",
+    "processed",
+    "packages/processor/test/specimens/local.css",
+  ],
+  Array [
+    "[processor]",
+    "processing",
+    "packages/processor/test/specimens/start.css",
+  ],
+  Array [
+    "[processor]",
+    "processed",
+    "packages/processor/test/specimens/start.css",
+  ],
+  Array [
+    "[processor]",
+    "string() done",
+    "packages/processor/test/specimens/start.css",
+  ],
+  Array [
+    "[processor]",
+    "string()",
+    "packages/processor/test/specimens/string.css",
+  ],
+  Array [
+    "[processor]",
+    "processing",
+    "packages/processor/test/specimens/string.css",
+  ],
+  Array [
+    "[processor]",
+    "processed",
+    "packages/processor/test/specimens/string.css",
+  ],
+  Array [
+    "[processor]",
+    "string() done",
+    "packages/processor/test/specimens/string.css",
+  ],
+]
+`;
+
 exports[`/processor.js options map should generate external source maps 1`] = `
 "/* packages/processor/test/specimens/folder/folder.css */
 .folder { margin: 2px; }

--- a/packages/processor/test/options.test.js
+++ b/packages/processor/test/options.test.js
@@ -5,6 +5,7 @@ const path = require("path");
 const dedent   = require("dedent");
 const namer    = require("@modular-css/test-utils/namer.js");
 const relative = require("@modular-css/test-utils/relative.js");
+const logs     = require("@modular-css/test-utils/logs.js");
 
 const Processor = require("../processor.js");
 
@@ -368,6 +369,27 @@ describe("/processor.js", () => {
                     )
                     .then(() => processor.output({ from : "packages/processor/test/specimens/async-done.css" }))
                     .then((result) => expect(result.css).toMatchSnapshot());
+                });
+            });
+
+            describe("verbose", () => {
+                it("should output debugging messages when verbose mode is enabled", async () => {
+                    const { logSnapshot } = logs();
+
+                    const processor = new Processor({
+                        namer,
+                        verbose : true,
+                    });
+                    
+                    await processor.file("./packages/processor/test/specimens/start.css");
+                    await processor.string(
+                        "packages/processor/test/specimens/string.css",
+                        ".foo { color: fuschia; }"
+                    );
+
+                    await processor.output();
+
+                    logSnapshot();
                 });
             });
         });

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -110,6 +110,110 @@ exports[`/rollup.js should handle assetFileNames being undefined 1`] = `
 "
 `;
 
+exports[`/rollup.js should log in verbose mode 1`] = `
+Array [
+  Array [
+    "[rollup]",
+    "build start",
+  ],
+  Array [
+    "[rollup]",
+    "transform",
+    "packages/rollup/test/specimens/simple.css",
+  ],
+  Array [
+    "[processor]",
+    "string()",
+    "packages/rollup/test/specimens/simple.css",
+  ],
+  Array [
+    "[processor]",
+    "processing",
+    "packages/rollup/test/specimens/simple.css",
+  ],
+  Array [
+    "[processor]",
+    "processed",
+    "packages/rollup/test/specimens/simple.css",
+  ],
+  Array [
+    "[processor]",
+    "string() done",
+    "packages/rollup/test/specimens/simple.css",
+  ],
+  Array [
+    "[rollup]",
+    "css output",
+    "40a365e7",
+  ],
+  Array [
+    "[processor]",
+    "file()",
+    "packages/processor/test/specimens/start.css",
+  ],
+  Array [
+    "[processor]",
+    "string()",
+    "packages/processor/test/specimens/start.css",
+  ],
+  Array [
+    "[processor]",
+    "processing",
+    "packages/processor/test/specimens/folder/folder.css",
+  ],
+  Array [
+    "[processor]",
+    "processed",
+    "packages/processor/test/specimens/folder/folder.css",
+  ],
+  Array [
+    "[processor]",
+    "processing",
+    "packages/processor/test/specimens/local.css",
+  ],
+  Array [
+    "[processor]",
+    "processed",
+    "packages/processor/test/specimens/local.css",
+  ],
+  Array [
+    "[processor]",
+    "processing",
+    "packages/processor/test/specimens/start.css",
+  ],
+  Array [
+    "[processor]",
+    "processed",
+    "packages/processor/test/specimens/start.css",
+  ],
+  Array [
+    "[processor]",
+    "string() done",
+    "packages/processor/test/specimens/start.css",
+  ],
+  Array [
+    "[processor]",
+    "string()",
+    "packages/processor/test/specimens/string.css",
+  ],
+  Array [
+    "[processor]",
+    "processing",
+    "packages/processor/test/specimens/string.css",
+  ],
+  Array [
+    "[processor]",
+    "processed",
+    "packages/processor/test/specimens/string.css",
+  ],
+  Array [
+    "[processor]",
+    "string() done",
+    "packages/processor/test/specimens/string.css",
+  ],
+]
+`;
+
 exports[`/rollup.js should not output sourcemaps when they are disabled 1`] = `
 "/* packages/rollup/test/specimens/simple.css */
 .fooga {

--- a/packages/svelte/svelte.js
+++ b/packages/svelte/svelte.js
@@ -8,7 +8,10 @@ const style = require("./src/style.js");
 module.exports = function(args) {
     const config = Object.assign(
         Object.create(null),
-        { strict : false },
+        {
+            strict  : false,
+            verbose : false,
+        },
         args
     );
 
@@ -18,7 +21,7 @@ module.exports = function(args) {
         processor,
 
         preprocess : {
-            markup : markup(processor),
+            markup : markup(processor, config),
             style,
         },
     };

--- a/packages/svelte/test/__snapshots__/svelte.test.js.snap
+++ b/packages/svelte/test/__snapshots__/svelte.test.js.snap
@@ -364,4 +364,122 @@ exports[`/svelte.js should remove files before reprocessing in case they changed
 }"
 `;
 
+exports[`/svelte.js should support verbose output: "<link>" 1`] = `
+Array [
+  Array [
+    "[svelte]",
+    "extract <link>",
+    "packages/svelte/test/specimens/external.html",
+    "packages/svelte/test/specimens/external.css",
+  ],
+  Array [
+    "[processor]",
+    "file()",
+    "packages/svelte/test/specimens/external.css",
+  ],
+  Array [
+    "[processor]",
+    "string()",
+    "packages/svelte/test/specimens/external.css",
+  ],
+  Array [
+    "[processor]",
+    "processing",
+    "packages/svelte/test/specimens/simple.css",
+  ],
+  Array [
+    "[processor]",
+    "processed",
+    "packages/svelte/test/specimens/simple.css",
+  ],
+  Array [
+    "[processor]",
+    "processing",
+    "packages/svelte/test/specimens/dependencies.css",
+  ],
+  Array [
+    "[processor]",
+    "processed",
+    "packages/svelte/test/specimens/dependencies.css",
+  ],
+  Array [
+    "[processor]",
+    "processing",
+    "packages/svelte/test/specimens/external.css",
+  ],
+  Array [
+    "[processor]",
+    "processed",
+    "packages/svelte/test/specimens/external.css",
+  ],
+  Array [
+    "[processor]",
+    "string() done",
+    "packages/svelte/test/specimens/external.css",
+  ],
+  Array [
+    "[svelte]",
+    "updating css references",
+    "./external.css",
+    "[\\"flex\\",\\"wrapper\\",\\"hd\\",\\"bd\\",\\"text\\",\\"active\\"]",
+  ],
+]
+`;
+
+exports[`/svelte.js should support verbose output: "<style>" 1`] = `
+Array [
+  Array [
+    "[svelte]",
+    "extract <style>",
+    "packages/svelte/test/specimens/style.html",
+  ],
+  Array [
+    "[processor]",
+    "string()",
+    "packages/svelte/test/specimens/style.html",
+  ],
+  Array [
+    "[processor]",
+    "processing",
+    "packages/svelte/test/specimens/simple.css",
+  ],
+  Array [
+    "[processor]",
+    "processed",
+    "packages/svelte/test/specimens/simple.css",
+  ],
+  Array [
+    "[processor]",
+    "processing",
+    "packages/svelte/test/specimens/dependencies.css",
+  ],
+  Array [
+    "[processor]",
+    "processed",
+    "packages/svelte/test/specimens/dependencies.css",
+  ],
+  Array [
+    "[processor]",
+    "processing",
+    "packages/svelte/test/specimens/style.html",
+  ],
+  Array [
+    "[processor]",
+    "processed",
+    "packages/svelte/test/specimens/style.html",
+  ],
+  Array [
+    "[processor]",
+    "string() done",
+    "packages/svelte/test/specimens/style.html",
+  ],
+  Array [
+    "[svelte]",
+    "updating css references",
+    "<style>",
+    "[\\"flex\\",\\"wrapper\\",\\"hd\\",\\"bd\\",\\"text\\",\\"active\\"]",
+  ],
+]
+`;
+
 exports[`/svelte.js should throw on both <style> and <link> in one file 1`] = `"@modular-css/svelte: use <style> OR <link>, but not both"`;

--- a/packages/test-utils/logs.js
+++ b/packages/test-utils/logs.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const path = require("path");
+
+const relative = require("./relative.js");
+
+module.exports = (method = "log") => {
+    const spy = jest.spyOn(global.console, method);
+
+    spy.mockImplementation(() => { /* NO-OP */ });
+
+    return {
+        spy,
+
+        logSnapshot() {
+            expect(spy).toHaveBeenCalled();
+
+            const calls = spy.mock.calls.map((call) =>
+                call.map((arg) => (path.isAbsolute(arg) ?
+                    relative([ arg ])[0] :
+                    arg
+                ))
+            );
+
+            expect(calls).toMatchSnapshot();
+        },
+    };
+};


### PR DESCRIPTION
Add new `verbose` option to rollup & svelte packages, also adds tests for the existing `verbose` option to processor package.

Fixes #520, though without using `npmlog` because it's more complicated than I need right now.