### PR TITLE
Add chunk CSS dependency metadata option

### DIFF
--- a/packages/rollup/README.md
+++ b/packages/rollup/README.md
@@ -80,6 +80,12 @@ Boolean to determine if inline source maps should be included. Defaults to `true
 
 To force the creation of external source maps set the value to `{ inline : false }`.
 
+### `meta`
+
+Boolean/String to determine if chunk metadata should be output. If set to true will write out a file named `metadata.json`. If a `String` will write out to that file name. Defaults to `false`.
+
+Currently the only metadata being written is CSS dependencies, but that may change in the future.
+
 ### `namedExports`
 
 By default this plugin will create both a default export and named `export`s for each class in a CSS file. You can disable this by setting `namedExports` to `false`.

--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -23,7 +23,7 @@ const emptyMappings = {
 
 module.exports = (opts) => {
     const options = Object.assign(Object.create(null), {
-        common       : "common",
+        common       : "common.css",
         json         : false,
         include      : "**/*.css",
         namedExports : true,
@@ -189,7 +189,7 @@ module.exports = (opts) => {
             });
 
             // Output CSS chunks
-            const out = [];
+            const out = new Map();
 
             // Keep track of files that are queued to be written
             const queued = new Set();
@@ -230,7 +230,7 @@ module.exports = (opts) => {
                     dest = outputOptions.dir ? name : path.basename(entry, path.extname(entry));
                 }
 
-                out.push([
+                out.set(entry, [
                     dest,
                     included,
                 ]);
@@ -254,14 +254,11 @@ module.exports = (opts) => {
 
             // Shove any unreferenced CSS files onto the beginning of the first chunk
             if(unused.length) {
-                if(out.length) {
-                    out[0][1].unshift(...unused);
-                } else {
-                    out.push([
-                        common,
-                        unused
-                    ]);
-                }
+                out.set("unused", [
+                    // Add .css automatically down below, so strip in case it was specified
+                    common.replace(path.extname(common), ""),
+                    unused
+                ]);
             }
 
             // If assets are being hashed then the automatic annotation has to be disabled
@@ -276,7 +273,7 @@ module.exports = (opts) => {
                 );
             }
 
-            for(const [ name, files ] of out) {
+            for(const [ name, files ] of out.values()) {
                 const id = this.emitAsset(`${name}.css`);
 
                 /* eslint-disable-next-line no-await-in-loop */

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -29,21 +29,35 @@ console.log({ foo: foo$1, bar: bar$3, bar2: bar$1 });
 `;
 
 exports[`/rollup.js should accept an existing processor instance (no css in bundle) 1`] = `
-"/* packages/rollup/test/specimens/fake.css */
+Array [
+  Object {
+    "file": "common.css",
+    "text": "/* packages/rollup/test/specimens/fake.css */
 .fake {
     color: yellow;
-}"
+}",
+  },
+]
 `;
 
 exports[`/rollup.js should accept an existing processor instance 1`] = `
-"/* packages/rollup/test/specimens/fake.css */
+Array [
+  Object {
+    "file": "common.css",
+    "text": "/* packages/rollup/test/specimens/fake.css */
 .fake {
     color: yellow;
-}
-/* packages/rollup/test/specimens/simple.css */
+}",
+  },
+  Object {
+    "file": "existing-processor.css",
+    "text": "/* packages/rollup/test/specimens/simple.css */
 .fooga {
     color: red;
-}"
+}
+",
+  },
+]
 `;
 
 exports[`/rollup.js should allow disabling of named exports 1`] = `
@@ -426,6 +440,26 @@ exports[`/rollup.js should respect the CSS dependency tree 2`] = `
     background: blue;
 }
 "
+`;
+
+exports[`/rollup.js should use the common arg for unreferenced CSS 1`] = `
+Array [
+  Object {
+    "file": "simple.css",
+    "text": "/* packages/rollup/test/specimens/simple.css */
+.fooga {
+    color: red;
+}
+",
+  },
+  Object {
+    "file": "unreferenced.css",
+    "text": "/* packages/rollup/test/specimens/fake.css */
+.fake {
+    color: yellow;
+}",
+  },
+]
 `;
 
 exports[`/rollup.js should warn & not export individual keys when they are not valid identifiers 1`] = `

--- a/packages/rollup/test/__snapshots__/splitting.test.js.snap
+++ b/packages/rollup/test/__snapshots__/splitting.test.js.snap
@@ -258,6 +258,44 @@ Array [
 ]
 `;
 
+exports[`/rollup.js code splitting should support outputting metadata about CSS dependencies 1`] = `
+Array [
+  Object {
+    "file": "chunk.css",
+    "text": "/* packages/rollup/test/specimens/simple.css */
+.fooga {
+    color: red;
+}
+",
+  },
+  Object {
+    "file": "dependencies.css",
+    "text": "/* packages/rollup/test/specimens/dependencies.css */
+.wooga {
+
+    background: blue;
+}
+",
+  },
+  Object {
+    "file": "metadata.json",
+    "text": "{
+    \\"chunk.js\\": {
+        \\"dependencies\\": [
+            \\"assets/chunk.css\\"
+        ]
+    },
+    \\"dependencies.js\\": {
+        \\"dependencies\\": [
+            \\"assets/dependencies.css\\",
+            \\"assets/chunk.css\\"
+        ]
+    }
+}",
+  },
+]
+`;
+
 exports[`/rollup.js code splitting should support splitting up CSS files 1`] = `
 Array [
   Object {

--- a/packages/rollup/test/splitting.test.js
+++ b/packages/rollup/test/splitting.test.js
@@ -55,6 +55,35 @@ describe("/rollup.js", () => {
 
             expect(dir("./splitting/assets")).toMatchSnapshot();
         });
+        
+        it("should support outputting metadata about CSS dependencies", async () => {
+            const bundle = await rollup({
+                input : [
+                    require.resolve("./specimens/simple.js"),
+                    require.resolve("./specimens/dependencies.js"),
+                ],
+
+                plugins : [
+                    plugin({
+                        namer,
+                        map,
+                        meta : true,
+                    }),
+                ],
+            });
+
+            await bundle.write({
+                format,
+                sourcemap,
+
+                assetFileNames,
+                chunkFileNames,
+
+                dir : prefix(`./output/css-metadata`),
+            });
+
+            expect(dir("./css-metadata/assets")).toMatchSnapshot();
+        });
 
         it("should support splitting up CSS files w/ shared assets", async () => {
             const bundle = await rollup({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a new option, `meta`, to the rollup plugin that will trigger it to write out a JSON file containing metadata about each JS chunk. Currently it only writes out CSS dependencies, but someday it might do more.

## Motivation and Context
Fixes #540

## How Has This Been Tested?
Added a test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
