### PR TITLE
fix: ignore external modules

### DIFF
--- a/packages/processor/processor.js
+++ b/packages/processor/processor.js
@@ -158,7 +158,7 @@ class Processor {
         if(!input) {
             throw new Error("invalidate() requires a file argument");
         }
-        
+
         // Only want files actually in the array
         const source = this._normalize(input);
 
@@ -380,7 +380,7 @@ class Processor {
             return;
         }
 
-        this._graph.addNode(name);
+        this._graph.addNode(name, 0);
 
         this._log("_before()", name);
 
@@ -407,7 +407,7 @@ class Processor {
 
             const dep = this._normalize(dependency);
 
-            this._graph.addNode(dep);
+            this._graph.addNode(dep, 0);
             this._graph.addDependency(name, dep);
         });
 

--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -193,8 +193,8 @@ module.exports = (opts) => {
                     return;
                 }
 
-                const { modules, name, fileName, isEntry } = bundle[entry];
                 const css = new Set();
+                const { modules, name, fileName, isEntry } = bundle[entry];
 
                 // Get CSS files being used by this chunk
                 const styles = Object.keys(modules).filter((file) => processor.has(file));
@@ -208,6 +208,7 @@ module.exports = (opts) => {
                     css.add(style);
                 });
 
+                // How does Set not have .filter yet ಠ_ಠ
                 const included = [ ...css ].filter((file) => !queued.has(file));
 
                 if(!included.length) {
@@ -341,10 +342,12 @@ module.exports = (opts) => {
 
                 const meta = {};
 
-                Object.entries(bundle).forEach(([ entry, { dynamicAssets = false, assets = false }]) => {
-                    if(!assets && !dynamicAssets) {
+                out.forEach((value, entry) => {
+                    if(!bundle[entry]) {
                         return;
                     }
+
+                    const { assets, dynamicAssets } = bundle[entry];
 
                     meta[entry] = {
                         assets,

--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -189,6 +189,10 @@ module.exports = (opts) => {
             const queued = new Set();
 
             usage.overallOrder().forEach((entry) => {
+                if(!bundle[entry]) {
+                    return;
+                }
+
                 const { modules, name, fileName, isEntry } = bundle[entry];
                 const css = new Set();
 

--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -169,15 +169,18 @@ module.exports = (opts) => {
             Object.entries(bundle).forEach(([ entry, chunk ]) => {
                 const { imports, dynamicImports } = chunk;
 
+                const statics = imports.filter((dep) => dep in bundle);
+                const dynamics = dynamicImports.filter((dep) => dep in bundle);
+
                 // Add all the nodes first, tagging them with their type for later
-                imports.forEach((dep) => usage.addNode(dep, "static"));
-                dynamicImports.forEach((dep) => usage.addNode(dep, "dynamic"));
+                statics.forEach((dep) => usage.addNode(dep, "static"));
+                dynamics.forEach((dep) => usage.addNode(dep, "dynamic"));
 
                 // Then tag the entry node
                 usage.addNode(entry, "entry");
 
                 // And then add all the dependency links
-                [ ...dynamicImports, ...imports ].forEach((dep) =>
+                [ ...dynamics, ...statics ].forEach((dep) =>
                     usage.addDependency(entry, dep)
                 );
             });
@@ -189,10 +192,6 @@ module.exports = (opts) => {
             const queued = new Set();
 
             usage.overallOrder().forEach((entry) => {
-                if(!bundle[entry]) {
-                    return;
-                }
-
                 const css = new Set();
                 const { modules, name, fileName, isEntry } = bundle[entry];
 
@@ -343,10 +342,6 @@ module.exports = (opts) => {
                 const meta = {};
 
                 out.forEach((value, entry) => {
-                    if(!bundle[entry]) {
-                        return;
-                    }
-
                     const { assets, dynamicAssets } = bundle[entry];
 
                     meta[entry] = {

--- a/packages/rollup/test/__snapshots__/splitting.test.js.snap
+++ b/packages/rollup/test/__snapshots__/splitting.test.js.snap
@@ -324,6 +324,12 @@ Array [
   Object {
     "file": "metadata.json",
     "text": "{
+    \\"chunk2.js\\": {
+        \\"assets\\": [],
+        \\"dynamicAssets\\": [
+            \\"assets/chunk.css\\"
+        ]
+    },
     \\"a.js\\": {
         \\"assets\\": [
             \\"assets/a.css\\"
@@ -335,12 +341,6 @@ Array [
             \\"assets/b.css\\"
         ],
         \\"dynamicAssets\\": []
-    },
-    \\"chunk2.js\\": {
-        \\"assets\\": [],
-        \\"dynamicAssets\\": [
-            \\"assets/chunk.css\\"
-        ]
     }
 }",
   },
@@ -370,6 +370,12 @@ Array [
   Object {
     "file": "chunks.json",
     "text": "{
+    \\"chunk2.js\\": {
+        \\"assets\\": [],
+        \\"dynamicAssets\\": [
+            \\"assets/chunk.css\\"
+        ]
+    },
     \\"a.js\\": {
         \\"assets\\": [
             \\"assets/a.css\\"
@@ -381,12 +387,6 @@ Array [
             \\"assets/b.css\\"
         ],
         \\"dynamicAssets\\": []
-    },
-    \\"chunk2.js\\": {
-        \\"assets\\": [],
-        \\"dynamicAssets\\": [
-            \\"assets/chunk.css\\"
-        ]
     }
 }",
   },

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -186,6 +186,26 @@ describe("/rollup.js", () => {
 
         expect(exists("./output/no-css/assets/no-css.css")).toBe(false);
     });
+    
+    it("should ignore external modules", async () => {
+        const bundle = await rollup({
+            input   : require.resolve("./specimens/external.js"),
+            plugins : [
+                plugin({
+                    namer,
+                }),
+            ],
+            external : [
+                require.resolve("./specimens/simple.js"),
+            ],
+        });
+
+        await bundle.generate({
+            format,
+            assetFileNames,
+            file : prefix(`./output/no-css/no-css.js`),
+        });
+    });
 
     it("should generate JSON", async () => {
         const bundle = await rollup({

--- a/packages/rollup/test/specimens/external.js
+++ b/packages/rollup/test/specimens/external.js
@@ -1,0 +1,3 @@
+import simple from "./simple.js";
+
+console.log(simple);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Modules flagged using `external` were throwing a wobbily, so now we filter 'em out.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I've got a project that uses `external` and it was breaking.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test, also it doesn't break in my other project.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
