### PR TITLE
fix: remove newlines left over after deleting composes declarations

### DIFF
--- a/packages/glob/test/__snapshots__/glob.test.js.snap
+++ b/packages/glob/test/__snapshots__/glob.test.js.snap
@@ -15,7 +15,6 @@ exports[`/glob.js should find files on disk & output css 1`] = `
 }
 /* dir/2.css */
 .two {
-    
     background: blue;
 }
 "
@@ -32,7 +31,6 @@ exports[`/glob.js should support exclusion patterns 1`] = `
 }
 /* dir/2.css */
 .two {
-    
     background: blue;
 }
 "
@@ -53,7 +51,6 @@ exports[`/glob.js should use a default search 1`] = `
 }
 /* dir/2.css */
 .two {
-    
     background: blue;
 }
 "

--- a/packages/processor/plugins/composition.js
+++ b/packages/processor/plugins/composition.js
@@ -94,8 +94,12 @@ module.exports = (css, result) => {
             }
         });
 
+        const next = decl.next();
+
         // Remove just the composes declaration if there are other declarations
-        if(decl.parent.nodes.length > 1) {
+        if(next) {
+            next.raws.before = decl.raw("before");
+
             return decl.remove();
         }
 

--- a/packages/processor/test/__snapshots__/api.test.js.snap
+++ b/packages/processor/test/__snapshots__/api.test.js.snap
@@ -233,7 +233,6 @@ exports[`/processor.js API .output() should order output by dependencies, then a
 /* packages/processor/test/specimens/composes.css */
 /* packages/processor/test/specimens/deep.css */
 .deep {
-    
     color: black;
 }
 /* packages/processor/test/specimens/local.css */

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -10,7 +10,6 @@ Array [
 }
 /* packages/rollup/test/specimens/casing/foo.css */
 .mc3dd08d27_foo {
-
     color: #F00;
 }",
   },
