### PR TITLE
fix(rollup): generated JS always uses clean names

### DIFF
--- a/packages/rollup/rollup.js
+++ b/packages/rollup/rollup.js
@@ -8,7 +8,7 @@ const utils = require("@rollup/pluginutils");
 const Processor = require("@modular-css/processor");
 const output = require("@modular-css/processor/lib/output.js");
 const relative = require("@modular-css/processor/lib/relative.js");
-const { transform } = require("@modular-css/css-to-js");
+const { reset, transform } = require("@modular-css/css-to-js");
 
 const DEFAULT_EXT = ".css";
 
@@ -73,6 +73,8 @@ module.exports = (
 
         buildStart() {
             log("build start");
+
+            reset();
 
             if(!options.namedExports) {
                 this.warn("@modular-css/rollup doesn't allow namedExports to be disabled");

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`/rollup.js  Exports option should generated valid JS even when identifiers aren't 1`] = `
+exports[`/rollup.js Exports option should generated valid JS even when identifiers aren't 1`] = `
 Object {
   "entry": "
 const fooBar = \\"mc_foo-bar\\";
@@ -15,7 +15,7 @@ console.log(style);
 }
 `;
 
-exports[`/rollup.js  Exports option should provide named exports by default 1`] = `
+exports[`/rollup.js Exports option should provide named exports by default 1`] = `
 Object {
   "named": "
 const a = \\"mc_a\\";
@@ -25,7 +25,7 @@ console.log(a);
 }
 `;
 
-exports[`/rollup.js  Exports option should warn & ignore invalid identifiers (namedExports.rewriteInvalid = false) 1`] = `
+exports[`/rollup.js Exports option should warn & ignore invalid identifiers (namedExports.rewriteInvalid = false) 1`] = `
 Object {
   "code": "PLUGIN_WARNING",
   "hook": "transform",
@@ -36,7 +36,7 @@ Object {
 }
 `;
 
-exports[`/rollup.js  Exports option should warn & ignore invalid identifiers (namedExports.rewriteInvalid = false) 2`] = `
+exports[`/rollup.js Exports option should warn & ignore invalid identifiers (namedExports.rewriteInvalid = false) 2`] = `
 Object {
   "invalid-name": "
 const fooga = \\"mc_fooga\\";
@@ -51,7 +51,7 @@ console.log(css, fooga);
 }
 `;
 
-exports[`/rollup.js  Exports option should warn & rewrite invalid identifiers (namedExports.rewriteInvalid = true) 1`] = `
+exports[`/rollup.js Exports option should warn & rewrite invalid identifiers (namedExports.rewriteInvalid = true) 1`] = `
 Object {
   "code": "PLUGIN_WARNING",
   "hook": "transform",
@@ -62,7 +62,7 @@ Object {
 }
 `;
 
-exports[`/rollup.js  Exports option should warn & rewrite invalid identifiers (namedExports.rewriteInvalid = true) 2`] = `
+exports[`/rollup.js Exports option should warn & rewrite invalid identifiers (namedExports.rewriteInvalid = true) 2`] = `
 Object {
   "invalid-name": "
 const fooga = \\"mc_fooga\\";
@@ -77,7 +77,7 @@ console.log(css, fooga);
 }
 `;
 
-exports[`/rollup.js  Exports option should warn if named exports are falsey 1`] = `
+exports[`/rollup.js Exports option should warn if named exports are falsey 1`] = `
 Array [
   Array [
     "@modular-css/rollup doesn't allow namedExports to be disabled",

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -1,5 +1,90 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`/rollup.js  Exports option should generated valid JS even when identifiers aren't 1`] = `
+Object {
+  "entry": "
+const fooBar = \\"mc_foo-bar\\";
+
+const out = fooBar + \\" \\" + \\"mc_out\\";
+var style = {
+    out
+};
+
+console.log(style);
+",
+}
+`;
+
+exports[`/rollup.js  Exports option should provide named exports by default 1`] = `
+Object {
+  "named": "
+const a = \\"mc_a\\";
+
+console.log(a);
+",
+}
+`;
+
+exports[`/rollup.js  Exports option should warn & ignore invalid identifiers (namedExports.rewriteInvalid = false) 1`] = `
+Object {
+  "code": "PLUGIN_WARNING",
+  "hook": "transform",
+  "id": Any<String>,
+  "message": "\\"fooga-wooga\\" is not a valid JS identifier",
+  "plugin": "@modular-css/rollup",
+  "toString": [Function],
+}
+`;
+
+exports[`/rollup.js  Exports option should warn & ignore invalid identifiers (namedExports.rewriteInvalid = false) 2`] = `
+Object {
+  "invalid-name": "
+const fooga = \\"mc_fooga\\";
+const foogaWooga = \\"mc_fooga-wooga\\";
+var css = {
+    fooga,
+\\"fooga-wooga\\" : foogaWooga
+};
+
+console.log(css, fooga);
+",
+}
+`;
+
+exports[`/rollup.js  Exports option should warn & rewrite invalid identifiers (namedExports.rewriteInvalid = true) 1`] = `
+Object {
+  "code": "PLUGIN_WARNING",
+  "hook": "transform",
+  "id": Any<String>,
+  "message": "\\"fooga-wooga\\" is not a valid JS identifier, exported as \\"foogaWooga\\"",
+  "plugin": "@modular-css/rollup",
+  "toString": [Function],
+}
+`;
+
+exports[`/rollup.js  Exports option should warn & rewrite invalid identifiers (namedExports.rewriteInvalid = true) 2`] = `
+Object {
+  "invalid-name": "
+const fooga = \\"mc_fooga\\";
+const foogaWooga = \\"mc_fooga-wooga\\";
+var css = {
+    fooga,
+\\"fooga-wooga\\" : foogaWooga
+};
+
+console.log(css, fooga);
+",
+}
+`;
+
+exports[`/rollup.js  Exports option should warn if named exports are falsey 1`] = `
+Array [
+  Array [
+    "@modular-css/rollup doesn't allow namedExports to be disabled",
+  ],
+]
+`;
+
 exports[`/rollup.js dev mode option should output a proxy 1`] = `
 Object {
   "simple": "
@@ -73,76 +158,6 @@ Object {
     }
 }",
 }
-`;
-
-exports[`/rollup.js namedExports option should provide named exports by default 1`] = `
-Object {
-  "named": "
-const a = \\"mc_a\\";
-
-console.log(a);
-",
-}
-`;
-
-exports[`/rollup.js namedExports option should warn & ignore invalid identifiers (namedExports.rewriteInvalid = false) 1`] = `
-Object {
-  "code": "PLUGIN_WARNING",
-  "hook": "transform",
-  "id": Any<String>,
-  "message": "\\"fooga-wooga\\" is not a valid JS identifier",
-  "plugin": "@modular-css/rollup",
-  "toString": [Function],
-}
-`;
-
-exports[`/rollup.js namedExports option should warn & ignore invalid identifiers (namedExports.rewriteInvalid = false) 2`] = `
-Object {
-  "invalid-name": "
-const fooga = \\"mc_fooga\\";
-const foogaWooga = \\"mc_fooga-wooga\\";
-var css = {
-    fooga,
-\\"fooga-wooga\\" : foogaWooga
-};
-
-console.log(css, fooga);
-",
-}
-`;
-
-exports[`/rollup.js namedExports option should warn & rewrite invalid identifiers (namedExports.rewriteInvalid = true) 1`] = `
-Object {
-  "code": "PLUGIN_WARNING",
-  "hook": "transform",
-  "id": Any<String>,
-  "message": "\\"fooga-wooga\\" is not a valid JS identifier, exported as \\"foogaWooga\\"",
-  "plugin": "@modular-css/rollup",
-  "toString": [Function],
-}
-`;
-
-exports[`/rollup.js namedExports option should warn & rewrite invalid identifiers (namedExports.rewriteInvalid = true) 2`] = `
-Object {
-  "invalid-name": "
-const fooga = \\"mc_fooga\\";
-const foogaWooga = \\"mc_fooga-wooga\\";
-var css = {
-    fooga,
-\\"fooga-wooga\\" : foogaWooga
-};
-
-console.log(css, fooga);
-",
-}
-`;
-
-exports[`/rollup.js namedExports option should warn if named exports are falsey 1`] = `
-Array [
-  Array [
-    "@modular-css/rollup doesn't allow namedExports to be disabled",
-  ],
-]
 `;
 
 exports[`/rollup.js processor option should accept an existing processor instance (no css in bundle) 1`] = `

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -509,6 +509,8 @@ describe("/rollup.js", () => {
         });
 
         it("should generated valid JS even when identifiers aren't", async () => {
+            logspy("warn");
+
             const bundle = await rollup({
                 input   : require.resolve("./specimens/composes-from-invalid-js/entry.js"),
                 plugins : [

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -435,7 +435,7 @@ describe("/rollup.js", () => {
         });
     });
 
-    describe("namedExports option", () => {
+    describe(" Exports option", () => {
         it("should provide named exports by default", async () => {
             const bundle = await rollup({
                 input   : require.resolve("./specimens/named.js"),
@@ -506,6 +506,21 @@ describe("/rollup.js", () => {
             });
 
             expect(spy).toMatchLogspySnapshot();
+        });
+
+        it.only("should generated valid JS even when identifiers aren't", async () => {
+            const bundle = await rollup({
+                input   : require.resolve("./specimens/composes-from-invalid-js/entry.js"),
+                plugins : [
+                    createPlugin(),
+                ],
+            });
+
+            expect(
+                await bundle.generate({
+                    format,
+                })
+            ).toMatchRollupCodeSnapshot();
         });
     });
 

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -435,7 +435,7 @@ describe("/rollup.js", () => {
         });
     });
 
-    describe(" Exports option", () => {
+    describe("Exports option", () => {
         it("should provide named exports by default", async () => {
             const bundle = await rollup({
                 input   : require.resolve("./specimens/named.js"),
@@ -508,7 +508,7 @@ describe("/rollup.js", () => {
             expect(spy).toMatchLogspySnapshot();
         });
 
-        it.only("should generated valid JS even when identifiers aren't", async () => {
+        it("should generated valid JS even when identifiers aren't", async () => {
             const bundle = await rollup({
                 input   : require.resolve("./specimens/composes-from-invalid-js/entry.js"),
                 plugins : [

--- a/packages/rollup/test/specimens/composes-from-invalid-js/entry.js
+++ b/packages/rollup/test/specimens/composes-from-invalid-js/entry.js
@@ -1,0 +1,3 @@
+import style from "./one.css";
+
+console.log(style);

--- a/packages/rollup/test/specimens/composes-from-invalid-js/one.css
+++ b/packages/rollup/test/specimens/composes-from-invalid-js/one.css
@@ -1,0 +1,3 @@
+.out {
+    composes: foo-bar from "./two.css";
+}

--- a/packages/rollup/test/specimens/composes-from-invalid-js/two.css
+++ b/packages/rollup/test/specimens/composes-from-invalid-js/two.css
@@ -1,0 +1,3 @@
+.foo-bar {
+    color: salmon;
+}

--- a/packages/vite/vite.js
+++ b/packages/vite/vite.js
@@ -6,7 +6,7 @@ const utils = require("@rollup/pluginutils");
 const dedent = require("dedent");
 
 const Processor = require("@modular-css/processor");
-const { transform } = require("@modular-css/css-to-js");
+const { reset, transform } = require("@modular-css/css-to-js");
 
 const { fileKey, filterByPrefix, FILE_PREFIX } = Processor;
 
@@ -80,6 +80,8 @@ module.exports = (
 
         buildStart() {
             log("build start");
+
+            reset();
 
             // Watch any files already in the procesor
             Object.keys(processor.files).forEach((file) => this.addWatchFile(file));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding in an extra layer of tracking of renamed/uniqued variables so that they're always used instead of raw classnames, for instances where that isn't a valid JS identifier that can be safely exported/imported.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #846 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Wrote tests for it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
