### PR TITLE
[css-to-js] Handle `defaultExport` option

### DIFF
--- a/packages/css-to-js/css-to-js.js
+++ b/packages/css-to-js/css-to-js.js
@@ -16,8 +16,9 @@ const DEFAULT_VALUES = "$values";
 const DEFAULTS = {
     __proto__           : null,
     dev                 : false,
-    styleExport         : false,
     variableDeclaration : "const",
+    defaultExport       : true,
+    styleExport         : false,
     namedExports        : {
         rewriteInvalid : true,
         warn           : true,
@@ -294,7 +295,7 @@ exports.transform = (file, processor, opts = {}) => {
                 }
             })
         `));
-    } else {
+    } else if(options.defaultExport) {
         out.push(dedent(`
             export default {
                 ${defaultExports.map(prop).join(",\n")}

--- a/packages/css-to-js/test/__snapshots__/api.test.js.snap
+++ b/packages/css-to-js/test/__snapshots__/api.test.js.snap
@@ -213,6 +213,14 @@ export {
 export const styles = ".mc74f3fa7b_a { color: red; }";
 `;
 
+exports[`@modular-css/css-to-js API should output without default export: code 1`] = `
+const a = "mc74f3fa7b_a"
+
+export {
+    a
+};
+`;
+
 exports[`@modular-css/css-to-js API should represent external @values namespaces: code 1`] = `
 import { $values as $aValues } from "<ROOT-DIR>/a.css";
 const v = "#0F0"

--- a/packages/css-to-js/test/api.test.js
+++ b/packages/css-to-js/test/api.test.js
@@ -98,6 +98,17 @@ describe("@modular-css/css-to-js API", () => {
         expect(namedExports).toEqual([ "b" ]);
     });
 
+    it("should output without default export", async () => {
+        const processor = new Processor({ resolvers });
+
+        await processor.string("./a.css", `.a { color: red; }`);
+
+        const { code, namedExports } = transform("./a.css", processor, { defaultExport : false });
+
+        expect(code).toMatchSnapshot("code");
+        expect(namedExports).toEqual([ "a" ]);
+    });
+
     it("should output css when requested", async () => {
         const processor = new Processor({ resolvers });
 

--- a/packages/rollup/README.md
+++ b/packages/rollup/README.md
@@ -132,6 +132,14 @@ import { styles } from "./styles.css";
 
 Enable `styleExport` will also disable the plugin from emitting any assets as well as sourcemaps (unless you explicitly opt-in to sourcemaps via the `map` option)
 
+### `defaultExport`
+
+You can disable exporting classes as default export, eg `import styles from "./style.css";`, by setting `defaultExport` to `false`. Defaults to `true`.
+
+#### `variableDeclaration`
+
+You can set variable declaration kind, eg `var mc_rule = ...;`, by setting `variableDeclaration` to `var`. Defaults to `const`.
+
 ### `empties`
 
 Set to `true` to enable writing out CSS files that don't contain any content (like if you have a CSS file that contains only `@value` rules).

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -35,6 +35,18 @@ A minimatch pattern, or an array of minimatch patterns, relative to `process.cwd
 
 Pass an already-instantiated `Processor` instance to the rollup plugin. It will then add any files found when traversing the modules to it and both the rollup-discovered and any already-existing files will be output in the final CSS.
 
+#### `styleExport`
+
+You can disable returning the style string, eg `import { styles } from "./style.css";`, by setting `styleExport` to `false`. Defaults to `true`.
+
+#### `defaultExport`
+
+You can disable exporting classes as default export, eg `import styles from "./style.css";`, by setting `defaultExport` to `false`. Defaults to `true`.
+
+#### `variableDeclaration`
+
+You can set variable declaration kind, eg `var mc_rule = ...;`, by setting `variableDeclaration` to `var`. Defaults to `const`.
+
 ### Shared Options
 
 All other options are passed to the underlying `Processor` instance, see the [Processor Options](#processor-options).

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -72,7 +72,7 @@ All other options are passed to the underlying `Processor` instance, see [Option
 
 #### `styleExport`
 
-You can enable returning the style string, eg `import { styles } from "./style.css";`, by setting `styleExport` to `true`.
+You can disable exporting the style string, eg `import { styles } from "./style.css";`, by setting `styleExport` to `false`. Defaults to `true`.
 
 ```js
 ...
@@ -92,7 +92,7 @@ You can enable returning the style string, eg `import { styles } from "./style.c
 
 #### `defaultExport`
 
-You can enable exporting classes as default export, eg `import styles from "./style.css";`, by setting `defaultExport` to `true`. Defaults to `true`.
+You can disable exporting classes as default export, eg `import styles from "./style.css";`, by setting `defaultExport` to `false`. Defaults to `true`.
 
 ```js
 ...
@@ -102,7 +102,7 @@ You can enable exporting classes as default export, eg `import styles from "./st
             use  : {
                 loader  : "@modular-css/webpack/loader",
                 options : {
-                    defaultExport : true,
+                    defaultExport : false,
                 }
             }
         }]

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -90,6 +90,26 @@ You can enable returning the style string, eg `import { styles } from "./style.c
 ...
 ```
 
+#### `defaultExport`
+
+You can enable exporting classes as default export, eg `import styles from "./style.css";`, by setting `defaultExport` to `true`. Defaults to `true`.
+
+```js
+...
+    module : {
+        rules : [{
+            test : /\.css$/,
+            use  : {
+                loader  : "@modular-css/webpack/loader",
+                options : {
+                    defaultExport : true,
+                }
+            }
+        }]
+    },
+...
+```
+
 #### `variableDeclaration`
 
 You can set variable declaration kind, eg `var mc_rule = ...;`, by setting `variableDeclaration` to `var`. Defaults to `const`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Webpack loader sets the `defaultExport` option.
https://github.com/tivac/modular-css/blob/f37b5a786259eacae45b5cf68e4fe352af570af4/packages/webpack/loader.js#L5-L21

Options are handed over to the `css-to-js` module and then nothing is done about `defaultExport`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Handle `defaultExport` option just like any other option set by webpack loader.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests have been updated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
