### PR TITLE
fix: limit import() rewrites

### DIFF
--- a/packages/rollup-rewriter/test/__snapshots__/rewriter.test.js.snap
+++ b/packages/rollup-rewriter/test/__snapshots__/rewriter.test.js.snap
@@ -12,6 +12,275 @@ Array [
 ]
 `;
 
+exports[`rollup-rewriter should only rewrite when necessary: amd 1`] = `
+Object {
+  "a.js": "
+define(['require'], function (require) { 'use strict';
+
+	var css = {
+	    \\"a\\": \\"a\\"
+	};
+
+	console.log(css);
+
+	new Promise(function (resolve, reject) { Promise.all([
+    lazyload(\\"./assets/chunk.css\\"),
+    new Promise(function (resolve, reject) { require(['./chunk.js'], resolve, reject) })
+])
+.then((results) => resolve(results[results.length - 1]))
+.catch(reject) }).then(console.log);
+
+});
+",
+  "assets/a.css": "
+/* packages/rollup-rewriter/test/specimens/no-asset-imports/a.css */
+.a { color: aqua; }
+",
+  "assets/b.css": "
+/* packages/rollup-rewriter/test/specimens/no-asset-imports/b.css */
+.b { color: blue; }
+",
+  "assets/chunk.css": "
+/* packages/rollup-rewriter/test/specimens/no-asset-imports/c.css */
+.c { color: crimson; }
+",
+  "b.js": "
+define(['require'], function (require) { 'use strict';
+
+	var css = {
+	    \\"b\\": \\"b\\"
+	};
+
+	console.log(css);
+
+	new Promise(function (resolve, reject) { require(['./chunk2.js'], resolve, reject) }).then(console.log);
+
+});
+",
+  "chunk.js": "
+define(['exports'], function (exports) { 'use strict';
+
+	var css = {
+	    \\"c\\": \\"c\\"
+	};
+
+	console.log(css);
+
+	var c$1 = \\"c\\";
+
+	exports.default = c$1;
+
+});
+",
+  "chunk2.js": "
+define(['exports'], function (exports) { 'use strict';
+
+	var d = \\"d\\";
+
+	exports.default = d;
+
+});
+",
+}
+`;
+
+exports[`rollup-rewriter should only rewrite when necessary: es 1`] = `
+Object {
+  "a.js": "
+var css = {
+    \\"a\\": \\"a\\"
+};
+
+console.log(css);
+
+Promise.all([
+    lazyload(\\"./assets/chunk.css\\"),
+    import('./chunk.js')
+])
+.then((results) => results[results.length - 1]).then(console.log);
+",
+  "assets/a.css": "
+/* packages/rollup-rewriter/test/specimens/no-asset-imports/a.css */
+.a { color: aqua; }
+",
+  "assets/b.css": "
+/* packages/rollup-rewriter/test/specimens/no-asset-imports/b.css */
+.b { color: blue; }
+",
+  "assets/chunk.css": "
+/* packages/rollup-rewriter/test/specimens/no-asset-imports/c.css */
+.c { color: crimson; }
+",
+  "b.js": "
+var css = {
+    \\"b\\": \\"b\\"
+};
+
+console.log(css);
+
+import('./chunk2.js').then(console.log);
+",
+  "chunk.js": "
+var css = {
+    \\"c\\": \\"c\\"
+};
+
+console.log(css);
+
+var c$1 = \\"c\\";
+
+export default c$1;
+",
+  "chunk2.js": "
+var d = \\"d\\";
+
+export default d;
+",
+}
+`;
+
+exports[`rollup-rewriter should only rewrite when necessary: esm 1`] = `
+Object {
+  "a.js": "
+var css = {
+    \\"a\\": \\"a\\"
+};
+
+console.log(css);
+
+Promise.all([
+    lazyload(\\"./assets/chunk.css\\"),
+    import('./chunk.js')
+])
+.then((results) => results[results.length - 1]).then(console.log);
+",
+  "assets/a.css": "
+/* packages/rollup-rewriter/test/specimens/no-asset-imports/a.css */
+.a { color: aqua; }
+",
+  "assets/b.css": "
+/* packages/rollup-rewriter/test/specimens/no-asset-imports/b.css */
+.b { color: blue; }
+",
+  "assets/chunk.css": "
+/* packages/rollup-rewriter/test/specimens/no-asset-imports/c.css */
+.c { color: crimson; }
+",
+  "b.js": "
+var css = {
+    \\"b\\": \\"b\\"
+};
+
+console.log(css);
+
+import('./chunk2.js').then(console.log);
+",
+  "chunk.js": "
+var css = {
+    \\"c\\": \\"c\\"
+};
+
+console.log(css);
+
+var c$1 = \\"c\\";
+
+export default c$1;
+",
+  "chunk2.js": "
+var d = \\"d\\";
+
+export default d;
+",
+}
+`;
+
+exports[`rollup-rewriter should only rewrite when necessary: system 1`] = `
+Object {
+  "a.js": "
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var css = {
+			    \\"a\\": \\"a\\"
+			};
+
+			console.log(css);
+
+			Promise.all([
+    lazyload(\\"./assets/chunk.css\\"),
+    module.import('./chunk.js')
+])
+.then((results) => results[results.length - 1]).then(console.log);
+
+		}
+	};
+});
+",
+  "assets/a.css": "
+/* packages/rollup-rewriter/test/specimens/no-asset-imports/a.css */
+.a { color: aqua; }
+",
+  "assets/b.css": "
+/* packages/rollup-rewriter/test/specimens/no-asset-imports/b.css */
+.b { color: blue; }
+",
+  "assets/chunk.css": "
+/* packages/rollup-rewriter/test/specimens/no-asset-imports/c.css */
+.c { color: crimson; }
+",
+  "b.js": "
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var css = {
+			    \\"b\\": \\"b\\"
+			};
+
+			console.log(css);
+
+			module.import('./chunk2.js').then(console.log);
+
+		}
+	};
+});
+",
+  "chunk.js": "
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var css = {
+			    \\"c\\": \\"c\\"
+			};
+
+			console.log(css);
+
+			var c$1 = exports('default', \\"c\\");
+
+		}
+	};
+});
+",
+  "chunk2.js": "
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var d = exports('default', \\"d\\");
+
+		}
+	};
+});
+",
+}
+`;
+
 exports[`rollup-rewriter should support loader & loadfn: amd 1`] = `
 Object {
   "a.js": "

--- a/packages/rollup-rewriter/test/rewriter.test.js
+++ b/packages/rollup-rewriter/test/rewriter.test.js
@@ -76,11 +76,11 @@ describe("rollup-rewriter", () => {
             const result = await bundle.generate({
                 format,
                 sourcemap,
-    
+
                 assetFileNames,
                 chunkFileNames,
             });
-    
+
             expect(result).toMatchRollupSnapshot(format);
         }
     });
