### PR TITLE
fix(vite): non-win32 file resolution

### DIFF
--- a/packages/vite/vite.js
+++ b/packages/vite/vite.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const fs = require("fs/promises");
 const path = require("path");
 
 const utils = require("@rollup/pluginutils");

--- a/packages/vite/vite.js
+++ b/packages/vite/vite.js
@@ -32,24 +32,6 @@ const virtualize = (file) => `${file}?${CSS_QUERY}`;
 const devirtualize = (file) => `${file.split("?")[0]}`;
 const isVirtual = (file) => file.endsWith(`?${CSS_QUERY}`);
 
-// NOTE: Can't use basic isAbsolute check because of paths vite passes in. On windows they can be
-// "/foo/bar/baz.mcss" which isAbsolute will treat as absolute, even though it definitely isn't
-// And on linux they're absolute-looking but actually local?
-const isPartial = async (file) => {
-    try {
-        await fs.stat(path.join(process.cwd(), file));
-
-        return true;
-    } catch(e) {
-        // NO-OP
-    }
-
-    return (process.platform !== "win32" ?
-        !path.isAbsolute(file) :
-        path.parse(file).root === "/"
-    );
-};
-
 module.exports = (
     /* istanbul ignore next: too painful to test */
     pluginOptions = {}
@@ -105,6 +87,7 @@ module.exports = (
         },
 
         async resolveId(source) {
+            // Only care about our particular type of virtual file
             if(!isVirtual(source)) {
                 return null;
             }
@@ -112,10 +95,17 @@ module.exports = (
             log("resolving", source);
 
             let resolved = source;
-            const file = devirtualize(resolved);
+            
+            // Check file as passed (minus the query params)
+            if(processor.has(devirtualize(resolved))) {
+                return resolved;
+            }
 
-            if(await isPartial(file)) {
-                resolved = path.join(process.cwd(), resolved);
+            resolved = path.join(process.cwd(), resolved);
+
+            // Check file as an asbolute path (minus the query params)
+            if(!processor.has(devirtualize(resolved))) {
+                return null;
             }
 
             resolved = slash(resolved);
@@ -138,13 +128,7 @@ module.exports = (
 
             const file = devirtualize(id);
 
-            // if(await isPartial(file)) {
-            //     file = path.join(process.cwd(), file);
-            // }
-
             if(!processor.has(file)) {
-                log("no loading", file);
-
                 return null;
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed `resolveId` hook in the vite plugin to properly resolve files, so that `load` hook doesn't need to duplicate the work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`@modular-css/vite` didn't work when serving on non-win32 platforms due to vite file resolution sending in both absolute files as well as relative files that *look* absolute (like `/src/bar.mcss`). vite plugin had logic to handle that, but it didn't work quite right.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run both m-css.com and the vite-mcss-tester repo against this new code in win32 & Ubuntu (via WSL2)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
