### PR TITLE
feat: Support escaped characters in composed class names

### DIFF
--- a/packages/processor/test/__snapshots__/composition.test.js.snap
+++ b/packages/processor/test/__snapshots__/composition.test.js.snap
@@ -64,3 +64,12 @@ Object {
   },
 }
 `;
+
+exports[`/processor.js composition should compose with escaped classes 1`] = `
+Object {
+  "escaped-classes.css": Object {
+    "c": "sm:foo c",
+    "sm:foo": "sm:foo",
+  },
+}
+`;

--- a/packages/processor/test/composition.test.js
+++ b/packages/processor/test/composition.test.js
@@ -188,5 +188,21 @@ describe("/processor.js", () => {
 
             expect(compositions).toMatchSnapshot();
         });
+
+        it("should compose with escaped classes", async () => {
+            await processor.string(
+                "./escaped-classes.css",
+                dedent(`
+                    .sm\\:foo { color: red; }
+                    .c {
+                        composes: sm\\:foo;
+                    }
+                `)
+            );
+
+            const { compositions } = await processor.output();
+
+            expect(compositions).toMatchSnapshot();
+        });
     });
 });

--- a/parsers/shared.pegjs
+++ b/parsers/shared.pegjs
@@ -6,11 +6,33 @@ s "string"
     = "\"" chars:[^\"\r\n]* "\"" { return chars.join(""); }
     / "\'" chars:[^\'\r\n]* "\'" { return chars.join(""); }
 
+
+hex_digit
+  = [0-9a-f]i
+
+nonascii
+  = [\x80-\uFFFF]
+
+unicode
+  = "\\" digits:$(hex_digit hex_digit? hex_digit? hex_digit? hex_digit? hex_digit?) ("\r\n" / [ \t\r\n\f])? {
+      return String.fromCharCode(parseInt(digits, 16));
+    }
+
+escape
+  = unicode
+  / "\\" char:[^\r\n\f0-9a-f]i { return char; }
+
+nmchar
+  = [_a-z0-9-]i
+  / nonascii
+  / escape
+
+
 // Partials
 
 // wooga
 ident "identifier"
-    = chars:[a-z0-9-_]i+ { return chars.join(""); }
+    = chars:nmchar+ { return chars.join(""); }
 
 global_keyword "global"
     = "global"


### PR DESCRIPTION
# Description
Support for more valid classnames, helpful with tailwindCSS which uses classes like `hover:bg-red`

implementation borrowed mostly from https://github.com/pegjs/pegjs/blob/v0.10.0/examples/css.pegjs

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