@@ -107,18 +107,48 @@ describe("rollup-rewriter", () => {
             const result = await bundle.generate({
                 format,
                 sourcemap,
-    
+
                 assetFileNames,
                 chunkFileNames,
             });
-    
+
+            expect(result).toMatchRollupSnapshot(format);
+        }
+    });
+
+    it("should only rewrite when necessary", async () => {
+        const bundle = await rollup({
+            input : [
+                require.resolve("./specimens/no-asset-imports/a.js"),
+                require.resolve("./specimens/no-asset-imports/b.js"),
+            ],
+            plugins : [
+                css({
+                    namer,
+                    map,
+                }),
+                rewriter({
+                    loadfn : "lazyload",
+                }),
+            ],
+        });
+
+        for(const format of formats) {
+            const result = await bundle.generate({
+                format,
+                sourcemap,
+
+                assetFileNames,
+                chunkFileNames,
+            });
+
             expect(result).toMatchRollupSnapshot(format);
         }
     });
 
     it("should log details in verbose mode", async () => {
         const { logSnapshot } = logs();
-        
+
         const bundle = await rollup({
             input : [
                 require.resolve("./specimens/dynamic-imports/a.js"),
@@ -143,7 +173,7 @@ describe("rollup-rewriter", () => {
             assetFileNames,
             chunkFileNames,
         });
-    
+
         logSnapshot();
     });
 });

--- a/packages/rollup-rewriter/test/specimens/no-asset-imports/a.css
+++ b/packages/rollup-rewriter/test/specimens/no-asset-imports/a.css
@@ -1,0 +1,1 @@
+.a { color: aqua; }

--- a/packages/rollup-rewriter/test/specimens/no-asset-imports/a.js
+++ b/packages/rollup-rewriter/test/specimens/no-asset-imports/a.js
@@ -1,0 +1,5 @@
+import css from "./a.css";
+
+console.log(css);
+
+import("./c.js").then(console.log);

--- a/packages/rollup-rewriter/test/specimens/no-asset-imports/b.css
+++ b/packages/rollup-rewriter/test/specimens/no-asset-imports/b.css
@@ -1,0 +1,1 @@
+.b { color: blue; }

--- a/packages/rollup-rewriter/test/specimens/no-asset-imports/b.js
+++ b/packages/rollup-rewriter/test/specimens/no-asset-imports/b.js
@@ -1,0 +1,5 @@
+import css from "./b.css";
+
+console.log(css);
+
+import("./d.js").then(console.log);

--- a/packages/rollup-rewriter/test/specimens/no-asset-imports/c.css
+++ b/packages/rollup-rewriter/test/specimens/no-asset-imports/c.css
@@ -1,0 +1,1 @@
+.c { color: crimson; }

--- a/packages/rollup-rewriter/test/specimens/no-asset-imports/c.js
+++ b/packages/rollup-rewriter/test/specimens/no-asset-imports/c.js
@@ -1,0 +1,5 @@
+import css from "./c.css";
+
+console.log(css);
+
+export default "c";

--- a/packages/rollup-rewriter/test/specimens/no-asset-imports/d.js
+++ b/packages/rollup-rewriter/test/specimens/no-asset-imports/d.js
@@ -1,0 +1,1 @@
+export default "d";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Don't try and rewrite `import()` statements if the chunk doesn't have any assets that need loading.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Don't want to bloat up bundles with useless code, and `@modular-css/rollup` only tags bundle with `.assets` when they actually have assets. Can lead to errors when `rollup-rewriter` tries to call `assets.map` and `assets` is `undefined`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests! Also ran it against a big project that first surfaced this behavior.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
