### PR TITLE
fix: use a safer regex for finding @values

### DIFF
--- a/packages/processor/plugins/values-replace.js
+++ b/packages/processor/plugins/values-replace.js
@@ -36,7 +36,7 @@ module.exports = (css, { opts, messages }) => {
     const matchRegex = new RegExp(
         Object.keys(values)
             .sort((a, b) => b.length - a.length)
-            .map((v) => `\\b${escape(v)}\\b`)
+            .map((v) => `^${escape(v)}$`)
             .join("|"),
         "g"
     );

--- a/packages/processor/test/__snapshots__/values.test.js.snap
+++ b/packages/processor/test/__snapshots__/values.test.js.snap
@@ -102,3 +102,30 @@ exports[`/processor.js values should support value replacement in :external(...)
 }
 "
 `;
+
+exports[`/processor.js values shouldn't replace values unless they're safe 1`] = `
+"/* values.css */
+.a {
+    color: foo-a;
+    color: foo(red);
+    color: foo_a;
+    color: fooa;
+    color: foo, red;
+    color: foo, red, woo;
+    width: foopx;
+    color:red;
+    color:foo-a;
+    color: red;
+}
+
+@media red { }
+@media red, b {}
+@media foo-a, b {}
+@media foo-a { }
+@media (min-width: red) { }
+@media (min-width: foo-a) { }
+@media not red {}
+@media not (red) {}
+@media not foo-a {}
+@media not (foo-a) {}"
+`;

--- a/packages/processor/test/values.test.js
+++ b/packages/processor/test/values.test.js
@@ -38,6 +38,45 @@ describe("/processor.js", () => {
                 );
             }
         });
+        
+        it("shouldn't replace values unless they're safe", async () => {
+            await processor.string(
+                "./values.css",
+                dedent(`
+                    @value a: red;
+                    @value c: foo-a;
+                    @value d:a;
+
+                    .a {
+                        color: foo-a;
+                        color: foo(a);
+                        color: foo_a;
+                        color: fooa;
+                        color: foo, a;
+                        color: foo, a, woo;
+                        width: foopx;
+                        color:a;
+                        color:foo-a;
+                        color: d;
+                    }
+
+                    @media a { }
+                    @media a, b {}
+                    @media foo-a, b {}
+                    @media foo-a { }
+                    @media (min-width: a) { }
+                    @media (min-width: foo-a) { }
+                    @media not a {}
+                    @media not (a) {}
+                    @media not foo-a {}
+                    @media not (foo-a) {}
+                `)
+            );
+
+            const { css } = await processor.output();
+            
+            expect(css).toMatchSnapshot();
+        });
 
         it("should support simple values", async () => {
             await processor.string(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`\bval\b` will match "-val" which is a problem for folks using hyphens to separate classes. Now using `^val$` which when combined with postcss-value-parser should match almost everything the old one did but w/o being too greedy.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #548

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test with a bunch of permutations seen in CSS values/@media, manually verified that they all transform correctly after this change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
