### PR TITLE
fix: use this.emitFile() API from rollup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1569,6 +1569,7 @@
     "@modular-css/browserify": {
       "version": "file:packages/browserify",
       "requires": {
+        "@modular-css/processor": "file:packages/processor",
         "mkdirp": "^0.5.1",
         "p-each-series": "^2.0.0",
         "sink-transform": "^2.0.0",
@@ -1578,6 +1579,8 @@
     "@modular-css/cli": {
       "version": "file:packages/cli",
       "requires": {
+        "@modular-css/glob": "file:packages/glob",
+        "@modular-css/processor": "file:packages/processor",
         "meow": "^5.0.0",
         "mkdirp": "^0.5.1"
       }
@@ -1585,6 +1588,7 @@
     "@modular-css/glob": {
       "version": "file:packages/glob",
       "requires": {
+        "@modular-css/processor": "file:packages/processor",
         "globule": "^1.1.0"
       }
     },
@@ -1603,6 +1607,7 @@
     "@modular-css/postcss": {
       "version": "file:packages/postcss",
       "requires": {
+        "@modular-css/processor": "file:packages/processor",
         "mkdirp": "^0.5.1",
         "postcss": "^7.0.0"
       }
@@ -1624,6 +1629,7 @@
     "@modular-css/rollup": {
       "version": "file:packages/rollup",
       "requires": {
+        "@modular-css/processor": "file:packages/processor",
         "dedent": "0.7.0",
         "esutils": "^2.0.2",
         "rollup-pluginutils": "^2.0.1",
@@ -1647,6 +1653,7 @@
     "@modular-css/svelte": {
       "version": "file:packages/svelte",
       "requires": {
+        "@modular-css/processor": "file:packages/processor",
         "escape-string-regexp": "^2.0.0",
         "is-url": "^1.2.4",
         "resolve-from": "^5.0.0"
@@ -1659,6 +1666,7 @@
     "@modular-css/webpack": {
       "version": "file:packages/webpack",
       "requires": {
+        "@modular-css/processor": "file:packages/processor",
         "esutils": "^2.0.2",
         "loader-utils": "^1.1.0",
         "lodash": "^4.17.0",
@@ -1669,6 +1677,10 @@
       "version": "file:packages/www",
       "dev": true,
       "requires": {
+        "@modular-css/processor": "file:packages/processor",
+        "@modular-css/rollup": "file:packages/rollup",
+        "@modular-css/shortnames": "file:packages/namer",
+        "@modular-css/svelte": "file:packages/svelte",
         "babel-eslint": "^10.0.1",
         "codemirror": "^5.42.2",
         "cssnano": "^4.1.8",
@@ -1700,7 +1712,7 @@
         "rollup-plugin-node-globals": "^1.4.0",
         "rollup-plugin-node-resolve": "^5.2.0",
         "rollup-plugin-svelte": "^5.0.1",
-        "rollup-plugin-terser": "^5.0.0",
+        "rollup-plugin-terser": "^5.1.1",
         "rollup-pluginutils": "^2.8.1",
         "svelte": "^2.16.0"
       }
@@ -12648,20 +12660,26 @@
       }
     },
     "rollup": {
-      "version": "1.19.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.19.4.tgz",
-      "integrity": "sha512-G24w409GNj7i/Yam2cQla6qV2k6Nug8bD2DZg9v63QX/cH/dEdbNJg8H4lUm5M1bRpPKRUC465Rm9H51JTKOfQ==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.21.2.tgz",
+      "integrity": "sha512-sCAHlcQ/PExU5t/kRwkEWHdhGmQrZ2IgdQzbjPVNfhWbKHMMZGYqkASVTpQqRPLtQKg15xzEscc+BnIK/TE7/Q==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "^12.6.9",
-        "acorn": "^6.2.1"
+        "@types/node": "^12.7.4",
+        "acorn": "^7.0.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "12.7.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
+          "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==",
+          "dev": true
+        },
         "acorn": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
+          "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12660,13 +12660,13 @@
       }
     },
     "rollup": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.21.2.tgz",
-      "integrity": "sha512-sCAHlcQ/PExU5t/kRwkEWHdhGmQrZ2IgdQzbjPVNfhWbKHMMZGYqkASVTpQqRPLtQKg15xzEscc+BnIK/TE7/Q==",
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.21.3.tgz",
+      "integrity": "sha512-43CgeUtHhfiqBOUd0uJo5NEOg2FuheF3SqGN8BqgvnqB4xM2TbfPdudeSdllDcMKpagHb//qtpaAADBurT4GzA==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "^12.7.4",
+        "@types/node": "^12.7.5",
         "acorn": "^7.0.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lerna": "^3.16.4",
     "pegjs": "0.10.0",
     "read-dir-deep": "^6.0.0",
-    "rollup": "^1.21.2",
+    "rollup": "^1.21.3",
     "rollup-plugin-hypothetical": "^2.1.0",
     "rollup-plugin-svelte": "^5.0.3",
     "shelljs": "^0.8.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lerna": "^3.16.4",
     "pegjs": "0.10.0",
     "read-dir-deep": "^6.0.0",
-    "rollup": "^1.11.3",
+    "rollup": "^1.21.2",
     "rollup-plugin-hypothetical": "^2.1.0",
     "rollup-plugin-svelte": "^5.0.3",
     "shelljs": "^0.8.3",

--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -257,7 +257,11 @@ module.exports = (opts) => {
                     continue;
                 }
 
-                const id = this.emitAsset(`${name}${ext}`, result.css);
+                const id = this.emitFile({
+                    type   : "asset",
+                    name   : `${name}${ext}`,
+                    source : result.css,
+                });
 
                 // Save off the final name of this asset for later use
                 const dest = this.getAssetFileName(id);
@@ -266,9 +270,6 @@ module.exports = (opts) => {
 
                 log("css output", dest);
 
-                // Maps can't be written out via the asset APIs becuase they shouldn't ever be hashed.
-                // They shouldn't be hashed because they simply follow the name of their parent .css asset.
-                // So add them to the bundle directly.
                 if(result.map) {
                     // Make sure to use the rollup name as the base, otherwise it won't
                     // automatically handle duplicate names correctly
@@ -276,11 +277,14 @@ module.exports = (opts) => {
 
                     log("map output", fileName);
 
-                    bundle[fileName] = {
-                        isAsset : true,
-                        source  : result.map.toString(),
+                    this.emitFile({
+                        type   : "asset",
+                        source : result.map.toString(),
+
+                        // Use fileName instead of name because this has to follow the parent
+                        // file naming and can't be double-hashed
                         fileName,
-                    };
+                    });
 
                     // Had to re-add the map annotation to the end of the source files
                     // if the filename had a hash, since we stripped it out up above
@@ -297,7 +301,11 @@ module.exports = (opts) => {
 
                 const compositions = await processor.compositions;
 
-                this.emitAsset(dest, JSON.stringify(compositions, null, 4));
+                this.emitFile({
+                    type   : "asset",
+                    name   : dest,
+                    source : JSON.stringify(compositions, null, 4),
+                });
             }
 
             const meta = {};
@@ -328,7 +336,11 @@ module.exports = (opts) => {
 
                 log("metadata output", dest);
 
-                this.emitAsset(dest, JSON.stringify(meta, null, 4));
+                this.emitFile({
+                    type   : "asset",
+                    source : JSON.stringify(meta, null, 4),
+                    name   : dest,
+                });
             }
         },
     };

--- a/packages/rollup/test/__snapshots__/splitting.test.js.snap
+++ b/packages/rollup/test/__snapshots__/splitting.test.js.snap
@@ -408,7 +408,7 @@ Object {
     color: red;
 }
 ",
-  "simple.96e4896f.js": "
+  "simple.336b919d.js": "
 var css = {
     \\"str\\": \\"\\\\\\"string\\\\\\"\\",
     \\"fooga\\": \\"fooga\\"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Using `this.emitFile()` for all file emission from the rollup plugin.

## Motivation and Context
`this.emitFile()` is the correct future-proof way to emit files from rollup plugins. `this.emitAsset()` and `this.emitChunk()` are being deprecated, and it was never *really* supported to add files directly to the bundle the way they were.

## How Has This Been Tested?
Normal test suite

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