@@ -436,7 +435,6 @@ exports[`/rollup.js should respect the CSS dependency tree 2`] = `
 }
 /* packages/rollup/test/specimens/dependencies.css */
 .wooga {
-
     background: blue;
 }
 "

--- a/packages/rollup/test/__snapshots__/splitting.test.js.snap
+++ b/packages/rollup/test/__snapshots__/splitting.test.js.snap
@@ -3,46 +3,30 @@
 exports[`/rollup.js code splitting should dedupe chunk names using rollup's incrementing counter logic (hashed) 1`] = `
 Array [
   Object {
-    "file": "a-14363c2f.css",
+    "file": "a-8dc3c49a.css",
     "text": "/* packages/rollup/test/specimens/multiple-chunks/a.css */
 .a {
-
     color: aqua;
 }
 
-/*# sourceMappingURL=a-14363c2f.css.map */",
+/*# sourceMappingURL=a-8dc3c49a.css.map */",
   },
   Object {
-    "file": "a-14363c2f.css.map",
-    "text": "{\\"version\\":3,\\"sources\\":[\\"../../../specimens/multiple-chunks/a.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,yDAAA;AAAA;;IAGI,WAAW;AACf\\",\\"file\\":\\"a-[hash].css\\",\\"sourcesContent\\":[\\".a {\\\\n    composes: shared from \\\\\\"./shared.css\\\\\\";\\\\n\\\\n    color: aqua;\\\\n}\\\\n\\"]}",
+    "file": "a-8dc3c49a.css.map",
+    "text": "{\\"version\\":3,\\"sources\\":[\\"../../../specimens/multiple-chunks/a.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,yDAAA;AAAA;IAGI,WAAW;AACf\\",\\"file\\":\\"a-[hash].css\\",\\"sourcesContent\\":[\\".a {\\\\n    composes: shared from \\\\\\"./shared.css\\\\\\";\\\\n\\\\n    color: aqua;\\\\n}\\\\n\\"]}",
   },
   Object {
-    "file": "b-b31885ac.css",
+    "file": "b-fc0ef588.css",
     "text": "/* packages/rollup/test/specimens/multiple-chunks/b.css */
 .b {
-
     color: blue;
 }
 
-/*# sourceMappingURL=b-b31885ac.css.map */",
+/*# sourceMappingURL=b-fc0ef588.css.map */",
   },
   Object {
-    "file": "b-b31885ac.css.map",
-    "text": "{\\"version\\":3,\\"sources\\":[\\"../../../specimens/multiple-chunks/b.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,yDAAA;AAAA;;IAGI,WAAW;AACf\\",\\"file\\":\\"b-[hash].css\\",\\"sourcesContent\\":[\\".b {\\\\n    composes: shared from \\\\\\"./shared.css\\\\\\";\\\\n\\\\n    color: blue;\\\\n}\\\\n\\"]}",
-  },
-  Object {
-    "file": "chunk-23649ca7.css",
-    "text": "/* packages/rollup/test/specimens/multiple-chunks/d.css */
-.d {
-
-    color: deepskyblue;
-}
-
-/*# sourceMappingURL=chunk-23649ca7.css.map */",
-  },
-  Object {
-    "file": "chunk-23649ca7.css.map",
-    "text": "{\\"version\\":3,\\"sources\\":[\\"../../../specimens/multiple-chunks/packages/rollup/test/specimens/multiple-chunks/b.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,yDAAA;AAAA;;IAGI,kBAAW;AACf\\",\\"file\\":\\"chunk-[hash].css\\",\\"sourcesContent\\":[\\".b {\\\\n    composes: shared from \\\\\\"./shared.css\\\\\\";\\\\n\\\\n    color: blue;\\\\n}\\\\n\\"]}",
+    "file": "b-fc0ef588.css.map",
+    "text": "{\\"version\\":3,\\"sources\\":[\\"../../../specimens/multiple-chunks/b.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,yDAAA;AAAA;IAGI,WAAW;AACf\\",\\"file\\":\\"b-[hash].css\\",\\"sourcesContent\\":[\\".b {\\\\n    composes: shared from \\\\\\"./shared.css\\\\\\";\\\\n\\\\n    color: blue;\\\\n}\\\\n\\"]}",
   },
   Object {
     "file": "chunk-2f7464a0.css",
@@ -58,18 +42,30 @@ Array [
     "text": "{\\"version\\":3,\\"sources\\":[\\"../../../specimens/multiple-chunks/constants.css\\",\\"../../../specimens/multiple-chunks/shared.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,iEAAA,ECAA,8DAAA;AAEA,UAAU,aAAa,EAAE;;AAEzB,SDJA,WAAiB,ECIK\\",\\"file\\":\\"chunk-[hash].css\\",\\"sourcesContent\\":[\\"@value main: blue;\\\\n\\",\\"@value main from \\\\\\"./constants.css\\\\\\";\\\\n\\\\n.shared { color: salmon; }\\\\n\\\\n.other { color: main; }\\\\n\\"]}",
   },
   Object {
-    "file": "chunk-57d5c038.css",
+    "file": "chunk-48a593d7.css",
     "text": "/* packages/rollup/test/specimens/multiple-chunks/c.css */
 .c {
-
     color: coral;
 }
 
-/*# sourceMappingURL=chunk-57d5c038.css.map */",
+/*# sourceMappingURL=chunk-48a593d7.css.map */",
   },
   Object {
-    "file": "chunk-57d5c038.css.map",
-    "text": "{\\"version\\":3,\\"sources\\":[\\"../../../specimens/multiple-chunks/packages/rollup/test/specimens/multiple-chunks/b.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,yDAAA;AAAA;;IAGI,YAAW;AACf\\",\\"file\\":\\"chunk-[hash].css\\",\\"sourcesContent\\":[\\".b {\\\\n    composes: shared from \\\\\\"./shared.css\\\\\\";\\\\n\\\\n    color: blue;\\\\n}\\\\n\\"]}",
+    "file": "chunk-48a593d7.css.map",
+    "text": "{\\"version\\":3,\\"sources\\":[\\"../../../specimens/multiple-chunks/packages/rollup/test/specimens/multiple-chunks/b.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,yDAAA;AAAA;IAGI,YAAW;AACf\\",\\"file\\":\\"chunk-[hash].css\\",\\"sourcesContent\\":[\\".b {\\\\n    composes: shared from \\\\\\"./shared.css\\\\\\";\\\\n\\\\n    color: blue;\\\\n}\\\\n\\"]}",
+  },
+  Object {
+    "file": "chunk-ee76f9f0.css",
+    "text": "/* packages/rollup/test/specimens/multiple-chunks/d.css */
+.d {
+    color: deepskyblue;
+}
+
+/*# sourceMappingURL=chunk-ee76f9f0.css.map */",
+  },
+  Object {
+    "file": "chunk-ee76f9f0.css.map",
+    "text": "{\\"version\\":3,\\"sources\\":[\\"../../../specimens/multiple-chunks/packages/rollup/test/specimens/multiple-chunks/b.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,yDAAA;AAAA;IAGI,kBAAW;AACf\\",\\"file\\":\\"chunk-[hash].css\\",\\"sourcesContent\\":[\\".b {\\\\n    composes: shared from \\\\\\"./shared.css\\\\\\";\\\\n\\\\n    color: blue;\\\\n}\\\\n\\"]}",
   },
 ]
 `;
@@ -80,7 +76,6 @@ Array [
     "file": "a.css",
     "text": "/* packages/rollup/test/specimens/multiple-chunks/a.css */
 .a {
-
     color: aqua;
 }
 
@@ -88,13 +83,12 @@ Array [
   },
   Object {
     "file": "a.css.map",
-    "text": "{\\"version\\":3,\\"sources\\":[\\"../../../specimens/multiple-chunks/a.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,yDAAA;AAAA;;IAGI,WAAW;AACf\\",\\"file\\":\\"a.css\\",\\"sourcesContent\\":[\\".a {\\\\n    composes: shared from \\\\\\"./shared.css\\\\\\";\\\\n\\\\n    color: aqua;\\\\n}\\\\n\\"]}",
+    "text": "{\\"version\\":3,\\"sources\\":[\\"../../../specimens/multiple-chunks/a.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,yDAAA;AAAA;IAGI,WAAW;AACf\\",\\"file\\":\\"a.css\\",\\"sourcesContent\\":[\\".a {\\\\n    composes: shared from \\\\\\"./shared.css\\\\\\";\\\\n\\\\n    color: aqua;\\\\n}\\\\n\\"]}",
   },
   Object {
     "file": "b.css",
     "text": "/* packages/rollup/test/specimens/multiple-chunks/b.css */
 .b {
-
     color: blue;
 }
 
@@ -102,7 +96,7 @@ Array [
   },
   Object {
     "file": "b.css.map",
-    "text": "{\\"version\\":3,\\"sources\\":[\\"../../../specimens/multiple-chunks/b.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,yDAAA;AAAA;;IAGI,WAAW;AACf\\",\\"file\\":\\"b.css\\",\\"sourcesContent\\":[\\".b {\\\\n    composes: shared from \\\\\\"./shared.css\\\\\\";\\\\n\\\\n    color: blue;\\\\n}\\\\n\\"]}",
+    "text": "{\\"version\\":3,\\"sources\\":[\\"../../../specimens/multiple-chunks/b.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,yDAAA;AAAA;IAGI,WAAW;AACf\\",\\"file\\":\\"b.css\\",\\"sourcesContent\\":[\\".b {\\\\n    composes: shared from \\\\\\"./shared.css\\\\\\";\\\\n\\\\n    color: blue;\\\\n}\\\\n\\"]}",
   },
   Object {
     "file": "chunk.css",
@@ -121,27 +115,25 @@ Array [
     "file": "chunk2.css",
     "text": "/* packages/rollup/test/specimens/multiple-chunks/d.css */
 .d {
-
     color: deepskyblue;
 }
 ",
   },
   Object {
     "file": "chunk2.css.map",
-    "text": "{\\"version\\":3,\\"sources\\":[\\"../../../specimens/multiple-chunks/packages/rollup/test/specimens/multiple-chunks/b.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,yDAAA;AAAA;;IAGI,kBAAW;AACf\\",\\"file\\":\\"chunk.css\\",\\"sourcesContent\\":[\\".b {\\\\n    composes: shared from \\\\\\"./shared.css\\\\\\";\\\\n\\\\n    color: blue;\\\\n}\\\\n\\"]}",
+    "text": "{\\"version\\":3,\\"sources\\":[\\"../../../specimens/multiple-chunks/packages/rollup/test/specimens/multiple-chunks/b.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,yDAAA;AAAA;IAGI,kBAAW;AACf\\",\\"file\\":\\"chunk.css\\",\\"sourcesContent\\":[\\".b {\\\\n    composes: shared from \\\\\\"./shared.css\\\\\\";\\\\n\\\\n    color: blue;\\\\n}\\\\n\\"]}",
   },
   Object {
     "file": "chunk3.css",
     "text": "/* packages/rollup/test/specimens/multiple-chunks/c.css */
 .c {
-
     color: coral;
 }
 ",
   },
   Object {
     "file": "chunk3.css.map",
-    "text": "{\\"version\\":3,\\"sources\\":[\\"../../../specimens/multiple-chunks/packages/rollup/test/specimens/multiple-chunks/b.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,yDAAA;AAAA;;IAGI,YAAW;AACf\\",\\"file\\":\\"chunk.css\\",\\"sourcesContent\\":[\\".b {\\\\n    composes: shared from \\\\\\"./shared.css\\\\\\";\\\\n\\\\n    color: blue;\\\\n}\\\\n\\"]}",
+    "text": "{\\"version\\":3,\\"sources\\":[\\"../../../specimens/multiple-chunks/packages/rollup/test/specimens/multiple-chunks/b.css\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,yDAAA;AAAA;IAGI,YAAW;AACf\\",\\"file\\":\\"chunk.css\\",\\"sourcesContent\\":[\\".b {\\\\n    composes: shared from \\\\\\"./shared.css\\\\\\";\\\\n\\\\n    color: blue;\\\\n}\\\\n\\"]}",
   },
 ]
 `;
@@ -160,7 +152,6 @@ Array [
     "file": "dependencies.css",
     "text": "/* packages/rollup/test/specimens/dependencies.css */
 .wooga {
-
     background: blue;
 }
 ",
@@ -284,12 +275,10 @@ Array [
 }
 /* packages/rollup/test/specimens/dynamic-imports/d.css */
 .d {
-    
     color: darkred;
 }
 /* packages/rollup/test/specimens/dynamic-imports/a.css */
 .a {
-
     color: aqua;
 }
 ",
@@ -302,7 +291,6 @@ Array [
 }
 /* packages/rollup/test/specimens/dynamic-imports/b.css */
 .b {
-    
     color: blue;
 }
 ",
@@ -311,7 +299,6 @@ Array [
     "file": "chunk.css",
     "text": "/* packages/rollup/test/specimens/dynamic-imports/c.css */
 .c {
-    
     color: cyan;
 }
 ",
@@ -325,7 +312,6 @@ Array [
     "file": "a.css",
     "text": "/* packages/rollup/test/specimens/manual-chunks/a.css */
 .a {
-
     color: red;
 }
 ",
@@ -334,7 +320,6 @@ Array [
     "file": "b.css",
     "text": "/* packages/rollup/test/specimens/manual-chunks/b.css */
 .b {
-
     color: blue;
 }
 ",
@@ -458,7 +443,6 @@ Array [
     "file": "dependencies.css",
     "text": "/* packages/rollup/test/specimens/dependencies.css */
 .wooga {
-
     background: blue;
 }
 ",
@@ -472,7 +456,6 @@ Array [
     "file": "a.css",
     "text": "/* packages/rollup/test/specimens/css-chunks/a.css */
 .a {
-
     color: aqua;
 }
 ",
@@ -481,7 +464,6 @@ Array [
     "file": "b.css",
     "text": "/* packages/rollup/test/specimens/css-chunks/b.css */
 .b {
-    
     color: blue;
 }
 ",
@@ -494,7 +476,6 @@ Array [
 }
 /* packages/rollup/test/specimens/css-chunks/c.css */
 .c {
-
     color: cyan;
 }
 ",
@@ -514,12 +495,10 @@ Array [
 }
 /* packages/rollup/test/specimens/common-splitting/a.css */
 .a {
-
     color: aqua;
 }
 /* packages/rollup/test/specimens/common-splitting/b.css */
 .b {
-
     color: blue;
 }
 ",

--- a/packages/svelte/test/__snapshots__/svelte.test.js.snap
+++ b/packages/svelte/test/__snapshots__/svelte.test.js.snap
@@ -37,7 +37,6 @@ exports[`/svelte.js should extract CSS from a <link> tag ("existing script") 2`]
 }
 /* packages/svelte/test/specimens/dependencies.css */
 .wooga {
-
     background: blue;
 }
 /* packages/svelte/test/specimens/external.css */
@@ -73,7 +72,6 @@ exports[`/svelte.js should extract CSS from a <link> tag ("no script") 2`] = `
 }
 /* packages/svelte/test/specimens/dependencies.css */
 .wooga {
-
     background: blue;
 }
 /* packages/svelte/test/specimens/external.css */
@@ -109,7 +107,6 @@ exports[`/svelte.js should extract CSS from a <link> tag ("single quotes") 2`] =
 }
 /* packages/svelte/test/specimens/dependencies.css */
 .wooga {
-
     background: blue;
 }
 /* packages/svelte/test/specimens/external.css */
@@ -145,7 +142,6 @@ exports[`/svelte.js should extract CSS from a <link> tag ("unquoted") 2`] = `
 }
 /* packages/svelte/test/specimens/dependencies.css */
 .wooga {
-
     background: blue;
 }
 /* packages/svelte/test/specimens/external.css */
@@ -191,7 +187,6 @@ exports[`/svelte.js should extract CSS from a <link> tag ("values") 2`] = `
 }
 /* packages/svelte/test/specimens/dependencies.css */
 .wooga {
-
     background: blue;
 }
 /* packages/svelte/test/specimens/external.css */
@@ -234,7 +229,6 @@ exports[`/svelte.js should extract CSS from a <style> tag 2`] = `
 }
 /* packages/svelte/test/specimens/dependencies.css */
 .wooga {
-
     background: blue;
 }
 /* packages/svelte/test/specimens/style.html */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
```diff
.foo {
-    
    color: fuschia;
}
``` 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I always hated that extra newline but never took the time to get rid of it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated a whoooooooole bunch of snapshots.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
