### PR TITLE
fix(svelte): case-sensitive matching on <link>

### DIFF
--- a/packages/svelte/svelte.js
+++ b/packages/svelte/svelte.js
@@ -16,7 +16,7 @@ const prefix = `[${require("./package.json").name}]`;
 
 module.exports = (config = false) => {
     // Defined here to avoid .lastIndex bugs since /g is set
-    const linkRegex = /<link\b[^<>]*?\bhref=\s*(?:"([^"]+)"|'([^']+)'|([^>\s]+))[^>]*>/gim;
+    const linkRegex = /<link\b[^<>]*?\bhref=\s*(?:"([^"]+)"|'([^']+)'|([^>\s]+))[^>]*>/gm;
 
     // Use a passed processor, or set up our own if necessary
     const { processor = new Processor(config) } = config;

--- a/packages/svelte/test/specimens/link-component.html
+++ b/packages/svelte/test/specimens/link-component.html
@@ -1,0 +1,14 @@
+<div class="{css.wrapper}">
+    <Link />
+</div>
+
+
+<style>
+    .flex {
+        display: flex;
+    }
+
+    .wrapper {
+        composes: flex;
+    }
+</style>

--- a/packages/svelte/test/svelte.test.js
+++ b/packages/svelte/test/svelte.test.js
@@ -465,4 +465,21 @@ describe("/svelte.js", () => {
         expect(warnSpy).toHaveBeenCalled();
         expect(warnSpy.mock.calls).toMatchSnapshot();
     });
+    
+    it("should ignore <Link />", async () => {
+        const filename = require.resolve("./specimens/link-component.html");
+        const { preprocess } = plugin({
+            namer,
+        });
+
+        await svelte.preprocess(
+            fs.readFileSync(filename, "utf8"),
+            {
+                ...preprocess,
+                filename,
+            },
+        );
+
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Remove the `i` flag from the regex that matches `<link>` so it can't match `<Link>`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #711 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
