### PR TITLE
fix: remove rule if there's no other decls

### DIFF
--- a/packages/processor/plugins/composition.js
+++ b/packages/processor/plugins/composition.js
@@ -79,11 +79,15 @@ module.exports = (css, result) => {
             }
         });
 
-        const next = decl.next();
-
         // Remove just the composes declaration if there are other declarations
-        if(next) {
-            next.raws.before = decl.raw("before");
+        if(decl.parent.nodes.length > 1) {
+            // If there's nodes after this one adjust their positioning
+            // so it's like the composes was never there
+            const next = decl.next();
+        
+            if(next) {
+                next.raws.before = decl.raw("before");
+            }
 
             return decl.remove();
         }

--- a/packages/processor/test/__snapshots__/composition.test.js.snap
+++ b/packages/processor/test/__snapshots__/composition.test.js.snap
@@ -73,3 +73,26 @@ Object {
   },
 }
 `;
+
+exports[`/processor.js composition should remove \`composes\` from the output css (composes first) 1`] = `
+"/* remove-composes.css */
+.a { color: red; }
+.b { background: blue; }"
+`;
+
+exports[`/processor.js composition should remove \`composes\` from the output css (composes last) 1`] = `
+"/* remove-composes.css */
+.a { color: red; }
+.b { background: blue; }"
+`;
+
+exports[`/processor.js composition should remove \`composes\` from the output css (composes middle) 1`] = `
+"/* remove-composes.css */
+.a { color: red; }
+.b { background: blue; border-color: green; }"
+`;
+
+exports[`/processor.js composition should remove \`composes\` from the output css (only composes) 1`] = `
+"/* remove-composes.css */
+.a { color: red; }"
+`;

--- a/packages/processor/test/composition.test.js
+++ b/packages/processor/test/composition.test.js
@@ -183,7 +183,7 @@ describe("/processor.js", () => {
             expect(compositions).toMatchSnapshot();
         });
 
-        it.only.each([
+        it.each([
             [ "only composes", dedent(`
                 .a { color: red; }
                 .b { composes: a; }

--- a/packages/processor/test/composition.test.js
+++ b/packages/processor/test/composition.test.js
@@ -182,5 +182,30 @@ describe("/processor.js", () => {
 
             expect(compositions).toMatchSnapshot();
         });
+
+        it.only.each([
+            [ "only composes", dedent(`
+                .a { color: red; }
+                .b { composes: a; }
+            `) ],
+            [ "composes first", dedent(`
+                .a { color: red; }
+                .b { composes: a; background: blue; }
+            `) ],
+            [ "composes last", dedent(`
+                .a { color: red; }
+                .b { background: blue; composes: a; }
+            `) ],
+            [ "composes middle", dedent(`
+                .a { color: red; }
+                .b { background: blue; composes: a; border-color: green; }
+            `) ],
+        ])("should remove `composes` from the output css (%s)", async (name, input) => {
+            await processor.string("./remove-composes.css", input);
+
+            const { css } = await processor.output();
+
+            expect(css).toMatchSnapshot();
+        });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Only remove the entire rule if `composes` is the only declaration within it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #768

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a bunch of tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
