### PR TITLE
fix: properly support loader option

### DIFF
--- a/packages/rollup-rewriter/formats/amd.js
+++ b/packages/rollup-rewriter/formats/amd.js
@@ -12,11 +12,11 @@ exports.loader = (options, str) => {
     if(i === -1) {
         throw new Error("Unable to find strict mode declaration");
     }
-    
+
     // + 1 is for the newline...
     str.appendRight(
         i + search.length + 1,
-        `import lazyload from "./css.js";\n`
+        `${options.loader}\n`
     );
 };
 
@@ -28,4 +28,4 @@ exports.load = (options, imports, statement) => `
     .then((results) => resolve(results[results.length - 1]))
     .catch(reject)
 `;
-        
+

--- a/packages/rollup-rewriter/formats/es.js
+++ b/packages/rollup-rewriter/formats/es.js
@@ -3,9 +3,7 @@ exports.regex = (deps) => new RegExp(
     "g"
 );
 
-exports.loader = (options, str) => str.prepend(
-    `import lazyload from "./css.js";\n`
-);
+exports.loader = (options, str) => str.prepend(`${options.loader}\n`);
 
 exports.load = (options, imports, statement) => `
     Promise.all([
@@ -14,4 +12,4 @@ exports.load = (options, imports, statement) => `
     ])
     .then((results) => results[results.length - 1])
 `;
-        
+

--- a/packages/rollup-rewriter/formats/system.js
+++ b/packages/rollup-rewriter/formats/system.js
@@ -12,11 +12,11 @@ exports.loader = (options, str) => {
     if(i === -1) {
         throw new Error("Unable to find strict mode declaration");
     }
-    
+
     // + 1 is for the newline...
     str.appendRight(
         i + search.length + 1,
-        `import lazyload from "./css.js";\n`
+        `${options.loader}\n`
     );
 };
 
@@ -27,4 +27,4 @@ exports.load = (options, imports, statement) => `
     ])
     .then((results) => results[results.length - 1])
 `;
-        
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`@modular-css/rollup-rewriter` advertises support for a `loader` option, but it wasn't actually pumped through to the different format rewriters.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I want to use a custom `loader`, but couldn't.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests already existed, but just tested for the defaults. Now at least they're fully-testing that codepath.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
