### PR TITLE
[css-to-js] Invalid JS when mixing rules with composes

### DIFF
--- a/.changeset/warm-dryers-thank.md
+++ b/.changeset/warm-dryers-thank.md
@@ -1,0 +1,5 @@
+---
+"@modular-css/css-to-js": patch
+---
+
+Class ordering in `.css` files could lead to invalid identifiers being created, so always make sure every class defined in the `.css` file has a local JS identifier before building the string concatenation to represent composition.

--- a/packages/css-to-js/css-to-js.js
+++ b/packages/css-to-js/css-to-js.js
@@ -227,13 +227,18 @@ exports.transform = (file, processor, opts = {}) => {
         namedExports.push(esm(unique, DEFAULT_VALUES));
     }
 
+    // Collect local exports first
+    exportedKeys.forEach((key) => {
+        const unique = deconflict(identifiers, key);
+
+        internalsMap.set(key, unique);
+    });
+
     // Create vars representing exported classes & use them in local var definitions
     exportedKeys.forEach((key) => {
         const elements = [];
-        const unique = deconflict(identifiers, key);
         const sKey = selectorKey(id, key);
-
-        internalsMap.set(key, unique);
+        const unique = internalsMap.get(key);
 
         // Build the list of composed classes for this class
         if(graph.hasNode(sKey)) {

--- a/packages/css-to-js/test/__snapshots__/api.test.js.snap
+++ b/packages/css-to-js/test/__snapshots__/api.test.js.snap
@@ -43,6 +43,34 @@ Array [
 ]
 `;
 
+exports[`@modular-css/css-to-js API should generate javascript from composes: code 1`] = `
+const custom = "mca72bf2bd_custom"
+const rule = custom + " " + "mca72bf2bd_rule"
+export default {
+    custom,
+rule
+};
+
+export {
+    custom,
+rule
+};
+`;
+
+exports[`@modular-css/css-to-js API should generate javascript from multiple composes: code 1`] = `
+const rule = custom + " " + "mc9c938a76_rule"
+const custom = "mc9c938a76_custom"
+export default {
+    rule,
+custom
+};
+
+export {
+    rule,
+custom
+};
+`;
+
 exports[`@modular-css/css-to-js API should generate javascript: code 1`] = `
 const a = "mc74f3fa7b_a"
 export default {

--- a/packages/css-to-js/test/api.test.js
+++ b/packages/css-to-js/test/api.test.js
@@ -168,6 +168,27 @@ describe("@modular-css/css-to-js API", () => {
         expect(namedExports).toEqual([ "$values", "b" ]);
     });
 
+
+    it("should generate javascript from composes", async () => {
+        const processor = new Processor({ resolvers });
+
+        await processor.file(require.resolve("./specimens/composes/custom-first-rule.css"));
+
+        const { code } = transform(require.resolve("./specimens/composes/custom-first-rule.css"), processor);
+
+        expect(code).toMatchSnapshot("code");
+    });
+
+    it("should generate javascript from multiple composes", async () => {
+        const processor = new Processor({ resolvers });
+
+        await processor.file(require.resolve("./specimens/composes/custom-between-rules.css"));
+
+        const { code } = transform(require.resolve("./specimens/composes/custom-between-rules.css"), processor);
+
+        expect(code).toMatchSnapshot("code");
+    });
+
     it.each([
         true,
         false,

--- a/packages/css-to-js/test/api.test.js
+++ b/packages/css-to-js/test/api.test.js
@@ -20,10 +20,7 @@ expect.addSnapshotSerializer({
 });
 
 const resolvers = [
-    (src, file) =>
-        // console.log({ src, file, result : path.join(path.dirname(src), file) });
-        
-         path.join(path.dirname(src), file),
+    (src, file) => path.join(path.dirname(src), file),
 ];
 
 describe("@modular-css/css-to-js API", () => {

--- a/packages/css-to-js/test/specimens/composes/custom-between-rules.css
+++ b/packages/css-to-js/test/specimens/composes/custom-between-rules.css
@@ -1,0 +1,9 @@
+.rule { 
+  display: flex;
+}
+.custom {
+  color: pink;
+}
+.rule {
+  composes: custom;
+}

--- a/packages/css-to-js/test/specimens/composes/custom-first-rule.css
+++ b/packages/css-to-js/test/specimens/composes/custom-first-rule.css
@@ -1,0 +1,9 @@
+.custom {
+  color: pink;
+}
+.rule { 
+  display: flex;
+}
+.rule {
+  composes: custom;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Hello 👋 I've spotted an issue with `css-to-js` module. [For CSS](https://github.com/plesiecki/modular-css/blob/df11a5be29fc66516de7ae60836a9adf515f61cd/packages/css-to-js/test/specimens/composes/custom-between-rules.css#L1-L9):
```css
.rule { 
  display: flex;
}
.custom {
  color: pink;
}
.rule {
  composes: custom;
}
```
it produces an [invalid JS](https://github.com/plesiecki/modular-css/blob/df11a5be29fc66516de7ae60836a9adf515f61cd/packages/css-to-js/test/__snapshots__/api.test.js.snap#L61) which looks like this:
```js
const rule =  + " " + "mc9c938a76_rule"
```

## Motivation and Context
A valid CSS can give an invalid JS.

## How Has This Been Tested?
Unit tests have been updated.

**For the second test a snapshot have been updated manually so the test should fail.**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
