### PR TITLE
fix: don't explode when dynamic imports are removed by tree-shaking

### DIFF
--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -150,12 +150,12 @@ module.exports = (opts) => {
 
             // Really wish rollup would provide this default...
             assetFileNames = outputOptions.assetFileNames || "assets/[name]-[hash][extname]";
-            
+
             const {
                 chunkFileNames = "[name]-[hash].js",
                 entryFileNames = "[name].js",
             } = outputOptions;
-            
+
             // Determine the correct to option for PostCSS by doing a bit of a dance
             let to;
 
@@ -178,6 +178,11 @@ module.exports = (opts) => {
                 usage.addNode(entry, true);
 
                 [ ...imports, ...dynamicImports ].forEach((dep) => {
+                    // Need to filter out invalid deps, see rollup/rollup#2659
+                    if(!dep) {
+                        return;
+                    }
+
                     usage.addNode(dep, true);
                     usage.addDependency(entry, dep);
                 });
@@ -215,7 +220,7 @@ module.exports = (opts) => {
                 // based on the module's template (either entry or chunk)
                 let dest;
                 const template = isEntry ? entryFileNames : chunkFileNames;
-                
+
                 if(template.includes("[hash]")) {
                     const parts = parse(template, fileName);
 
@@ -326,11 +331,11 @@ module.exports = (opts) => {
                     path.dirname(to),
                     path.basename(target)
                 );
-                
+
                 log("map output", target);
 
                 fs.writeFileSync(dest, content.toString(), "utf8");
-                
+
                 if(!assetFileNames.includes("hash")) {
                     return;
                 }

--- a/packages/rollup/test/__snapshots__/splitting.test.js.snap
+++ b/packages/rollup/test/__snapshots__/splitting.test.js.snap
@@ -316,6 +316,8 @@ Array [
 ]
 `;
 
+exports[`/rollup.js code splitting shouldn't break when dynamic imports are tree-shaken away (rollup/rollup#2659) 1`] = `Array []`;
+
 exports[`/rollup.js code splitting shouldn't put bundle-specific CSS in common.css 1`] = `
 Array [
   Object {

--- a/packages/rollup/test/specimens/stripped-dynamic-imports/a.js
+++ b/packages/rollup/test/specimens/stripped-dynamic-imports/a.js
@@ -1,3 +1,1 @@
-if(false) {
-    import("./b.js").then(console.log);
-}
+export default false ? import('./b.js') : null;

--- a/packages/rollup/test/specimens/stripped-dynamic-imports/a.js
+++ b/packages/rollup/test/specimens/stripped-dynamic-imports/a.js
@@ -1,0 +1,3 @@
+if(false) {
+    import("./b.js").then(console.log);
+}

--- a/packages/rollup/test/specimens/stripped-dynamic-imports/b.js
+++ b/packages/rollup/test/specimens/stripped-dynamic-imports/b.js
@@ -1,0 +1,1 @@
+export default "hi";

--- a/packages/rollup/test/splitting.test.js
+++ b/packages/rollup/test/splitting.test.js
@@ -174,6 +174,33 @@ describe("/rollup.js", () => {
             expect(dir("./dynamic-imports/assets/")).toMatchSnapshot();
         });
 
+        it("shouldn't break when dynamic imports are tree-shaken away (rollup/rollup#2659)", async () => {
+            const bundle = await rollup({
+                input : [
+                    require.resolve("./specimens/stripped-dynamic-imports/a.js"),
+                ],
+
+                plugins : [
+                    plugin({
+                        namer,
+                        map,
+                    }),
+                ],
+            });
+
+            await bundle.write({
+                format,
+                sourcemap,
+
+                assetFileNames,
+                chunkFileNames,
+
+                dir : prefix(`./output/stripped-dynamic-imports`),
+            });
+
+            expect(dir("./stripped-dynamic-imports/assets/")).toMatchSnapshot();
+        });
+
         it("should ouput only 1 JSON file", async () => {
             const bundle = await rollup({
                 input : [
@@ -260,7 +287,7 @@ describe("/rollup.js", () => {
 
             expect(dir("./multiple-chunks/assets")).toMatchSnapshot();
         });
-        
+
         it("should dedupe chunk names using rollup's incrementing counter logic (hashed)", async () => {
             const bundle = await rollup({
                 input : [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Working around https://github.com/rollup/rollup/issues/2659

## Motivation and Context

Without this change if you have any dynamic imports in your codebase that can be dropped by treeshaking you'll get JS errors like the following:

```
[!] (@modular-css/rollup plugin) TypeError: Cannot destructure property `modules` of 'undefined' or 'null'.
TypeError: Cannot destructure property `modules` of 'undefined' or 'null'.
    at usage.overallOrder.forEach (node_modules\@modular-css\rollup\rollup.js:199:68)
    at Array.forEach (<anonymous>)
    at Object.generateBundle (node_modules\@modular-css\rollup\rollup.js:196:34)
    at \node_modules\rollup\dist\rollup.js:16609:25
```

## How Has This Been Tested?

Added specimens and a test to the rollup code-splitting tests to ensure it no longer throws an error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
