### PR TITLE
chore: add custom outdated script

### DIFF
--- a/lerna/outdated.js
+++ b/lerna/outdated.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const shell = require("shelljs");
+
+const name = process.env.LERNA_PACKAGE_NAME;
+
+const info = shell.exec("npm outdated --json", { silent : true }).stdout;
+
+const packages = JSON.parse(info);
+const keys = Object.keys(packages);
+
+if(!keys.length) {
+    return;
+}
+
+keys.forEach((key) => {
+    const { wanted, latest } = packages[key];
+
+    if(wanted === "linked" && latest === "linked") {
+        return;
+    }
+
+    if(wanted === latest) {
+        return;
+    }
+
+    // TODO: Better formatting someday
+    console.log(name, key, { wanted, latest });
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "cover": "jest --coverage",
     "lint": "eslint .",
-    "outdated": "lerna exec --no-bail --stream -- npm outdated",
+    "outdated": "lerna exec -- node ../../lerna/outdated.js",
     "parsers": "node parsers/build.js",
     "release": "env-cmd lerna publish",
     "prepublishOnly": "npm run parsers",

--- a/packages/www/package-lock.json
+++ b/packages/www/package-lock.json
@@ -4647,9 +4647,9 @@
       }
     },
     "rollup-plugin-commonjs": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.1.0.tgz",
-      "integrity": "sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.0.1.tgz",
+      "integrity": "sha512-x0PcCVdEc4J8igv1qe2vttz8JKAKcTs3wfIA3L8xEty3VzxgORLrzZrNWaVMc+pBC4U3aDOb9BnWLAQ8J11vkA==",
       "requires": {
         "estree-walker": "^0.6.1",
         "is-reference": "^1.1.2",


### PR DESCRIPTION
`npm outdated` run in every package is full of noise from bootstrapped packages, this is much more minimal and useful.