### PR TITLE
fix(webpack): don't try to emit if there were errors

### DIFF
--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -2,7 +2,8 @@
   "name": "@modular-css/webpack",
   "version": "25.4.1",
   "description": "Webpack support for modular-css",
-  "main": "./index.js",
+  "main": "./plugin.js",
+  "loader": "./loader.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/tivac/modular-css.git",

--- a/packages/webpack/plugin.js
+++ b/packages/webpack/plugin.js
@@ -71,7 +71,12 @@ ModularCSS.prototype.apply = function(compiler) {
         }
     });
 
-    compiler.plugin("emit", (compilation, done) =>
+    compiler.plugin("emit", (compilation, done) => {
+        // Don't even bother if errors happened
+        if(compilation.errors.length) {
+            return done();
+        }
+
         this.processor.output({
             to : this.options.css || false,
         })
@@ -103,8 +108,8 @@ ModularCSS.prototype.apply = function(compiler) {
 
             return done();
         })
-        .catch(done)
-    );
+        .catch(done);
+    });
 };
 
 module.exports = ModularCSS;

--- a/packages/webpack/test/records/parse-error.js.json
+++ b/packages/webpack/test/records/parse-error.js.json
@@ -1,0 +1,11 @@
+{
+  "modules": {
+    "byIdentifier": {},
+    "usedIds": {}
+  },
+  "chunks": {
+    "byName": {},
+    "bySource": {},
+    "usedIds": []
+  }
+}

--- a/packages/webpack/test/specimens/parse-error.css
+++ b/packages/webpack/test/specimens/parse-error.css
@@ -1,0 +1,4 @@
+// This comment should be a parsing error
+.foo {
+    color: red;
+}

--- a/packages/webpack/test/specimens/parse-error.js
+++ b/packages/webpack/test/specimens/parse-error.js
@@ -1,0 +1,1 @@
+require("./parse-error.css");

--- a/packages/webpack/test/webpack.test.js
+++ b/packages/webpack/test/webpack.test.js
@@ -61,7 +61,7 @@ describe("/webpack.js", () => {
         expect(typeof Plugin).toBe("function");
     });
 
-    it("should output css to disk", (done) => {
+    it("should output css to disk", () => new Promise((done) => {
         webpack(config({
             entry : "./packages/webpack/test/specimens/simple.js",
         }), (err, stats) => {
@@ -72,9 +72,9 @@ describe("/webpack.js", () => {
 
             done();
         });
-    });
+    }));
 
-    it("should output json to disk", (done) => {
+    it("should output json to disk", () => new Promise((done) => {
         webpack(config({
             entry  : "./packages/webpack/test/specimens/simple.js",
             plugin : {
@@ -88,9 +88,9 @@ describe("/webpack.js", () => {
 
             done();
         });
-    });
+    }));
 
-    it("should output inline source maps", (done) => {
+    it("should output inline source maps", () => new Promise((done) => {
         webpack(config({
             entry  : "./packages/webpack/test/specimens/simple.js",
             plugin : {
@@ -103,9 +103,9 @@ describe("/webpack.js", () => {
 
             done();
         });
-    });
+    }));
 
-    it("should output external source maps to disk", (done) => {
+    it("should output external source maps to disk", () => new Promise((done) => {
         webpack(config({
             entry  : "./packages/webpack/test/specimens/simple.js",
             plugin : {
@@ -120,20 +120,31 @@ describe("/webpack.js", () => {
 
             done();
         });
-    });
+    }));
 
-    // TODO: webpack is doing something weird with errors here suddenly?
-    it.skip("should report errors", (done) => {
+    it("should report modular-css errors", () => new Promise((done) => {
         webpack(config({
             entry : "./packages/webpack/test/specimens/invalid.js",
         }), (err, stats) => {
+            expect(stats.hasErrors()).toBe(true);
             expect(stats.toJson().errors[0]).toMatch("Invalid composes reference");
 
             done();
         });
-    });
+    }));
+    
+    it("should report postcss errors", () => new Promise((done) => {
+        webpack(config({
+            entry : "./packages/webpack/test/specimens/parse-error.js",
+        }), (err, stats) => {
+            expect(stats.hasErrors()).toBe(true);
+            expect(stats.toJson().errors[0]).toMatch("Unexpected '/'");
 
-    it("should report warnings on invalid property names", (done) => {
+            done();
+        });
+    }));
+
+    it("should report warnings on invalid property names", () => new Promise((done) => {
         webpack(config({
             entry : "./packages/webpack/test/specimens/invalid-name.js",
         }), (err, stats) => {
@@ -143,9 +154,9 @@ describe("/webpack.js", () => {
 
             done();
         });
-    });
+    }));
 
-    it("should handle dependencies", (done) => {
+    it("should handle dependencies", () => new Promise((done) => {
         webpack(config({
             entry  : "./packages/webpack/test/specimens/start.js",
             plugin : {
@@ -160,9 +171,9 @@ describe("/webpack.js", () => {
 
             done();
         });
-    });
+    }));
 
-    it("should support ES2015 default exports", (done) => {
+    it("should support ES2015 default exports", () => new Promise((done) => {
         webpack(config({
             entry : "./packages/webpack/test/specimens/es2015-default.js",
         }), (err, stats) => {
@@ -173,9 +184,9 @@ describe("/webpack.js", () => {
 
             done();
         });
-    });
+    }));
 
-    it("should support ES2015 named exports", (done) => {
+    it("should support ES2015 named exports", () => new Promise((done) => {
         webpack(config({
             entry : "./packages/webpack/test/specimens/es2015-named.js",
         }), (err, stats) => {
@@ -186,9 +197,9 @@ describe("/webpack.js", () => {
 
             done();
         });
-    });
+    }));
 
-    it("should support disabling namedExports when the option is set", (done) => {
+    it("should support disabling namedExports when the option is set", () => new Promise((done) => {
         webpack(config({
             entry : "./packages/webpack/test/specimens/simple.js",
             use   : {
@@ -204,9 +215,9 @@ describe("/webpack.js", () => {
 
             done();
         });
-    });
+    }));
 
-    it("should support disabling styleExport when the option is set", (done) => {
+    it("should support disabling styleExport when the option is set", () => new Promise((done) => {
         webpack(config({
             entry : "./packages/webpack/test/specimens/simple.js",
             use   : {
@@ -222,9 +233,9 @@ describe("/webpack.js", () => {
 
             done();
         });
-    });
+    }));
 
-    it("should support disabling defaultExport when the option is set", (done) => {
+    it("should support disabling defaultExport when the option is set", () => new Promise((done) => {
         webpack(config({
             entry : "./packages/webpack/test/specimens/simple.js",
             use   : {
@@ -240,9 +251,9 @@ describe("/webpack.js", () => {
 
             done();
         });
-    });
+    }));
 
-    it("should generate correct builds in watch mode when files change", (done) => {
+    it("should generate correct builds in watch mode when files change", () => new Promise((done) => {
         var changed = 0,
             compiler, watcher;
 
@@ -280,7 +291,7 @@ describe("/webpack.js", () => {
 
             return watcher.close();
         });
-    });
+    }));
 
     it("should generate correct builds when files change", () => {
         var changed = "./packages/webpack/test/output/changed.css",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Turns out that even if a loader throws an error webpack will still happily fire the `emit` event to plugins. Unclear why, but needed to add some bomb-proofing there so that `@modular-css/webpack/plugin` wouldn't try to generate output from invalid input files that had already errored out.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #724 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran tests locally, also, Travis.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

/CC @chiel