### PR TITLE
Improve consistency of composition map

### DIFF
--- a/.changeset/giant-garlics-worry.md
+++ b/.changeset/giant-garlics-worry.md
@@ -1,0 +1,5 @@
+---
+"@modular-css/processor": patch
+---
+
+Improve consistency of composition map by ensuring that both forms of `composes` declaration correctly order the classes.

--- a/packages/processor/processor.js
+++ b/packages/processor/processor.js
@@ -493,11 +493,14 @@ class Processor {
 
         this._addSelector(name, selector);
 
-        refs.forEach(({ name : depSelector }) => {
+        // Loops backwards to keep order of classes consistent with a composition splitted into multiple `composes` declarations.
+        refs.reduceRight((_, { name : depSelector }) => {
             const depSelectorId = this._addSelector(dep, depSelector);
 
             graph.addDependency(selectorId, depSelectorId);
-        });
+
+            return null;
+        }, null);
     }
 
     // Take a file id and some text, walk it for dependencies, then

--- a/packages/processor/test/__snapshots__/api.test.js.snap
+++ b/packages/processor/test/__snapshots__/api.test.js.snap
@@ -231,6 +231,7 @@ exports[`/processor.js API .output() should order output by dependencies, then a
 .mc_folder { margin: 2px; }
 /* packages/processor/test/specimens/folder/folder2.css */
 .mc_folder2 { color: green; }
+.mc_foo { display: block; }
 /* packages/processor/test/specimens/folder/subfolder/subfolder.css */
 .mc_subfolder { color: yellow; }
 /* packages/processor/test/specimens/composes.css */

--- a/packages/processor/test/__snapshots__/composition.test.js.snap
+++ b/packages/processor/test/__snapshots__/composition.test.js.snap
@@ -75,8 +75,8 @@ exports[`/processor.js composition should compose from other files in multiple d
 Object {
   "packages/processor/test/specimens/composes2.css": Object {
     "composes": Array [
-      "mc_foo",
       "mc_folder2",
+      "mc_foo",
       "mc_composes",
     ],
   },
@@ -95,8 +95,8 @@ exports[`/processor.js composition should compose from other files in single dec
 Object {
   "packages/processor/test/specimens/composes.css": Object {
     "composes": Array [
-      "mc_foo",
       "mc_folder2",
+      "mc_foo",
       "mc_composes",
     ],
   },

--- a/packages/processor/test/__snapshots__/composition.test.js.snap
+++ b/packages/processor/test/__snapshots__/composition.test.js.snap
@@ -71,10 +71,11 @@ Object {
 }
 `;
 
-exports[`/processor.js composition should compose from other files 1`] = `
+exports[`/processor.js composition should compose from other files in multiple declarations 1`] = `
 Object {
-  "packages/processor/test/specimens/composes.css": Object {
+  "packages/processor/test/specimens/composes2.css": Object {
     "composes": Array [
+      "mc_foo",
       "mc_folder2",
       "mc_composes",
     ],
@@ -82,6 +83,29 @@ Object {
   "packages/processor/test/specimens/folder/folder2.css": Object {
     "folder2": Array [
       "mc_folder2",
+    ],
+    "foo": Array [
+      "mc_foo",
+    ],
+  },
+}
+`;
+
+exports[`/processor.js composition should compose from other files in single declaration 1`] = `
+Object {
+  "packages/processor/test/specimens/composes.css": Object {
+    "composes": Array [
+      "mc_foo",
+      "mc_folder2",
+      "mc_composes",
+    ],
+  },
+  "packages/processor/test/specimens/folder/folder2.css": Object {
+    "folder2": Array [
+      "mc_folder2",
+    ],
+    "foo": Array [
+      "mc_foo",
     ],
   },
 }

--- a/packages/processor/test/composition.test.js
+++ b/packages/processor/test/composition.test.js
@@ -182,8 +182,16 @@ describe("/processor.js", () => {
             expect(compositions).toMatchSnapshot();
         });
 
-        it("should compose from other files", async () => {
+        it("should compose from other files in single declaration", async () => {
             await processor.file(require.resolve("./specimens/composes.css"));
+
+            const { compositions } = await processor.output();
+
+            expect(compositions).toMatchSnapshot();
+        });
+
+        it("should compose from other files in multiple declarations", async () => {
+            await processor.file(require.resolve("./specimens/composes2.css"));
 
             const { compositions } = await processor.output();
 

--- a/packages/processor/test/specimens/composes.css
+++ b/packages/processor/test/specimens/composes.css
@@ -1,3 +1,3 @@
 .composes {
-    composes: folder2 from "./folder/folder2.css";
+    composes: folder2, foo from "./folder/folder2.css";
 }

--- a/packages/processor/test/specimens/composes2.css
+++ b/packages/processor/test/specimens/composes2.css
@@ -1,0 +1,4 @@
+.composes {
+    composes: folder2 from "./folder/folder2.css";
+    composes: foo from "./folder/folder2.css";
+}

--- a/packages/processor/test/specimens/folder/folder2.css
+++ b/packages/processor/test/specimens/folder/folder2.css
@@ -1,1 +1,2 @@
 .folder2 { color: green; }
+.foo { display: block; }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently a technically the same composition of multiple classes from other file gives slightly different composition information depending on how it has been declared.

<details>
<summary>Multiple composes</summary>

```css
// composes.css
.class {
  composes: someDep from 'lib';
  composes: anotherDep from 'lib';
}
```
give
```json
"composes.css": {
  "composes": [
    "anotherDep",
    "someDep",
    "class",
  ],
```
</details>

<details>
<summary>Single compose</summary>

```css
// composes.css
.class {
  composes: someDep, anotherDep from 'lib';
}
```
gives 
```diff
"composes.css": {
  "composes": [
-  "anotherDep",
    "someDep",
+   "anotherDep",
    "class",
  ],
```
</details>


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For sake of consistency. It gives an idea of order in which classes have been declared and it can be used for post-processing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests have been updated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
