### PR TITLE
fix: don't move composed classes early

### DIFF
--- a/packages/css-to-js/css-to-js.js
+++ b/packages/css-to-js/css-to-js.js
@@ -108,14 +108,8 @@ exports.transform = (file, processor, opts = {}) => {
 
         const imported = importsMap.get(depFile);
 
-        // File we're transforming
+        // Local deps are ignored at this point
         if(depFile === id) {
-            // Track this selector as part of the keys to be exported, adding
-            // here so it'll be sorted topologically
-            if(isSelector(depKey)) {
-                exportedKeys.add(data.selector);
-            }
-
             return;
         }
 

--- a/packages/css-to-js/css-to-js.js
+++ b/packages/css-to-js/css-to-js.js
@@ -26,7 +26,6 @@ const DEFAULTS = {
 const {
     selectorKey,
     isFile,
-    isSelector,
     isValue,
 } = Processor;
 

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -268,6 +268,35 @@ Object {
 }
 `;
 
+exports[`/rollup.js should express local & remote-composed classes correctly 1`] = `
+Object {
+  "assets/multiple-composition-b50d9a50.css": "
+/* packages/rollup/test/specimens/multiple-composition/other.css */
+.mc_other {
+    color: green;
+}
+/* packages/rollup/test/specimens/multiple-composition/multiple-composition.css */
+.mc_one {
+    color: red;
+}
+.mc_two {
+    background: blue;
+}",
+  "multiple-composition.js": "
+const other = \\"mc_other\\";
+
+const one = \\"mc_one\\";
+const two = other + \\" \\" + one + \\" \\" + \\"mc_two\\";
+var css = {
+    two,
+one
+};
+
+console.log(css);
+",
+}
+`;
+
 exports[`/rollup.js should express locally-composed classes correctly 1`] = `
 Object {
   "assets/local-composition-1485bb4a.css": "

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -288,8 +288,8 @@ const other = \\"mc_other\\";
 const one = \\"mc_one\\";
 const two = other + \\" \\" + one + \\" \\" + \\"mc_two\\";
 var css = {
-    two,
-one
+    one,
+two
 };
 
 console.log(css);

--- a/packages/rollup/test/__snapshots__/rollup.test.js.snap
+++ b/packages/rollup/test/__snapshots__/rollup.test.js.snap
@@ -270,7 +270,7 @@ Object {
 
 exports[`/rollup.js should express local & remote-composed classes correctly 1`] = `
 Object {
-  "assets/multiple-composition-b50d9a50.css": "
+  "assets/multiple-composition.css": "
 /* packages/rollup/test/specimens/multiple-composition/other.css */
 .mc_other {
     color: green;
@@ -299,7 +299,7 @@ console.log(css);
 
 exports[`/rollup.js should express locally-composed classes correctly 1`] = `
 Object {
-  "assets/local-composition-1485bb4a.css": "
+  "assets/local-composition.css": "
 /* packages/rollup/test/specimens/local-composition.css */
 .mc_one {
     color: red;

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -51,6 +51,7 @@ describe("/rollup.js", () => {
         expect(
             await bundle.generate({
                 format,
+                assetFileNames,
             })
         ).toMatchRollupCodeSnapshot();
     });
@@ -66,6 +67,7 @@ describe("/rollup.js", () => {
         expect(
             await bundle.generate({
                 format,
+                assetFileNames,
             })
         ).toMatchRollupSnapshot();
     });
@@ -81,6 +83,7 @@ describe("/rollup.js", () => {
         expect(
             await bundle.generate({
                 format,
+                assetFileNames,
             })
         ).toMatchRollupSnapshot();
     });
@@ -96,6 +99,7 @@ describe("/rollup.js", () => {
         expect(
             await bundle.generate({
                 format,
+                assetFileNames,
             })
         ).toMatchRollupCodeSnapshot();
     });

--- a/packages/rollup/test/rollup.test.js
+++ b/packages/rollup/test/rollup.test.js
@@ -70,6 +70,21 @@ describe("/rollup.js", () => {
         ).toMatchRollupSnapshot();
     });
 
+    it("should express local & remote-composed classes correctly", async () => {
+        const bundle = await rollup({
+            input   : require.resolve(`./specimens/multiple-composition/multiple-composition.js`),
+            plugins : [
+                createPlugin(),
+            ],
+        });
+
+        expect(
+            await bundle.generate({
+                format,
+            })
+        ).toMatchRollupSnapshot();
+    });
+
     it("should be able to tree-shake results", async () => {
         const bundle = await rollup({
             input   : require.resolve("./specimens/tree-shaking.js"),

--- a/packages/rollup/test/specimens/multiple-composition/multiple-composition.css
+++ b/packages/rollup/test/specimens/multiple-composition/multiple-composition.css
@@ -1,0 +1,10 @@
+.one {
+    color: red;
+}
+
+.two {
+    composes: other from "./other.css";
+    composes: one;
+
+    background: blue;
+}

--- a/packages/rollup/test/specimens/multiple-composition/multiple-composition.js
+++ b/packages/rollup/test/specimens/multiple-composition/multiple-composition.js
@@ -1,0 +1,3 @@
+import css from "./multiple-composition.css";
+
+console.log(css);

--- a/packages/rollup/test/specimens/multiple-composition/other.css
+++ b/packages/rollup/test/specimens/multiple-composition/other.css
@@ -1,0 +1,3 @@
+.other {
+    color: green;
+}


### PR DESCRIPTION
Because it can cause invalid output if they get moved ahead of their dependencies, and we don't need to handle them at this point anyways.