### PR TITLE
fix: move bundle asset tagging later

### DIFF
--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -267,6 +267,11 @@ Array [
     "simple.css",
   ],
   Array [
+    "[rollup]",
+    "attaching assets",
+    "simple.js",
+  ],
+  Array [
     "[processor]",
     "file()",
     "packages/processor/test/specimens/start.css",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows for all filenames to be fully-resolved first, otherwise things get hairy. Also making sure that bundles are tagged even if they don't have any dependencies beyond their own CSS chunk

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On a bigger project I was seeing some `assets` arrays have `undefined` values due to a bug. This is a bit of a brute-force fix, but it does work.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested against a big project w/o errors. It makes the plugin ever so slightly slower but I doubt it matters much. I wasn't able to create a simple test to reproduce the error I was seeing unfortunately.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
