### PR TITLE
fix: Join class compositions for webpack JSON output

### DIFF
--- a/.changeset/empty-tools-happen.md
+++ b/.changeset/empty-tools-happen.md
@@ -1,0 +1,5 @@
+---
+"@modular-css/webpack": patch
+---
+
+Join class compositions for JSON output

--- a/packages/webpack/test/__snapshots__/webpack.test.js.snap
+++ b/packages/webpack/test/__snapshots__/webpack.test.js.snap
@@ -828,30 +828,22 @@ exports[`/webpack.js should handle dependencies 2`] = `
 exports[`/webpack.js should handle dependencies 3`] = `
 "{
     "packages/webpack/test/specimens/folder/folder.css": {
-        "folder": [
-            "mc_folder"
-        ]
+        "folder": "mc_folder"
     },
     "packages/webpack/test/specimens/local.css": {
-        "booga": [
-            "mc_booga"
-        ],
-        "looga": [
-            "mc_booga",
-            "mc_looga"
-        ]
+        "one": "red",
+        "two": "blue",
+        "folder": "white",
+        "booga": "mc_booga",
+        "looga": "mc_booga mc_looga"
     },
     "packages/webpack/test/specimens/start.css": {
-        "wooga": [
-            "mc_booga",
-            "mc_wooga"
-        ],
-        "booga": [
-            "mc_booga"
-        ],
-        "tooga": [
-            "mc_tooga"
-        ]
+        "one": "red",
+        "two": "blue",
+        "folder": "white",
+        "wooga": "mc_booga mc_wooga",
+        "booga": "mc_booga",
+        "tooga": "mc_tooga"
     }
 }"
 `;
@@ -1068,9 +1060,7 @@ __webpack_require__(/*! ./simple.css */ "./packages/webpack/test/specimens/simpl
 exports[`/webpack.js should output json to disk 2`] = `
 "{
     "packages/webpack/test/specimens/simple.css": {
-        "wooga": [
-            "mc_wooga"
-        ]
+        "wooga": "mc_wooga"
     }
 }"
 `;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

JSON output for webpack package outputted arrays of classes, this change will join the classes into strings, matching behavior in m-css/rollup package.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added a changeset for my change.
