### PR TITLE
fix: metadata output breaks when common.css is output

### DIFF
--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -342,6 +342,10 @@ module.exports = (opts) => {
                 const meta = {};
 
                 out.forEach((value, entry) => {
+                    if(!bundle[entry]) {
+                        return;
+                    }
+
                     const { assets, dynamicAssets } = bundle[entry];
 
                     meta[entry] = {

--- a/packages/rollup/test/__snapshots__/splitting.test.js.snap
+++ b/packages/rollup/test/__snapshots__/splitting.test.js.snap
@@ -180,6 +180,57 @@ Array [
 ]
 `;
 
+exports[`/rollup.js code splitting should output metadata successfully when unreferenced CSS is output to common 1`] = `
+Array [
+  Object {
+    "file": "a.css",
+    "text": "/* packages/rollup/test/specimens/metadata/a.css */
+.mc541d3f5c_a { color: aqua; }
+",
+  },
+  Object {
+    "file": "b.css",
+    "text": "/* packages/rollup/test/specimens/metadata/b.css */
+.mc04101138_b { color: blue; }
+",
+  },
+  Object {
+    "file": "chunk.css",
+    "text": "/* packages/rollup/test/specimens/metadata/d.css */
+.mc7de0d66b_d { color: darkkhaki; }
+",
+  },
+  Object {
+    "file": "common.css",
+    "text": "/* fake.css */
+.mc2c838439_fake { color: red; }",
+  },
+  Object {
+    "file": "metadata.json",
+    "text": "{
+    \\"chunk2.js\\": {
+        \\"assets\\": [],
+        \\"dynamicAssets\\": [
+            \\"assets/chunk.css\\"
+        ]
+    },
+    \\"a.js\\": {
+        \\"assets\\": [
+            \\"assets/a.css\\"
+        ],
+        \\"dynamicAssets\\": []
+    },
+    \\"b.js\\": {
+        \\"assets\\": [
+            \\"assets/b.css\\"
+        ],
+        \\"dynamicAssets\\": []
+    }
+}",
+  },
+]
+`;
+
 exports[`/rollup.js code splitting should support circular JS dependencies 1`] = `
 Array [
   Object {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Files that rollup hasn't actually processed but live within the processor instance are put into common.css. This file becomes part of the `out` set, but doesn't live within the bundle from rollup. If you don't validate that the file exists in the bundle before trying to do stuff with it things get real :fire: :skull:-y.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes a bug I haven't reported yet.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests, real world project that surfaced the issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
