### PR TITLE
feat(stylelint-config): add @modular-css/stylelint-config package

### DIFF
--- a/packages/stylelint-config/.npmignore
+++ b/packages/stylelint-config/.npmignore
@@ -1,0 +1,5 @@
+coverage/
+profiling/
+test/
+.*
+CHANGELOG.md

--- a/packages/stylelint-config/LICENSE
+++ b/packages/stylelint-config/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Pat Cavit
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/stylelint-config/README.md
+++ b/packages/stylelint-config/README.md
@@ -1,0 +1,32 @@
+@modular-css/stylelint-config  [![NPM Version](https://img.shields.io/npm/v/@modular-css/stylelint-config.svg)](https://www.npmjs.com/package/@modular-css/stylelint-config) [![NPM License](https://img.shields.io/npm/l/@modular-css/stylelint-config.svg)](https://www.npmjs.com/package/@modular-css/stylelint-config) [![NPM Downloads](https://img.shields.io/npm/dm/@modular-css/stylelint-config.svg)](https://www.npmjs.com/package/@modular-css/stylelint-config)
+===========
+
+<p align="center">
+    <a href="https://gitter.im/modular-css/modular-css"><img src="https://img.shields.io/gitter/room/modular-css/modular-css.svg" alt="Gitter" /></a>
+</p>
+
+Sharable stylelint config for [`modular-css`](https://m-css). By default stylelint will complain about things like `@value`, `@composes`, `composes: fooga;`, and other bits of custom modular-css syntax. This configures the relevant stylelint rules so that those bits of functionality are ignored so that you don't get a bunch of bogus warnings or errors for using modular-css.
+
+Someday it might even validate things for you, but that's a trickier proposition. For now not barfing errors/warnings everywhere is a good start.
+
+- [Install](#install)
+- [Usage](#usage)
+
+## Install
+
+```bash
+> npm i @modular-css/stylelint -D
+```
+
+## Usage
+
+Inside your [stylelint config](https://stylelint.io/user-guide/configuration/) you'll specify an [`extends`](https://stylelint.io/user-guide/configuration/#extends) property pointing to this package.
+
+```json
+{
+    "extends" : "@modular-css/stylelint-config",
+    "rules" : {
+        // ...
+    }
+}
+```

--- a/packages/stylelint-config/README.md
+++ b/packages/stylelint-config/README.md
@@ -22,7 +22,7 @@ Someday it might even validate things for you, but that's a trickier proposition
 
 Inside your [stylelint config](https://stylelint.io/user-guide/configuration/) you'll specify an [`extends`](https://stylelint.io/user-guide/configuration/#extends) property pointing to this package.
 
-```json
+```js
 {
     "extends" : "@modular-css/stylelint-config",
     "rules" : {

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@modular-css/stylelint-config",
+  "version": "24.2.2",
+  "description": "Stylelint config to suport modular-css syntax",
+  "main": "./stylelint.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tivac/modular-css.git",
+    "directory": "packages/stylelint"
+  },
+  "bugs": {
+    "url": "https://github.com/tivac/modular-css/issues"
+  },
+  "author": "Pat Cavit <npm@patcavit.com>",
+  "homepage": "https://m-css.com",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "stylelint",
+    "stylelint-config",
+    "css",
+    "css-modules",
+    "modular-css",
+    "postcss"
+  ]
+}

--- a/packages/stylelint-config/stylelint.js
+++ b/packages/stylelint-config/stylelint.js
@@ -1,0 +1,31 @@
+"use strict";
+
+module.exports = {
+    rules : {
+        "at-rule-no-unknown" : [ true, {
+            ignoreAtRules : [
+                "value",
+                "composes"
+            ]
+        }],
+
+        "declaration-block-no-duplicate-properties" : [ true, {
+            ignoreProperties : [
+                "composes"
+            ]
+        }],
+
+        "property-no-unknown" : [ true, {
+            ignoreProperties : [
+                "composes"
+            ]
+        }],
+
+        "selector-pseudo-class-no-unknown" : [ true, {
+            ignorePseudoClasses : [
+                "global",
+                "external",
+            ]
+        }],
+    }
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding a new package, `@modular-css/stylelint-config` to make it easy to have stylelint ignore the modular-css custom syntax using its `extends` support.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I don't want to keep on having to do this manually every time I start a new project using stylelint & modular-css.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Been using these properties as part of our broader stylelint config on a project for over a year. Extracted from that and then tested within that project.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
