### PR TITLE
fix(vite): vite 8 rolldown integration enforces strict type checking

### DIFF
--- a/.changeset/yummy-doors-count.md
+++ b/.changeset/yummy-doors-count.md
@@ -1,0 +1,5 @@
+---
+"@modular-css/vite": patch
+---
+
+Fix type mismatch with vite 8

--- a/packages/vite/vite.js
+++ b/packages/vite/vite.js
@@ -255,7 +255,7 @@ module.exports = (
 
                 // Disable tree-shaking for CSS modules w/o any classes/values to export
                 // to make sure they're included in the bundle
-                moduleSideEffects : namedExports.length || "no-treeshake",
+                moduleSideEffects : Boolean(namedExports.length) || "no-treeshake",
             };
         },
     };


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix for vite 8. The new rolldown integration introduced strict type checking for `moduleSideEffects`.

`moduleSideEffects` cannot return a number (this sometimes would return `0` 🙃).

```
Error: Value is none of these types `bool`, `String`,  on BindingHookTransformOutput.moduleSideEffects
```

## Motivation and Context
i like using these tools

## How Has This Been Tested?
passes tests locally, this is not tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
- [ ] I have added a changeset for my change.
