### PR TITLE
fix: ignore URLs in <link href> 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1157,6 +1157,8 @@
       "requires": {
         "@modular-css/processor": "file:packages/processor",
         "dedent": "^0.7.0",
+        "escape-string-regexp": "^1.0.5",
+        "is-url": "^1.2.4",
         "mkdirp": "^0.5.1",
         "resolve-from": "^4.0.0",
         "rollup-pluginutils": "^2.3.0"
@@ -7099,6 +7101,11 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
+    },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
     },
     "is-utf8": {
       "version": "0.2.1",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@modular-css/processor": "file:../processor",
     "dedent": "^0.7.0",
+    "is-url": "^1.2.4",
     "mkdirp": "^0.5.1",
     "resolve-from": "^4.0.0",
     "rollup-pluginutils": "^2.3.0"

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@modular-css/processor": "file:../processor",
     "dedent": "^0.7.0",
+    "escape-string-regexp": "^1.0.5",
     "is-url": "^1.2.4",
     "mkdirp": "^0.5.1",
     "resolve-from": "^4.0.0",

--- a/packages/svelte/svelte.js
+++ b/packages/svelte/svelte.js
@@ -4,6 +4,7 @@ const path = require("path");
 
 const resolve = require("resolve-from");
 const dedent = require("dedent");
+const isUrl = require("is-url");
 
 const Processor = require("@modular-css/processor");
 
@@ -21,7 +22,7 @@ module.exports = (config = false) => {
     // This function is hilariously large but it's actually simpler this way
     // Mostly because markup() is async so tracking state is painful w/o inlining
     // the whole damn thing
-    // eslint-disable-next-line max-statements
+    // eslint-disable-next-line max-statements, complexity
     const markup = async ({ content, filename }) => {
         let source = content;
 
@@ -58,6 +59,13 @@ module.exports = (config = false) => {
         if(link) {
             // This looks weird, but it's to support multiple types of quotation marks
             file = link[1] || link[2] || link[3];
+
+            // Don't transform URLs
+            if(isUrl(file)) {
+                return {
+                    code : content,
+                };
+            }
 
             const external = resolve(path.dirname(filename), file);
 

--- a/packages/svelte/svelte.js
+++ b/packages/svelte/svelte.js
@@ -81,7 +81,15 @@ module.exports = (config = false) => {
                 return out;
             }, []);
 
+            // No-op
+            if(!valid.length) {
+                return {
+                    code : source,
+                };
+            }
+
             if(valid.length > 1) {
+                // eslint-disable-next-line no-console
                 console.warn("@modular-css/svelte will only use the first local <link> tag");
             }
 

--- a/packages/svelte/test/__snapshots__/svelte.test.js.snap
+++ b/packages/svelte/test/__snapshots__/svelte.test.js.snap
@@ -398,6 +398,14 @@ exports[`/svelte.js should ignore files without <style> blocks 1`] = `
 
 exports[`/svelte.js should ignore files without <style> blocks 2`] = `""`;
 
+exports[`/svelte.js should no-op if all <link>s reference a URL 1`] = `
+"<link rel=\\"stylesheet\\" href=\\"http://example.com/styles.css\\" />
+<link rel=\\"stylesheet\\" href=\\"http://example.com/styles2.css\\" />
+
+<div class=\\"fooga\\">fooga</div>
+"
+`;
+
 exports[`/svelte.js should remove files before reprocessing when config.clean is set 1`] = `
 "<div class=\\"source\\">Source</div><script>
     import css from \\"./source.css\\";

--- a/packages/svelte/test/__snapshots__/svelte.test.js.snap
+++ b/packages/svelte/test/__snapshots__/svelte.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`/svelte.js should extract CSS from a <link> tag ("existing script") 1`] = `
 "
-
 <div class=\\"flex wrapper\\">
     <h1 class=\\"flex fooga hd\\">Head</h1>
     <div class=\\"fooga wooga bd\\">
@@ -56,7 +55,6 @@ exports[`/svelte.js should extract CSS from a <link> tag ("existing script") 2`]
 
 exports[`/svelte.js should extract CSS from a <link> tag ("no script") 1`] = `
 "
-
 <div class=\\"flex wrapper\\">
     <h1 class=\\"flex fooga hd\\">Head</h1>
     <div class=\\"fooga wooga bd\\">
@@ -93,7 +91,6 @@ exports[`/svelte.js should extract CSS from a <link> tag ("no script") 2`] = `
 
 exports[`/svelte.js should extract CSS from a <link> tag ("single quotes") 1`] = `
 "
-
 <div class=\\"flex wrapper\\">
     <h1 class=\\"flex fooga hd\\">Head</h1>
     <div class=\\"fooga wooga bd\\">
@@ -130,7 +127,6 @@ exports[`/svelte.js should extract CSS from a <link> tag ("single quotes") 2`] =
 
 exports[`/svelte.js should extract CSS from a <link> tag ("unquoted") 1`] = `
 "
-
 <div class=\\"flex wrapper\\">
     <h1 class=\\"flex fooga hd\\">Head</h1>
     <div class=\\"fooga wooga bd\\">
@@ -167,7 +163,6 @@ exports[`/svelte.js should extract CSS from a <link> tag ("unquoted") 2`] = `
 
 exports[`/svelte.js should extract CSS from a <link> tag ("values") 1`] = `
 "
-
 <div
     data-simple=\\"color: #BEEFED\\"
     data-expression=\\"{\\"color: \\" + \\"#BEEFED\\"}\\"
@@ -270,7 +265,6 @@ Array [
 
 exports[`/svelte.js should handle errors: "empty css file - <link>" 3`] = `
 "
-
 <div class=\\"{css.nope}\\">NOPE</div>
 <div class=\\"{css.alsonope}\\">STILL NOPE</div>
 <script>
@@ -311,7 +305,6 @@ Array [
 
 exports[`/svelte.js should handle errors: "invalid reference <script> - <link>" 3`] = `
 "
-
 <h2 class=\\"yup\\">Yup</h2>
 
 <script>
@@ -356,7 +349,6 @@ Array [
 
 exports[`/svelte.js should handle errors: "invalid reference template - <link>" 3`] = `
 "
-
 <h1 class=\\"{css.nope}\\">Nope</h1>
 <h2 class=\\"yup\\">Yup</h2>
 <script>
@@ -382,6 +374,23 @@ exports[`/svelte.js should handle errors: "invalid reference template - <style>"
 "
 `;
 
+exports[`/svelte.js should ignore <links> that reference a URL 1`] = `
+"<link rel=\\"stylesheet\\" href=\\"http://example.com/styles.css\\" />
+
+<div class=\\"fooga\\">fooga</div>
+<script>
+    import css from \\"./simple.css\\";
+</script>"
+`;
+
+exports[`/svelte.js should ignore <links> that reference a URL 2`] = `
+"/* packages/svelte/test/specimens/simple.css */
+.fooga {
+    color: red;
+}
+"
+`;
+
 exports[`/svelte.js should ignore files without <style> blocks 1`] = `
 "<h1>Hello</h1>
 <script>console.log(\\"output\\")</script>"
@@ -390,8 +399,7 @@ exports[`/svelte.js should ignore files without <style> blocks 1`] = `
 exports[`/svelte.js should ignore files without <style> blocks 2`] = `""`;
 
 exports[`/svelte.js should remove files before reprocessing when config.clean is set 1`] = `
-"
-<div class=\\"source\\">Source</div><script>
+"<div class=\\"source\\">Source</div><script>
     import css from \\"./source.css\\";
 </script>"
 `;
@@ -404,8 +412,7 @@ exports[`/svelte.js should remove files before reprocessing when config.clean is
 `;
 
 exports[`/svelte.js should remove files before reprocessing when config.clean is set 3`] = `
-"
-<div class=\\"source\\">Source</div><script>
+"<div class=\\"source\\">Source</div><script>
     import css from \\"./source.css\\";
 </script>"
 `;

--- a/packages/svelte/test/__snapshots__/svelte.test.js.snap
+++ b/packages/svelte/test/__snapshots__/svelte.test.js.snap
@@ -622,3 +622,32 @@ Array [
 `;
 
 exports[`/svelte.js should throw on both <style> and <link> in one file 1`] = `"@modular-css/svelte: use <style> OR <link>, but not both"`;
+
+exports[`/svelte.js should warn when multiple <link> elements are in the html 1`] = `
+"<link rel=\\"stylesheet\\" href=\\"./simple2.css\\" />
+
+<div class=\\"fooga\\">fooga</div>
+<div class=\\"{css.booga}\\">booga</div>
+<script>
+    import css from \\"./simple.css\\";
+</script>"
+`;
+
+exports[`/svelte.js should warn when multiple <link> elements are in the html 2`] = `
+"/* packages/svelte/test/specimens/simple.css */
+.fooga {
+    color: red;
+}
+"
+`;
+
+exports[`/svelte.js should warn when multiple <link> elements are in the html 3`] = `
+Array [
+  Array [
+    "@modular-css/svelte will only use the first local <link> tag",
+  ],
+  Array [
+    "@modular-css/svelte: Unable to find .booga in \\"./simple.css\\"",
+  ],
+]
+`;

--- a/packages/svelte/test/specimens/multiple-link.html
+++ b/packages/svelte/test/specimens/multiple-link.html
@@ -1,0 +1,5 @@
+<link rel="stylesheet" href="./simple.css" />
+<link rel="stylesheet" href="./simple2.css" />
+
+<div class="{css.fooga}">fooga</div>
+<div class="{css.booga}">booga</div>

--- a/packages/svelte/test/specimens/multiple-url.html
+++ b/packages/svelte/test/specimens/multiple-url.html
@@ -1,0 +1,4 @@
+<link rel="stylesheet" href="http://example.com/styles.css" />
+<link rel="stylesheet" href="http://example.com/styles2.css" />
+
+<div class="fooga">fooga</div>

--- a/packages/svelte/test/specimens/simple2.css
+++ b/packages/svelte/test/specimens/simple2.css
@@ -1,0 +1,3 @@
+.booga {
+    color: blue;
+}

--- a/packages/svelte/test/specimens/url.html
+++ b/packages/svelte/test/specimens/url.html
@@ -1,0 +1,4 @@
+<link rel="stylesheet" href="http://example.com/styles.css" />
+<link rel="stylesheet" href="./simple.css" />
+
+<div class="{css.fooga}">fooga</div>

--- a/packages/svelte/test/svelte.test.js
+++ b/packages/svelte/test/svelte.test.js
@@ -203,6 +203,21 @@ describe("/svelte.js", () => {
         expect(spy.mock.calls).toMatchSnapshot();
     });
 
+    it("should no-op if all <link>s reference a URL", async () => {
+        const filename = require.resolve("./specimens/multiple-url.html");
+        
+        const { preprocess } = plugin({
+            namer,
+        });
+
+        const processed = await svelte.preprocess(
+            fs.readFileSync(filename, "utf8"),
+            Object.assign({}, preprocess, { filename })
+        );
+
+        expect(processed.toString()).toMatchSnapshot();
+    });
+    
     it("should remove files before reprocessing when config.clean is set", async () => {
         // V1 of files
         fs.writeFileSync(path.resolve(__dirname, "./output/source.html"), dedent(`

--- a/packages/svelte/test/svelte.test.js
+++ b/packages/svelte/test/svelte.test.js
@@ -177,7 +177,7 @@ describe("/svelte.js", () => {
         logSnapshot();
     });
 
-    it.skip("should warn when multiple <link> elements are in the html", async () => {
+    it("should warn when multiple <link> elements are in the html", async () => {
         const spy = jest.spyOn(global.console, "warn");
 
         spy.mockImplementation(() => { /* NO-OP */ });

--- a/packages/svelte/test/svelte.test.js
+++ b/packages/svelte/test/svelte.test.js
@@ -31,6 +31,24 @@ describe("/svelte.js", () => {
 
         expect(output.css).toMatchSnapshot();
     });
+    
+    it("should ignore <links> that reference a URL", async () => {
+        const filename = require.resolve("./specimens/url.html");
+        const { preprocess, processor } = plugin({
+            namer,
+        });
+
+        const processed = await svelte.preprocess(
+            fs.readFileSync(filename, "utf8"),
+            Object.assign({}, preprocess, { filename })
+        );
+
+        expect(processed.toString()).toMatchSnapshot();
+
+        const output = await processor.output();
+
+        expect(output.css).toMatchSnapshot();
+    });
 
     it.each`
         specimen                    | title
@@ -157,6 +175,32 @@ describe("/svelte.js", () => {
         await processor.output();
 
         logSnapshot();
+    });
+
+    it.skip("should warn when multiple <link> elements are in the html", async () => {
+        const spy = jest.spyOn(global.console, "warn");
+
+        spy.mockImplementation(() => { /* NO-OP */ });
+
+        const filename = require.resolve(`./specimens/multiple-link.html`);
+
+        const { processor, preprocess } = plugin({
+            namer,
+        });
+
+        const processed = await svelte.preprocess(
+            fs.readFileSync(filename, "utf8"),
+            Object.assign({}, preprocess, { filename })
+        );
+
+        expect(processed.toString()).toMatchSnapshot();
+
+        const output = await processor.output();
+        
+        expect(output.css).toMatchSnapshot();
+        
+        expect(spy).toHaveBeenCalled();
+        expect(spy.mock.calls).toMatchSnapshot();
     });
 
     it("should remove files before reprocessing when config.clean is set", async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Adds a warning if there are multiple `<link>` elements in a file, processes only the first
- Ignores <link> elements when the `href` attribute is a URL
- Early-out if all the `<link>` elements are to URLs
- Removes trailing newlines when stripping out replaced `<link>`, which looks nicer

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Wanted to be able to mix local `<link>` that should be transformed with external CSS that shouldn't be.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests!
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
