### PR TITLE
refactor: Bye Object.assign

### DIFF
--- a/packages/aliases/aliases.js
+++ b/packages/aliases/aliases.js
@@ -3,11 +3,11 @@
 const from = require("resolve-from");
 
 module.exports = (args) => {
-    const options = Object.assign(
-        Object.create(null),
-        { aliases : {} },
-        args
-    );
+    const options = {
+        __proto__ : null,
+        aliases   : {},
+        ...args,
+    };
 
     const aliases = Object.keys(options.aliases).map((alias) => ({
         name   : alias,

--- a/packages/browserify/browserify.js
+++ b/packages/browserify/browserify.js
@@ -26,12 +26,15 @@ const outputs = ({ exports }) => `module.exports = ${
 };`;
 
 module.exports = (browserify, opts) => {
-    const options = Object.assign(Object.create(null), {
-            ext   : ".css",
-            map   : browserify._options.debug,
-            cwd   : browserify._options.basedir || process.cwd(),
-            cache : true,
-        }, opts);
+    const options = {
+        __proto__ : null,
+
+        ext   : ".css",
+        map   : browserify._options.debug,
+        cwd   : browserify._options.basedir || process.cwd(),
+        cache : true,
+        ...opts,
+    };
 
     let processor = options.cache && new Processor(options);
     let bundler;

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -39,11 +39,13 @@ if(!cli.input.length) {
     cli.showHelp();
 }
 
-glob(Object.assign(
-    Object.create(null),
-    cli.flags,
-    { search : cli.input }
-))
+glob({
+    __proto__ : null,
+
+    ...cli.flags,
+    
+    search : cli.input,
+})
 .then((processor) => processor.output({ to : cli.flags.out }))
 .then(({ compositions, css }) => {
     if(cli.flags.json) {

--- a/packages/glob/glob.js
+++ b/packages/glob/glob.js
@@ -3,14 +3,13 @@
 const globule = require("globule");
 const Processor = require("@modular-css/processor");
 
-module.exports = async (opts) => {
-    const options = Object.assign(
-            Object.create(null),
-            {
-                search : [ "**/*.css" ],
-            },
-            opts || {}
-        );
+module.exports = async (opts = {}) => {
+    const options = {
+        __proto__ : null,
+        
+        search : [ "**/*.css" ],
+        ...opts,
+    };
 
     const processor = new Processor(options);
 

--- a/packages/paths/paths.js
+++ b/packages/paths/paths.js
@@ -3,13 +3,12 @@
 const from = require("resolve-from");
 
 module.exports = (args) => {
-    const options = Object.assign(
-            Object.create(null),
-            {
-                paths : [],
-            },
-            args
-        );
+    const options = {
+        __proto__ : null,
+        
+        paths : [],
+        ...args,
+    };
     
     return (src, file) => {
         let result;

--- a/packages/postcss/postcss.js
+++ b/packages/postcss/postcss.js
@@ -6,13 +6,13 @@ const postcss = require("postcss");
 const mkdirp  = require("mkdirp");
 const Processor = require("@modular-css/processor");
 
-module.exports = postcss.plugin("modular-css", (opts) =>
+module.exports = postcss.plugin("modular-css", (opts = {}) =>
     async (root, result) => {
-        const processor = new Processor(Object.assign(
-            Object.create(null),
-            opts,
-            result.opts
-        ));
+        const processor = new Processor({
+            __proto__ : null,
+            ...opts,
+            ...result.opts,
+        });
 
         const { exports : exported } = await processor.string(result.opts.from, root);
         

--- a/packages/postcss/test/postcss.test.js
+++ b/packages/postcss/test/postcss.test.js
@@ -6,17 +6,16 @@ const read    = require("@modular-css/test-utils/read.js")(__dirname);
 const namer   = require("@modular-css/test-utils/namer.js");
 const plugin  = require("../postcss.js");
 
-function process(file, opts) {
+function process(file, opts = {}) {
     return plugin.process(
         fs.readFileSync(file),
-        Object.assign(
-            Object.create(null),
-            {
-                from : file,
-                namer,
-            },
-            opts || {}
-        )
+        {
+            __proto__ : null,
+
+            from : file,
+            namer,
+            ...opts,
+        }
     );
 }
 

--- a/packages/processor/lib/message.js
+++ b/packages/processor/lib/message.js
@@ -6,8 +6,9 @@ module.exports = ({ messages }, filter) => {
     const message = find(messages, filter);
 
     // Don't get to mess w/ other plugins objects
-    return Object.assign(
-        Object.create(null),
-        message ? message[filter] : {}
-    );
+    return {
+        __proto__ : null,
+
+        ...(message ? message[filter] : {}),
+    };
 };

--- a/packages/processor/lib/output.js
+++ b/packages/processor/lib/output.js
@@ -6,7 +6,9 @@ const relative = require("./relative.js");
 
 exports.join = (output) =>
     map(output, (classes) => (
-            classes.join(" ")
+        Array.isArray(classes) ?
+            classes.join(" ") :
+            classes.toString()
     ));
 
 exports.compositions = ({ options, files }) => {

--- a/packages/processor/lib/output.js
+++ b/packages/processor/lib/output.js
@@ -6,9 +6,7 @@ const relative = require("./relative.js");
 
 exports.join = (output) =>
     map(output, (classes) => (
-        Array.isArray(classes) ?
-            classes.join(" ") :
-            classes.toString()
+            classes.join(" ")
     ));
 
 exports.compositions = ({ options, files }) => {

--- a/packages/processor/plugins/values-export.js
+++ b/packages/processor/plugins/values-export.js
@@ -16,11 +16,12 @@ module.exports = (css, { opts, messages }) => {
         .sort((a, b) => order.indexOf(a.plugin) - order.indexOf(b.plugin))
         .reduce((prev, curr) => Object.assign(prev, curr.values), Object.create(null));
     
-    file.values = Object.assign(
-        Object.create(null),
-        values,
-        file.values || {}
-    );
+    file.values = {
+        __proto__ : null,
+        
+        ...values,
+        ...(file.values || {}),
+    };
 };
 
 module.exports.postcssPlugin = "modular-css-values-export";

--- a/packages/processor/plugins/values-replace.js
+++ b/packages/processor/plugins/values-replace.js
@@ -12,10 +12,11 @@ module.exports = (css, { opts, messages }) => {
     const graph = new Graph();
 
     // Create local copy of values since we're going to merge in namespace stuff
-    const values = Object.assign(
-        Object.create(null),
-        get(opts, [ "files", opts.from, "values" ])
-    );
+    const values = {
+        __proto__ : null,
+        
+        ...get(opts, [ "files", opts.from, "values" ]),
+    };
 
     // Merge namespaced values in w/ prefixed names
     messages

--- a/packages/rollup-rewriter/rewriter.js
+++ b/packages/rollup-rewriter/rewriter.js
@@ -17,12 +17,18 @@ const formats = {
 
 const supported = new Set(Object.keys(formats).sort());
 
-module.exports = (opts) => {
-    const options = Object.assign(Object.create(null), {
-        loader  : false,
-        loadfn  : false,
-        verbose : false,
-    }, opts);
+const DEFAULTS = {
+    loader  : false,
+    loadfn  : false,
+    verbose : false,
+};
+
+module.exports = (opts = {}) => {
+    const options = {
+        __proto__ : null,
+        ...DEFAULTS,
+        ...opts,
+    };
 
     if(!options.loadfn) {
         throw new Error("options.loadfn must be configured");

--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -19,20 +19,26 @@ const emptyMappings = {
     mappings : "",
 };
 
-module.exports = (opts) => {
-    const options = Object.assign(Object.create(null), {
-        common       : "common.css",
-        dev          : false,
-        json         : false,
-        meta         : false,
-        namedExports : true,
-        styleExport  : false,
-        verbose      : false,
-        empties      : true,
+const DEFAULTS = {
+    common       : "common.css",
+    dev          : false,
+    json         : false,
+    meta         : false,
+    namedExports : true,
+    styleExport  : false,
+    verbose      : false,
+    empties      : true,
 
-        // Regexp to work around https://github.com/rollup/rollup-pluginutils/issues/39
-        include : /\.css$/i,
-    }, opts);
+    // Regexp to work around https://github.com/rollup/rollup-pluginutils/issues/39
+    include : /\.css$/i,
+};
+
+module.exports = (opts = {}) => {
+    const options = {
+        __proto__ : null,
+        ...DEFAULTS,
+        ...opts,
+    };
 
     const filter = utils.createFilter(options.include, options.exclude);
 
@@ -218,11 +224,11 @@ module.exports = (opts) => {
             let mapOpt = map;
 
             if(assetFileNames.includes("[hash]") && typeof mapOpt === "object") {
-                mapOpt = Object.assign(
-                    Object.create(null),
-                    mapOpt,
-                    { annotation : false }
-                );
+                mapOpt = {
+                    __proto__  : null,
+                    ...mapOpt,
+                    annotation : false,
+                };
             }
 
             // Track specified name -> output name for writing out metadata later

--- a/packages/webpack/loader.js
+++ b/packages/webpack/loader.js
@@ -5,15 +5,21 @@ const { keyword } = require("esutils");
 
 const output = require("@modular-css/processor/lib/output.js");
 
+const DEFAULTS = {
+    styleExport   : true,
+    namedExports  : true,
+    defaultExport : true,
+};
+
 // Can't be an arrow function due to `this` usage :(
 module.exports = async function(source) {
-    const defaults  = {
-        styleExport   : true,
-        namedExports  : true,
-        defaultExport : true,
+    const options   = {
+        __proto__ : null,
+        ...DEFAULTS,
+        ...utils.getOptions(this),
     };
-    const options   = Object.assign(Object.create(null), defaults, utils.getOptions(this)) || false;
-    const done      = this.async();
+
+    const done = this.async();
     const processor = this.options ?
         // Webpack 2 & 3
         this.options.processor :

--- a/packages/webpack/plugin.js
+++ b/packages/webpack/plugin.js
@@ -16,10 +16,10 @@ const getChangedFiles = (prev, curr) =>
         );
 
 function ModularCSS(args) {
-    var options = Object.assign(
-            Object.create(null),
-            args
-        );
+    var options = {
+        __proto__ : null,
+        ...args,
+    };
 
     if(options.cjs) {
         options.namedExports = false;

--- a/packages/www/build/svelte.js
+++ b/packages/www/build/svelte.js
@@ -13,10 +13,10 @@ module.exports = async ({ file, preprocess = false }) => {
     if(preprocess) {
         const preprocessed = await svelte.preprocess(
             source,
-            Object.assign(
-                { filename : file },
-                preprocess
-            )
+            {
+                filename : file,
+                ...preprocess,
+            }
         );
 
         compiled = svelte.compile(preprocessed.toString(), { generate : "ssr" });

--- a/packages/www/src/api/usage-svelte.md
+++ b/packages/www/src/api/usage-svelte.md
@@ -51,7 +51,7 @@ const { processor, preprocess } = require("@modular-css/svelte")({
 
 const processed = await svelte.preprocess(
     fs.readFileSync(filename, "utf8"),
-    Object.assign({}, preprocess, { filename })
+    { ...preprocess, filename },
 );
 
 const result = await processor.output();
@@ -131,6 +131,14 @@ If `true` whenever a missing replacement is found like `{css.doesnotexist}` an e
 ##### `procesor`
 
 Pass a previously-created `@modular-css/processor` instance into the preprocessor. Will **not** pass through any other options to the processor if this is set, but `strict` will still be honored by the preprocessor.
+
+##### `warnOnUnused`
+
+If `true` any classes in the source CSS that aren't directly utilized by the template (or indirectly used via `composes`) will be logged out as warnings.
+
+⚠️⚡💀⚠️💀⚡⚠️
+Please note that this functionality is **EXPERIMENTAL** and subject to change. The first iteration of this feature is very basic and may lead to considerable false-positive warnings. Use your best judgement before removing CSS!
+⚠️⚡💀⚠️💀⚡⚠️
 
 ##### Shared Options
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Using `{ __proto__ : null }` and object spread everywhere.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Never liked the `Object.assign()` flow all that much, and while using it + `Object.create(null)` is technically more correct than `{ __proto__ : null }` until someone *actually deprecates* `__proto__` I think it's plenty clear and looks nicer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All tests pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
