### PR TITLE
fix(svelte): Match missed classes to word boundaries (#780)

### DIFF
--- a/packages/svelte/svelte.js
+++ b/packages/svelte/svelte.js
@@ -53,7 +53,7 @@ module.exports = (config = false) => {
 
         // Turn all missing values into strings so nothing explodes
         return source.replace(
-            new RegExp(`(${missed.map((ref) => escape(ref)).join("|")})`, "g"),
+            new RegExp(`(\\b)(${missed.map((ref) => escape(ref)).join("|")})(\\b)`, "g"),
             (match) => JSON.stringify(match)
         );
     };

--- a/packages/svelte/test/__snapshots__/svelte.test.js.snap
+++ b/packages/svelte/test/__snapshots__/svelte.test.js.snap
@@ -241,7 +241,7 @@ exports[`/svelte.js should extract CSS from a <style> tag 2`] = `
 "
 `;
 
-exports[`/svelte.js should handle errors: empty css file - <link> 1`] = `"[@modular-css/svelte] Unable to find .nope, .alsonope in \\"./empty.css\\""`;
+exports[`/svelte.js should handle errors: empty css file - <link> 1`] = `"[@modular-css/svelte] Unable to find .nope, .nopedynope, .alsonope in \\"./empty.css\\""`;
 
 exports[`/svelte.js should handle errors: empty css file - <link> 2`] = `
 Array [
@@ -253,6 +253,11 @@ Array [
   Array [
     "[@modular-css/svelte]",
     "WARN",
+    "Unable to find .nopedynope in ./empty.css",
+  ],
+  Array [
+    "[@modular-css/svelte]",
+    "WARN",
     "Unable to find .alsonope in ./empty.css",
   ],
 ]
@@ -260,6 +265,7 @@ Array [
 
 exports[`/svelte.js should handle errors: empty css file - <link> 3`] = `
 "<div class=\\"{\\"css.nope\\"}\\">NOPE</div>
+<div class=\\"{\\"css.nopedynope\\"}\\">NOPEDY NOPE</div>
 <div class=\\"{\\"css.alsonope\\"}\\">STILL NOPE</div>
 <script>import css from \\"./empty.css\\";</script>"
 `;

--- a/packages/svelte/test/specimens/invalid-external-empty.html
+++ b/packages/svelte/test/specimens/invalid-external-empty.html
@@ -1,4 +1,5 @@
 <link rel="stylesheet" href="./empty.css" />
 
 <div class="{css.nope}">NOPE</div>
+<div class="{css.nopedynope}">NOPEDY NOPE</div>
 <div class="{css.alsonope}">STILL NOPE</div>

--- a/packages/svelte/test/svelte.test.js
+++ b/packages/svelte/test/svelte.test.js
@@ -480,7 +480,7 @@ describe("/svelte.js", () => {
         expect(warnSpy).toHaveBeenCalled();
         expect(warnSpy.mock.calls).toMatchSnapshot();
     });
-    
+
     it("should ignore <Link />", async () => {
         const filename = require.resolve("./specimens/link-component.html");
         const { preprocess } = plugin({


### PR DESCRIPTION
## Description
 + Modify existing test against empty css files to also test against this - I am happy to split this into its own test if that is preferred.
 + Add word boundary (`\b`) selectors to ensure that we don't have collisions of advancingly specific class names when they are all undefined (for example, if you had both `.foo` and `.foobar` referenced in template, yet both are undefined in css, that will cause this error).

## Motivation and Context
https://github.com/tivac/modular-css/issues/780

## How Has This Been Tested?
test added.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)