### PR TITLE
fix: always use normalized path

### DIFF
--- a/.changeset/old-bugs-sell.md
+++ b/.changeset/old-bugs-sell.md
@@ -1,0 +1,7 @@
+---
+"@modular-css/css-to-js": patch
+---
+
+Always use absolute paths internally
+
+Previously `@modular-css/css-to-js` would use the path as passed to it, which could cause issues with bundlers that passed relative paths (usually because of the use of aliases). Since the module already had to normalize paths to be absolute it will now use those absolute paths internally when looking up information from the `Processor` instance.

--- a/packages/css-to-js/css-to-js.js
+++ b/packages/css-to-js/css-to-js.js
@@ -69,7 +69,7 @@ exports.transform = (file, processor, opts = {}) => {
     const { graph } = processor;
 
     const id = processor.normalize(file);
-    const details = processor.files[file];
+    const details = processor.files[id];
 
     const warnings = [];
     const dependencies = new Set();

--- a/packages/css-to-js/test/api.test.js
+++ b/packages/css-to-js/test/api.test.js
@@ -37,7 +37,7 @@ describe("@modular-css/css-to-js API", () => {
 
         await processor.string("./a.css", `.a { color: red; }`);
 
-        const { code, namedExports } = transform(processor.normalize("./a.css"), processor);
+        const { code, namedExports } = transform("./a.css", processor);
 
         expect(code).toMatchSnapshot("code");
         expect(namedExports).toEqual([ "a" ]);
@@ -48,7 +48,7 @@ describe("@modular-css/css-to-js API", () => {
 
         await processor.string("./a.css", `.a { color: red; }`);
 
-        const { code } = transform(processor.normalize("./a.css"), processor, { dev : true });
+        const { code } = transform("./a.css", processor, { dev : true });
 
         expect(code).toMatchSnapshot("code");
     });
@@ -70,7 +70,7 @@ describe("@modular-css/css-to-js API", () => {
 
         await processor.string("./a.css", `.a { color: blue; } .b { composes: a; }`);
 
-        const { code, namedExports } = transform(processor.normalize("./a.css"), processor);
+        const { code, namedExports } = transform("./a.css", processor);
 
         expect(code).toMatchSnapshot("code");
         expect(namedExports).toEqual([ "a", "b" ]);
@@ -83,7 +83,7 @@ describe("@modular-css/css-to-js API", () => {
 
         await processor.string("./b.css", `.b { composes: a from "./a.css"; color: blue; }`);
 
-        const { code, namedExports } = transform(processor.normalize("./b.css"), processor);
+        const { code, namedExports } = transform("./b.css", processor);
 
         expect(code).toMatchSnapshot("code");
         expect(namedExports).toEqual([ "b" ]);
@@ -96,7 +96,7 @@ describe("@modular-css/css-to-js API", () => {
 
         await processor.string("./b.css", `.b { composes: a from "./a.css"; color: blue; }`);
 
-        const { code, namedExports } = transform(processor.normalize("./b.css"), processor, { relativeImports : true });
+        const { code, namedExports } = transform("./b.css", processor, { relativeImports : true });
 
         expect(code).toMatchSnapshot("code");
         expect(namedExports).toEqual([ "b" ]);
@@ -107,7 +107,7 @@ describe("@modular-css/css-to-js API", () => {
 
         await processor.string("./a.css", `.a { color: red; }`);
 
-        const { code, namedExports } = transform(processor.normalize("./a.css"), processor, { styleExport : true });
+        const { code, namedExports } = transform("./a.css", processor, { styleExport : true });
 
         expect(code).toMatchSnapshot("code");
         expect(namedExports).toEqual([ "a" ]);
@@ -119,7 +119,7 @@ describe("@modular-css/css-to-js API", () => {
         await processor.string("./a.css", `.a { color: red; }`);
         await processor.string("./b.css", `.a { composes: a from "./a.css"; color: blue; }`);
 
-        const { code, namedExports } = transform(processor.normalize("./b.css"), processor);
+        const { code, namedExports } = transform("./b.css", processor);
 
         expect(code).toMatchSnapshot("code");
         expect(namedExports).toEqual([ "a1 as a" ]);
@@ -130,7 +130,7 @@ describe("@modular-css/css-to-js API", () => {
 
         await processor.string("./a.css", `@value v: #00F; .a { color: v; }`);
 
-        const { code, namedExports } = transform(processor.normalize("./a.css"), processor);
+        const { code, namedExports } = transform("./a.css", processor);
 
         expect(code).toMatchSnapshot("code");
         expect(namedExports).toEqual([ "$values", "a" ]);
@@ -142,7 +142,7 @@ describe("@modular-css/css-to-js API", () => {
         await processor.string("./a.css", `@value v: #00F;`);
         await processor.string("./b.css", `@value v from "./a.css"; .b { color: v; }`);
 
-        const { code, namedExports } = transform(processor.normalize("./b.css"), processor);
+        const { code, namedExports } = transform("./b.css", processor);
 
         expect(code).toMatchSnapshot("code");
         expect(namedExports).toEqual([ "$values", "b" ]);
@@ -163,7 +163,7 @@ describe("@modular-css/css-to-js API", () => {
             }
         `));
 
-        const { code, namedExports } = transform(processor.normalize("./b.css"), processor);
+        const { code, namedExports } = transform("./b.css", processor);
 
         expect(code).toMatchSnapshot("code");
         expect(namedExports).toEqual([ "$values", "b" ]);
@@ -181,7 +181,7 @@ describe("@modular-css/css-to-js API", () => {
 
         await processor.string("./a.css", `.a-1 { color: red; }`);
 
-        const { code, namedExports : exported, warnings } = transform(processor.normalize("./a.css"), processor, { namedExports });
+        const { code, namedExports : exported, warnings } = transform("./a.css", processor, { namedExports });
 
         expect(code).toMatchSnapshot("code");
         expect(warnings).toMatchSnapshot("warnings");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since the module already had to normalize paths to be absolute it will now use those absolute paths internally when looking up information from the `Processor` instance.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously `@modular-css/css-to-js` would use the path as passed to it, which could cause issues with bundlers that passed relative paths (usually because of the use of aliases). 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
