### PR TITLE
fix: vite@8 build compatibility

### DIFF
--- a/.changeset/funny-banks-bet.md
+++ b/.changeset/funny-banks-bet.md
@@ -1,0 +1,7 @@
+---
+"@modular-css/vite": patch
+---
+
+fix: vite@8 build compatibility
+
+Vite plugins can return `moduleSideEffects` from their `transform` hook, but with the switch to Rolldown for built output the valid arguments changed.

--- a/packages/vite/vite.js
+++ b/packages/vite/vite.js
@@ -220,7 +220,7 @@ module.exports = (
                 return this.error(e);
             }
 
-            const { code : css, namedExports, warnings } = transform(file, processor, pluginOptions);
+            const { code : css, warnings } = transform(file, processor, pluginOptions);
 
             warnings.forEach((warning) => {
                 this.warn(warning);

--- a/packages/vite/vite.js
+++ b/packages/vite/vite.js
@@ -253,9 +253,8 @@ module.exports = (
                 code : result,
                 map  : emptyMappings,
 
-                // Disable tree-shaking for CSS modules w/o any classes/values to export
-                // to make sure they're included in the bundle
-                moduleSideEffects : Boolean(namedExports.length) || "no-treeshake",
+                // Disable tree-shaking for CSS modules to make sure they're included in the bundle
+                moduleSideEffects : true,
             };
         },
     };


### PR DESCRIPTION
Rolldown doesn't support `moduleSideEffects : "no-treeshake"`, so just always return `true` to ensure nothing gets removed.