### PR TITLE
[css-to-js] option to change type of variable declaration

### DIFF
--- a/.changeset/chatty-turtles-look.md
+++ b/.changeset/chatty-turtles-look.md
@@ -1,5 +1,7 @@
 ---
 "@modular-css/css-to-js": minor
+"@modular-css/rollup": minor
+"@modular-css/vite": minor
 "@modular-css/webpack": minor
 ---
 

--- a/.changeset/chatty-turtles-look.md
+++ b/.changeset/chatty-turtles-look.md
@@ -1,0 +1,6 @@
+---
+"@modular-css/css-to-js": minor
+"@modular-css/webpack": minor
+---
+
+New option to change type of variable declaration — `variableDeclaration` which defaults to `const`. Can be set to `var` if necessary, e.g. ES5 support.

--- a/packages/css-to-js/css-to-js.js
+++ b/packages/css-to-js/css-to-js.js
@@ -14,11 +14,11 @@ const slash = (file) => file.replace(/\/|\\/g, "/");
 const DEFAULT_VALUES = "$values";
 
 const DEFAULTS = {
-    __proto__   : null,
-    dev         : false,
-    styleExport : false,
-
-    namedExports : {
+    __proto__           : null,
+    dev                 : false,
+    styleExport         : false,
+    variableDeclaration : "const",
+    namedExports        : {
         rewriteInvalid : true,
         warn           : true,
     },
@@ -65,6 +65,8 @@ exports.transform = (file, processor, opts = {}) => {
         rewriteInvalid =  options.namedExports;
         warnOnInvalid = options.namedExports;
     }
+
+    const { variableDeclaration } = options;
 
     const { graph } = processor;
 
@@ -209,7 +211,7 @@ exports.transform = (file, processor, opts = {}) => {
 
         internalsMap.set(value, unique);
 
-        out.push(`const ${unique} = ${JSON.stringify(value)}`);
+        out.push(`${variableDeclaration} ${unique} = ${JSON.stringify(value)}`);
 
         valueExports.set(key, unique);
     });
@@ -217,7 +219,7 @@ exports.transform = (file, processor, opts = {}) => {
     if(valueExports.size) {
         const unique = deconflict(identifiers, DEFAULT_VALUES);
 
-        out.push(dedent(`const ${unique} = {
+        out.push(dedent(`${variableDeclaration} ${unique} = {
             ${[ ...valueExports ].map(prop).join(",\n")},
         };`));
 
@@ -255,7 +257,7 @@ exports.transform = (file, processor, opts = {}) => {
 
         elements.push(...details.classes[key].map((t) => JSON.stringify(t)));
 
-        out.push(`const ${unique} = ${elements.join(` + " " + `)}`);
+        out.push(`${variableDeclaration} ${unique} = ${elements.join(` + " " + `)}`);
 
         defaultExports.push([ key, unique ]);
 

--- a/packages/css-to-js/test/__snapshots__/api.test.js.snap
+++ b/packages/css-to-js/test/__snapshots__/api.test.js.snap
@@ -71,6 +71,23 @@ custom
 };
 `;
 
+exports[`@modular-css/css-to-js API should generate javascript with var variable statements: code 1`] = `
+var str = "\\"string\\""
+var $values = {
+    str,
+};
+var fooga = "mce1ef44f3_fooga"
+export default {
+    $values,
+fooga
+};
+
+export {
+    $values,
+fooga
+};
+`;
+
 exports[`@modular-css/css-to-js API should generate javascript: code 1`] = `
 const a = "mc74f3fa7b_a"
 export default {

--- a/packages/css-to-js/test/api.test.js
+++ b/packages/css-to-js/test/api.test.js
@@ -186,6 +186,16 @@ describe("@modular-css/css-to-js API", () => {
         expect(code).toMatchSnapshot("code");
     });
 
+    it("should generate javascript with var variable statements", async () => {
+        const processor = new Processor({ resolvers });
+
+        await processor.file(require.resolve("./specimens/simple.css"));
+
+        const { code } = transform(require.resolve("./specimens/simple.css"), processor, { variableDeclaration : "var" });
+
+        expect(code).toMatchSnapshot("code");
+    });
+
     it.each([
         true,
         false,

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -72,7 +72,7 @@ All other options are passed to the underlying `Processor` instance, see [Option
 
 #### `styleExport`
 
-You can enable returning the style string, eg `import { styles } from "./style.css";`. by setting `styleExport` to `true`.
+You can enable returning the style string, eg `import { styles } from "./style.css";`, by setting `styleExport` to `true`.
 
 ```js
 ...
@@ -82,7 +82,27 @@ You can enable returning the style string, eg `import { styles } from "./style.c
             use  : {
                 loader  : "@modular-css/webpack/loader",
                 options : {
-                    styleExport : true
+                    styleExport : true,
+                }
+            }
+        }]
+    },
+...
+```
+
+#### `variableDeclaration`
+
+You can set variable declaration kind, eg `var mc_rule = ...;`, by setting `variableDeclaration` to `var`. Defaults to `const`.
+
+```js
+...
+    module : {
+        rules : [{
+            test : /\.css$/,
+            use  : {
+                loader  : "@modular-css/webpack/loader",
+                options : {
+                    variableDeclaration : "var",
                 }
             }
         }]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
New option for `css-to-js` to change a kind of variable declaration, defaults to `const`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some folks still have to support ES5, thus `const` declarations within JS output may not help.
Naturally, we can process modules by an additional loader (e.g. babel-loader) but it involves significant overhead.
To avoid extra loaders I'd like to introduce a new option.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests have been updated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
