### PR TITLE
fix: support mismatched case when invalidating

### DIFF
--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -61,14 +61,13 @@ module.exports = (opts) => {
         },
 
         watchChange(file) {
-            if(!processor.files[file]) {
-                return;
-            }
-
             log("file changed", file);
 
-            // TODO: should the file be removed if it's gone?
-            processor.invalidate(file);
+            try {
+                processor.invalidate(file);
+            } catch(e) {
+                log("Unable to invalidate", file);
+            }
         },
 
         async transform(code, id) {


### PR DESCRIPTION
The `watchChange` invalidation that landed in v19 was trying to be clever, which it turns out is a problem when your filenames might have mismatched cases (thanks Windows!).

Instead let the already-existing `Processor` logic inside `.invalidate()` handle it, and then just silently eat errors for files that the `Processor` doesn't know about.

**NO TESTS** because they'd never run on anything but a windows machine anyways and that's a PITA to set up.