### PR TITLE
chore: only .toString() if dirty

### DIFF
--- a/.changeset/tricky-cats-fail.md
+++ b/.changeset/tricky-cats-fail.md
@@ -1,0 +1,5 @@
+---
+"@modular-css/processor": patch
+---
+
+chore: only .toString() if dirty when replacing `@value` references

--- a/packages/processor/plugins/values-replace.js
+++ b/packages/processor/plugins/values-replace.js
@@ -34,6 +34,7 @@ module.exports = () => ({
         const replacer = (prop) =>
             (thing) => {
                 const parsed = value(thing[prop]);
+                let modified = false;
 
                 parsed.walk((node) => {
                     if(node.type !== "word" || !values[node.value]) {
@@ -47,9 +48,13 @@ module.exports = () => ({
 
                     // Replace any value instances
                     node.value = current.value;
+
+                    modified = true;
                 });
 
-                thing[prop] = parsed.toString();
+                if(modified) {
+                    thing[prop] = parsed.toString();
+                }
             };
 
         return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Small optimization to `@value` replacement, only call `.toString()` on the parsed value if it was dirtied.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Speeeeed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have added a changeset for my change.
