### PR TITLE
fix: don't assume `plugin` key on messages

### DIFF
--- a/packages/processor/processor.js
+++ b/packages/processor/processor.js
@@ -404,7 +404,7 @@ class Processor {
 
                 // Export anything from plugins named "modular-css-export*"
                 result.messages.reduce((out, { plugin, exports : exported }) => {
-                    if(plugin.indexOf("modular-css-export") !== 0) {
+                    if(!plugin || plugin.indexOf("modular-css-export") !== 0) {
                         return out;
                     }
 


### PR DESCRIPTION
when passing custom plugins you may get messages that don't have this key