### PR TITLE
fix: walk invalidated dependencies

### DIFF
--- a/packages/processor/processor.js
+++ b/packages/processor/processor.js
@@ -430,11 +430,17 @@ class Processor {
 
         // Walk this node's dependencies, reading new files from disk as necessary
         await Promise.all(
-            this._graph.dependenciesOf(name).map((dependency) => (
-                dependency in this._files ?
-                    this._files[dependency].walked :
-                    this.file(dependency)
-            ))
+            this._graph.dependenciesOf(name).map((dependency) => {
+                const { valid, walked : complete } = this._files[dependency] || false;
+
+                // If the file hasn't been invalidated wait for it to be done processing
+                if(valid) {
+                    return complete;
+                }
+
+                // Otherwise add it to the queue
+                return this.file(dependency);
+            })
         );
 
         // Mark the walk of this file & its dependencies complete


### PR DESCRIPTION
## Description
When invalidation was added in #532 I apparently forgot to account for it withiin the dependency walking code, so invalidated files wouldn't ever be rewalked.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This has likely been causing a variety of nasty-to-debug errors in the wild :disappointed:

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See #572, the added test in `watch.test.js` is how I discovered this was broken.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
