### PR TITLE
fix: force rollup output to use .css

### DIFF
--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -220,8 +220,10 @@ module.exports = (opts) => {
                     continue;
                 }
 
-                const { name, ext, base } = path.parse(node);
-                const id = this.emitAsset(base);
+                const ext = ".css";
+                const name = path.basename(node, path.extname(node));
+                
+                const id = this.emitAsset(`${name}${ext}`);
 
                 /* eslint-disable-next-line no-await-in-loop */
                 const result = await processor.output({

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -399,7 +399,7 @@ console.log(css);
 
 exports[`/rollup.js should output assets with a .css file extension 1`] = `
 Object {
-  "assets/style-ea90c2f3.css": "
+  "assets/style.css": "
 /* packages/rollup/test/specimens/file-extension/style.cssx */
 .style {
     color: salmon;

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -397,6 +397,24 @@ console.log(css);
 }
 `;
 
+exports[`/rollup.js should output assets with a .css file extension 1`] = `
+Object {
+  "assets/style-ea90c2f3.css": "
+/* packages/rollup/test/specimens/file-extension/style.cssx */
+.style {
+    color: salmon;
+}
+",
+  "entry.js": "
+var style = {
+    \\"style\\": \\"style\\"
+};
+
+console.log(style);
+",
+}
+`;
+
 exports[`/rollup.js should output unreferenced CSS 1`] = `
 Array [
   Object {

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -587,7 +587,10 @@ describe("/rollup.js", () => {
             ],
         });
 
-        const result = await bundle.generate({ format });
+        const result = await bundle.generate({
+            format,
+            assetFileNames,
+        });
 
         expect(result).toMatchRollupSnapshot();
     });

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -15,6 +15,7 @@ const namer   = require("@modular-css/test-utils/namer.js");
 const logs    = require("@modular-css/test-utils/logs.js");
 
 require("@modular-css/test-utils/rollup-code-snapshot.js");
+require("@modular-css/test-utils/rollup-build-snapshot.js");
 
 const Processor = require("@modular-css/processor");
 
@@ -573,6 +574,22 @@ describe("/rollup.js", () => {
         await processor.output();
 
         logSnapshot();
+    });
+
+    it.only("should output assets with a .css file extension", async () => {
+        const bundle = await rollup({
+            input   : require.resolve("./specimens/file-extension/entry.js"),
+            plugins : [
+                plugin({
+                    namer,
+                    include : /\.cssx$/
+                }),
+            ],
+        });
+
+        const result = await bundle.generate({ format });
+
+        expect(result).toMatchRollupSnapshot();
     });
 
     describe("case sensitivity tests", () => {

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -576,7 +576,7 @@ describe("/rollup.js", () => {
         logSnapshot();
     });
 
-    it.only("should output assets with a .css file extension", async () => {
+    it("should output assets with a .css file extension", async () => {
         const bundle = await rollup({
             input   : require.resolve("./specimens/file-extension/entry.js"),
             plugins : [

--- a/packages/rollup/test/specimens/file-extension/entry.js
+++ b/packages/rollup/test/specimens/file-extension/entry.js
@@ -1,0 +1,3 @@
+import style from "./style.cssx";
+
+console.log(style);

--- a/packages/rollup/test/specimens/file-extension/style.cssx
+++ b/packages/rollup/test/specimens/file-extension/style.cssx
@@ -1,0 +1,3 @@
+.style {
+    color: salmon;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Don't use the source file's original extension, it may not be `.css` and that does bad things.

See https://5c5a73dabd66690008908a73--m-css.netlify.com/ for an example of the "bad things" I'm referring to 🤨

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In this case it was the svelte plugin's support for inline `<style>` tags, meaning that a bunch of `.html` files were generated containing CSS. Most web servers handle content-type by file extension, so this went poorly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test, also ran https://m-css.com locally & verified that this fixed the issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
