### PR TITLE
feat(processor): add processor.resolve()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2120,8 +2120,7 @@
       "requires": {
         "@modular-css/processor": "file:packages/processor",
         "escape-string-regexp": "^2.0.0",
-        "is-url": "^1.2.4",
-        "resolve-from": "^5.0.0"
+        "is-url": "^1.2.4"
       }
     },
     "@modular-css/test-utils": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "prepublishOnly": "npm run parsers",
     "pretest": "npm run parsers",
     "test": "jest",
-    "posttest": "npm run lint",
     "watch": "jest --watch",
     "www:build": "lerna run --stream build packages/www",
     "www:start": "lerna run --stream start packages/www",

--- a/packages/processor/processor.js
+++ b/packages/processor/processor.js
@@ -9,24 +9,25 @@ const postcss   = require("postcss");
 const slug      = require("unique-slug");
 const mapValues = require("lodash/mapValues");
 
-const output    = require("./lib/output.js");
-const message   = require("./lib/message.js");
-const relative  = require("./lib/relative.js");
-const tiered    = require("./lib/graph-tiers.js");
-const resolve   = require("./lib/resolve.js");
-const normalize = require("./lib/normalize.js");
+const output        = require("./lib/output.js");
+const message       = require("./lib/message.js");
+const relative      = require("./lib/relative.js");
+const tiered        = require("./lib/graph-tiers.js");
+const normalize     = require("./lib/normalize.js");
+const { resolvers } = require("./lib/resolve.js");
 
 const noop = () => true;
 
-const params = ({ _options, _files, _graph, _resolve }, args) => Object.assign(
+const params = ({ _options, _files, _graph, resolve }, args) => Object.assign(
     Object.create(null),
     _options,
     _options.postcss,
     {
-        from    : null,
-        files   : _files,
-        graph   : _graph,
-        resolve : _resolve,
+        resolve,
+        
+        from  : null,
+        files : _files,
+        graph : _graph,
     },
     args
 );
@@ -70,7 +71,8 @@ class Processor {
             // eslint-disable-next-line no-empty-function
             () => {};
 
-        this._resolve = resolve.resolvers(options.resolvers);
+        // Expose resolving API publicly, because it's useful
+        this.resolve = resolvers(options.resolvers);
 
         this._normalize = normalize.bind(null, this._options.cwd);
 

--- a/packages/processor/processor.js
+++ b/packages/processor/processor.js
@@ -18,16 +18,15 @@ const { resolvers } = require("./lib/resolve.js");
 
 const noop = () => true;
 
-const params = ({ _options, _files, _graph, resolve }, args) => Object.assign(
+const params = ({ _options, _files, _graph, _resolve }, args) => Object.assign(
     Object.create(null),
     _options,
     _options.postcss,
     {
-        resolve,
-        
-        from  : null,
-        files : _files,
-        graph : _graph,
+        from    : null,
+        files   : _files,
+        graph   : _graph,
+        resolve : _resolve,
     },
     args
 );
@@ -71,9 +70,7 @@ class Processor {
             // eslint-disable-next-line no-empty-function
             () => {};
 
-        // Expose resolving API publicly, because it's useful
-        this.resolve = resolvers(options.resolvers);
-
+        this._resolve = resolvers(options.resolvers);
         this._normalize = normalize.bind(null, this._options.cwd);
 
         this._files = Object.create(null);
@@ -155,6 +152,11 @@ class Processor {
     // Return the corrected-path version of the file
     normalize(file) {
         return this._normalize(file);
+    }
+
+    // Resolve a file from a src using the configured resolvers
+    resolve(src, file) {
+        return this._resolve(src, file);
     }
 
     // Check if a file exists in the currently-processed set

--- a/packages/processor/test/__snapshots__/api.test.js.snap
+++ b/packages/processor/test/__snapshots__/api.test.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`/processor.js API ._resolve() should fall back to a default resolver 1`] = `
+exports[`/processor.js API .resolve() should fall back to a default resolver 1`] = `
 Array [
   "packages/processor/test/specimens/local.css",
 ]
 `;
 
-exports[`/processor.js API ._resolve() should run resolvers until a match is found 1`] = `
+exports[`/processor.js API .resolve() should run resolvers until a match is found 1`] = `
 Array [
   "packages/processor/test/specimens/local.css",
 ]

--- a/packages/processor/test/api.test.js
+++ b/packages/processor/test/api.test.js
@@ -336,7 +336,7 @@ describe("/processor.js", () => {
             });
         });
 
-        describe("._resolve()", () => {
+        describe(".resolve()", () => {
             it("should run resolvers until a match is found", () => {
                 let ran = false;
 
@@ -350,7 +350,7 @@ describe("/processor.js", () => {
                 
                 expect(
                     relative([
-                        processor._resolve(
+                        processor.resolve(
                             require.resolve("./specimens/start.css"),
                             "./local.css"
                         ),
@@ -370,7 +370,7 @@ describe("/processor.js", () => {
                 
                 expect(
                     relative([
-                        processor._resolve(
+                        processor.resolve(
                             require.resolve("./specimens/start.css"),
                             "./local.css"
                         ),

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -31,8 +31,7 @@
   "dependencies": {
     "@modular-css/processor": "file:../processor",
     "escape-string-regexp": "^2.0.0",
-    "is-url": "^1.2.4",
-    "resolve-from": "^5.0.0"
+    "is-url": "^1.2.4"
   },
   "peerDependencies": {
     "svelte": ">1"

--- a/packages/svelte/svelte.js
+++ b/packages/svelte/svelte.js
@@ -2,7 +2,6 @@
 
 const path = require("path");
 
-const resolve = require("resolve-from");
 const isUrl = require("is-url");
 const escape = require("escape-string-regexp");
 
@@ -143,7 +142,7 @@ module.exports = (config = false) => {
             // Assign to file for later usage in logging
             css = href;
 
-            const external = resolve(path.dirname(html), css);
+            const external = processor.resolve(html, css);
 
             log("extract <link>", external);
 

--- a/packages/svelte/test/__snapshots__/svelte.test.js.snap
+++ b/packages/svelte/test/__snapshots__/svelte.test.js.snap
@@ -658,7 +658,10 @@ exports[`/svelte.js should use an already-created processor 2`] = `
 }"
 `;
 
-exports[`/svelte.js should use modular-css's file resolver 1`] = `"<div class=\\"fooga\\">fooga</div><script>import css from \\"./does-not-exist.css\\";</script>"`;
+exports[`/svelte.js should use modular-css's file resolver 1`] = `
+"<div class=\\"fooga\\">fooga</div>
+<script>import css from \\"./does-not-exist.css\\";</script>"
+`;
 
 exports[`/svelte.js should use modular-css's file resolver 2`] = `
 "/* packages/svelte/test/specimens/simple.css */

--- a/packages/svelte/test/__snapshots__/svelte.test.js.snap
+++ b/packages/svelte/test/__snapshots__/svelte.test.js.snap
@@ -658,6 +658,16 @@ exports[`/svelte.js should use an already-created processor 2`] = `
 }"
 `;
 
+exports[`/svelte.js should use modular-css's file resolver 1`] = `"<div class=\\"fooga\\">fooga</div><script>import css from \\"./does-not-exist.css\\";</script>"`;
+
+exports[`/svelte.js should use modular-css's file resolver 2`] = `
+"/* packages/svelte/test/specimens/simple.css */
+.fooga {
+    color: red;
+}
+"
+`;
+
 exports[`/svelte.js should wait for files to finish 1`] = `
 Array [
   "<style>/* replaced by modular-css */</style>

--- a/packages/svelte/test/specimens/link-resolving.html
+++ b/packages/svelte/test/specimens/link-resolving.html
@@ -1,0 +1,3 @@
+<link rel="stylesheet" href="./does-not-exist.css" />
+
+<div class="{css.fooga}">fooga</div>

--- a/packages/svelte/test/svelte.test.js
+++ b/packages/svelte/test/svelte.test.js
@@ -370,4 +370,30 @@ describe("/svelte.js", () => {
 
         expect(results.map((result) => result.toString())).toMatchSnapshot();
     });
+
+    it("should use modular-css's file resolver", async () => {
+        const processor = new Processor({
+            namer,
+            resolvers : [
+                // Force all paths to resolve to a different file
+                () => require.resolve("./specimens/simple.css"),
+            ],
+        });
+
+        const filename = require.resolve("./specimens/link-resolving.html");
+        const { preprocess } = plugin({
+            processor,
+        });
+
+        const processed = await svelte.preprocess(
+            fs.readFileSync(filename, "utf8"),
+            Object.assign({}, preprocess, { filename })
+        );
+
+        expect(processed.toString()).toMatchSnapshot();
+
+        const output = await processor.output();
+
+        expect(output.css).toMatchSnapshot();
+    });
 });

--- a/packages/www/src/api/usage-js.md
+++ b/packages/www/src/api/usage-js.md
@@ -225,3 +225,18 @@ Remove files from the `Processor` instance. Accepts a single file or array of fi
 
 Returns an array of file paths. Accepts a single file argument to get the dependencies for, will return entire dependency graph in order if argument is omitted.
 
+##### `.invalidate(file)`
+
+Marks a file as stale, if that file is re-added either directly or as a dependency it will be reloaded from disk instead of the Processor cache.
+
+##### `.has(file)`
+
+Checks if the Processor instance knows about a file.
+
+##### `.normalize(file)`
+
+Uses the built-in path normalization settings to normalize the case of a file path.
+
+##### `.resolve(src, file)`
+
+Resolves `file` from `src`, using any of the specified [`resolvers`](#resolvers).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Exposed previously private(ish) `processor._resolve()` as `processor.resolve()` so it's obvious that it's fine and reasonable for consumers to use it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #679 by allowing the svelte preprocessor to use the exact same file resolution logic as the core `modular-css` package.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a new svelte test, all existing tests still pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
